### PR TITLE
Sync translations and make the dashboard fully translatable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2993 Sync translations and add complete German, Dutch and Spanish translations
+- #2993 Make the dashboard fully translatable
 - #2992 Fix UnicodeEncodeError in Organization.getPrintAddress with non-ASCII address
 - #2988 Fix worksheet template analysis filtering for selected samples
 - #2985 Add a SENAITE-specific Manage Viewlets view

--- a/src/senaite/core/browser/dashboard/dashboard.py
+++ b/src/senaite/core/browser/dashboard/dashboard.py
@@ -40,6 +40,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import WORKSHEET_CATALOG
+from senaite.core.i18n import translate
 from senaite.core.permissions import AddAnalysisRequest
 from senaite.core.permissions import EditResults
 from senaite.core.permissions import ManageBika
@@ -77,23 +78,23 @@ PERIODICITY_DAYS = {
 # Status cards: (permission, title, portal_type,
 #                review_state, catalog, url, icon)
 STATUS_CARD_DEFS = [
-    (TransitionReceiveSample, "Samples to Receive",
+    (TransitionReceiveSample, _("Samples to Receive"),
      "AnalysisRequest", "sample_due", SAMPLE_CATALOG,
      "samples?samples_review_state=sample_due",
      "fa-inbox"),
-    (ViewResults, "Results Pending",
+    (ViewResults, _("Results Pending"),
      "AnalysisRequest", "sample_received", SAMPLE_CATALOG,
      "samples?samples_review_state=sample_received",
      "fa-flask"),
-    (TransitionVerify, "To be Verified",
+    (TransitionVerify, _("To be Verified"),
      "AnalysisRequest", "to_be_verified", SAMPLE_CATALOG,
      "samples?samples_review_state=to_be_verified",
      "fa-check-circle"),
-    (TransitionPublishResults, "To be Published",
+    (TransitionPublishResults, _("To be Published"),
      "AnalysisRequest", "verified", SAMPLE_CATALOG,
      "samples?samples_review_state=verified",
      "fa-paper-plane"),
-    (EditResults, "Open Worksheets",
+    (EditResults, _("Open Worksheets"),
      "Worksheet", "open", WORKSHEET_CATALOG,
      "worksheets?worksheets_review_state=open",
      "fa-th-list"),
@@ -101,19 +102,43 @@ STATUS_CARD_DEFS = [
 
 # Quick action links: (permission, title, url, icon)
 QUICK_LINK_DEFS = [
-    (AddAnalysisRequest, "Register Samples",
+    (AddAnalysisRequest, _("Register Samples"),
      "samples", "fa-plus-circle"),
-    (EditResults, "Worksheets",
+    (EditResults, _("Worksheets"),
      "worksheets", "fa-th-list"),
-    (TransitionVerify, "Verify Results",
+    (TransitionVerify, _("Verify Results"),
      "samples?samples_review_state=to_be_verified",
      "fa-check-double"),
-    (TransitionPublishResults, "Publish Reports",
+    (TransitionPublishResults, _("Publish Reports"),
      "samples?samples_review_state=verified",
      "fa-paper-plane"),
-    (ManageBika, "SENAITE Setup",
+    (ManageBika, _("SENAITE Setup"),
      "setup", "fa-cog"),
 ]
+
+# Keys in the async JSON payload whose values are i18n messages and must be
+# translated to the active language before serialization (the D3 chart data
+# under "data"/"datacolors" is deliberately excluded).
+TRANSLATABLE_KEYS = ("title", "description", "tooltip", "name")
+
+# Labels rendered client-side by dashboard.js. Exposed pre-translated via a
+# data attribute so the script stays translation-agnostic.
+JS_LABEL_DEFS = collections.OrderedDict([
+    ("status", _("Status")),
+    ("quick_actions", _("Quick Actions")),
+    ("show_hide_timeline", _("Show/hide timeline")),
+    ("no_data", _("No data for the selected period")),
+    ("no_actions", _("No actions available. Please contact your "
+                     "laboratory manager to get permissions assigned.")),
+    ("timeline_range",
+     _("From ${from} to ${to} (updated every 2 hours)")),
+    ("daily", _("Daily")),
+    ("weekly", _("Weekly")),
+    ("monthly", _("Monthly")),
+    ("quarterly", _("Quarterly")),
+    ("biannual", _("Biannual")),
+    ("yearly", _("Yearly")),
+])
 
 # State labels for evolution charts
 ANALYSIS_STATES = collections.OrderedDict([
@@ -300,6 +325,13 @@ class DashboardView(BrowserView):
 
     def get_current_time(self):
         return datetime.datetime.now().strftime("%H:%M")
+
+    def get_js_labels_json(self):
+        """Return the translated dashboard.js labels as a JSON string
+        """
+        labels = dict((key, translate(msg))
+                      for key, msg in JS_LABEL_DEFS.items())
+        return json.dumps(labels)
 
     # --- Status cards ---
 
@@ -572,7 +604,7 @@ class DashboardView(BrowserView):
     def _legend(self, count, total):
         pct = self._pct(count, total)
         return "%s %s (%s%%)" % (
-            _("of"), total, pct)
+            translate(_("of")), total, pct)
 
     # --- Cookie filter ---
 
@@ -827,6 +859,24 @@ SECTION_HANDLERS = {
 }
 
 
+def translate_labels(data):
+    """Recursively translate the i18n labels of a dashboard data structure
+
+    Only the values of `TRANSLATABLE_KEYS` are translated; every other value
+    (counts, urls, chart data) is returned unchanged. This lets the async JSON
+    payload carry text in the active language, since `json.dumps` would
+    otherwise serialize i18n messages to their untranslated message id.
+    """
+    if isinstance(data, dict):
+        return dict(
+            (key, translate(value) if key in TRANSLATABLE_KEYS and value
+             else translate_labels(value))
+            for key, value in data.items())
+    if isinstance(data, (list, tuple)):
+        return [translate_labels(item) for item in data]
+    return data
+
+
 class DashboardDataView(BrowserView):
     """JSON endpoint for async dashboard data loading
 
@@ -855,4 +905,4 @@ class DashboardDataView(BrowserView):
         view._setup(mtool)
 
         data = getattr(view, handler_name)()
-        return json.dumps(data)
+        return json.dumps(translate_labels(data))

--- a/src/senaite/core/browser/dashboard/static/js/dashboard.js
+++ b/src/senaite/core/browser/dashboard/static/js/dashboard.js
@@ -17,6 +17,18 @@ document.addEventListener("DOMContentLoaded", function () {
   var dateFrom = config.getAttribute("data-date-from");
   var dateTo = config.getAttribute("data-date-to");
 
+  // Translated labels rendered server-side (get_js_labels_json).
+  // Fall back to English if the attribute is missing.
+  var i18n = {};
+  try {
+    i18n = JSON.parse(config.getAttribute("data-i18n") || "{}");
+  } catch (e) {
+    i18n = {};
+  }
+  function t(key, fallback) {
+    return i18n[key] || fallback;
+  }
+
   // Load overview (cards + links) together
   Promise.all([
     fetchSection("status_cards"),
@@ -67,9 +79,10 @@ document.addEventListener("DOMContentLoaded", function () {
       icon.className = "fas fa-info-circle mr-2";
       msg.appendChild(icon);
       msg.appendChild(document.createTextNode(
-        "No actions available. Please contact your "
-        + "laboratory manager to get permissions "
-        + "assigned."));
+        t("no_actions",
+          "No actions available. Please contact your "
+          + "laboratory manager to get permissions "
+          + "assigned.")));
       el.appendChild(msg);
       return;
     }
@@ -79,7 +92,7 @@ document.addEventListener("DOMContentLoaded", function () {
       var heading = document.createElement("h2");
       heading.className = "h6 text-uppercase text-muted "
         + "font-weight-bold mb-3";
-      heading.textContent = "Status";
+      heading.textContent = t("status", "Status");
       el.appendChild(heading);
 
       var wrap = document.createElement("div");
@@ -96,7 +109,7 @@ document.addEventListener("DOMContentLoaded", function () {
       var heading2 = document.createElement("h2");
       heading2.className = "h6 text-uppercase text-muted "
         + "font-weight-bold mb-3";
-      heading2.textContent = "Quick Actions";
+      heading2.textContent = t("quick_actions", "Quick Actions");
       el.appendChild(heading2);
 
       var linkWrap = document.createElement("div");
@@ -190,7 +203,8 @@ document.addEventListener("DOMContentLoaded", function () {
       btnIcon.className = "fas fa-chart-bar mr-1";
       btn.appendChild(btnIcon);
       btn.appendChild(
-        document.createTextNode("Show/hide timeline"));
+        document.createTextNode(
+          t("show_hide_timeline", "Show/hide timeline")));
       btnWrap.appendChild(btn);
       container.appendChild(btnWrap);
 
@@ -206,8 +220,11 @@ document.addEventListener("DOMContentLoaded", function () {
 
       var legendDiv = document.createElement("div");
       legendDiv.className = "h2-legend mb-3";
-      legendDiv.textContent = "From " + dateFrom
-        + " to " + dateTo + " (updated every 2 hours)";
+      legendDiv.textContent = t(
+        "timeline_range",
+        "From ${from} to ${to} (updated every 2 hours)")
+        .replace("${from}", dateFrom)
+        .replace("${to}", dateTo);
       period.appendChild(legendDiv);
 
       period.appendChild(buildNavPills());
@@ -223,7 +240,7 @@ document.addEventListener("DOMContentLoaded", function () {
       var noData = document.createElement("div");
       noData.className = "bar-chart-no-data";
       noData.textContent =
-        "No data for the selected period";
+        t("no_data", "No data for the selected period");
       chartDiv.appendChild(noData);
       container.appendChild(chartDiv);
     });
@@ -299,12 +316,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function buildNavPills() {
     var pills = [
-      { label: "Daily", value: "d" },
-      { label: "Weekly", value: "w" },
-      { label: "Monthly", value: "m" },
-      { label: "Quarterly", value: "q" },
-      { label: "Biannual", value: "b" },
-      { label: "Yearly", value: "y" }
+      { label: t("daily", "Daily"), value: "d" },
+      { label: t("weekly", "Weekly"), value: "w" },
+      { label: t("monthly", "Monthly"), value: "m" },
+      { label: t("quarterly", "Quarterly"), value: "q" },
+      { label: t("biannual", "Biannual"), value: "b" },
+      { label: t("yearly", "Yearly"), value: "y" }
     ];
     var ul = document.createElement("ul");
     ul.className = "nav nav-pills nav-pills-sm mb-3";

--- a/src/senaite/core/browser/dashboard/templates/dashboard.pt
+++ b/src/senaite/core/browser/dashboard/templates/dashboard.pt
@@ -29,6 +29,7 @@
                          data-periodicity view/periodicity;
                          data-can-view-stats python:'true' if view.can_view_statistics() else 'false';
                          data-portal-url view/portal_url;
+                         data-i18n view/get_js_labels_json;
                          data-date-from python:plone_view.toLocalizedTime(view.date_from);
                          data-date-to python:plone_view.toLocalizedTime(view.date_to)">
     </div>

--- a/src/senaite/core/locales/af/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/af/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Afrikaans (https://app.transifex.com/senaite/teams/87045/af/)\n"

--- a/src/senaite/core/locales/af/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/af/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Afrikaans (https://app.transifex.com/senaite/teams/87045/af/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/af/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/af/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Afrikaans (https://app.transifex.com/senaite/teams/87045/af/)\n"

--- a/src/senaite/core/locales/af/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/af/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Afrikaans (https://app.transifex.com/senaite/teams/87045/af/)\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: af\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -29,6 +29,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} Aanhangsels, in totaal ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -54,6 +55,7 @@ msgid "%s has no '%s' column."
 msgstr "%s Het nie 'n  '%s' kolom nie"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Terug"
@@ -123,6 +125,10 @@ msgstr "*** Hierdie epos kom van 'n bot. Jy hoef nie te antwoord nie ***"
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -140,7 +146,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Welkom by Bika Senaite"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -198,7 +204,7 @@ msgid "Account Type"
 msgstr "Rekening Tipe"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -243,21 +249,21 @@ msgstr "Aktiveer"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Aktief"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Rolspeler"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Voeg By"
 
@@ -285,15 +291,19 @@ msgstr "Voeg Duplikaat By"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Voeg 'n kommnetaar veld toe aan alle ontledings"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -306,8 +316,11 @@ msgstr "Heg nuwe aan"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -371,13 +384,21 @@ msgstr "Alle ge-akkrediteerde ontledings is hier gelys"
 msgid "All Analyses of Service"
 msgstr "Alle ontledings van diens"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Alle Ontledings Toegewys"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Laat handmatige  waarneming grense invoer"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -395,11 +416,11 @@ msgstr "Dielfde gebruiker mag meer as een keer verifieer"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Dielfde gebruiker mag meer as een keer verifieer, maar nie na mekaar"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Self verifikasie"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -428,15 +449,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Ontleed deur"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Ontledings"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Ontledings versoek"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -505,7 +542,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -542,7 +579,7 @@ msgstr "Analis verpligtend"
 msgid "Any"
 msgstr "Enige"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -553,6 +590,10 @@ msgstr "Pas toe"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Pas Templaat Toe"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -566,19 +607,15 @@ msgstr "Batenommer"
 msgid "Assign"
 msgstr "Wys toe"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Toegeken"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Toegewys aan: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Hangende toewysing"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -592,7 +629,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -680,11 +717,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -692,15 +733,15 @@ msgstr ""
 msgid "Autofill"
 msgstr "'Autofill'"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Outomatiese Aftekening"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -751,7 +792,7 @@ msgstr "Groep"
 msgid "Batch Book"
 msgstr "Groep boek"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Groep ID"
 
@@ -781,6 +822,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Rigting"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Rekeningadres"
@@ -801,7 +846,7 @@ msgstr "Handelsmerk"
 msgid "Bulk Discount"
 msgstr "Volume afslag"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Volume afslag toegepas"
@@ -819,19 +864,19 @@ msgstr "Business Foon"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -839,12 +884,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "Kopie aan E-pos"
 
@@ -900,23 +945,23 @@ msgstr "Kalibrasies"
 msgid "Calibrator"
 msgstr "Kalibreerder"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Kanselleer"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Gekanselleer"
 
@@ -936,15 +981,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -970,7 +1015,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Katalogusnommer"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Kategoriseer ontledings dienste"
 
@@ -1002,11 +1047,11 @@ msgid "Changes Saved"
 msgstr "Veranderings gestoor"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Veranderings gestoor"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1043,31 +1088,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1080,12 +1125,26 @@ msgstr "Stad"
 msgid "Classic"
 msgstr "Klassiek"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1093,7 +1152,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Kliënt"
@@ -1105,7 +1164,7 @@ msgstr "Kliënt Groep ID"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Kliënt ID"
 
@@ -1117,7 +1176,7 @@ msgstr "Kliënt landings blad"
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Kliënt Bestelling"
 
@@ -1127,7 +1186,7 @@ msgstr "Kliënt Bestelling"
 msgid "Client Order Number"
 msgstr "Kliënt bestelling nommer"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Kliënt Ref"
 
@@ -1136,7 +1195,7 @@ msgstr "Kliënt Ref"
 msgid "Client Reference"
 msgstr "Kliënt Verwysing"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Kliënt SID"
 
@@ -1229,7 +1288,7 @@ msgstr "Kommentaar"
 msgid "Comments or results interpretation"
 msgstr "Kommentaar of interpretasie van resultate"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "Komersiële ID"
@@ -1267,6 +1326,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1285,7 +1348,7 @@ msgstr "Bevestig Wagwoord"
 msgid "Considerations"
 msgstr "Oorwegings"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kontak"
@@ -1329,7 +1392,7 @@ msgstr "Monster houers"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1362,15 +1425,15 @@ msgstr "Kopieer ontledings dienste"
 msgid "Copy from"
 msgstr "Kopieer vanaf"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Kopieer na nuwe"
 
@@ -1380,6 +1443,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1398,11 +1465,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1415,7 +1482,7 @@ msgstr "Land"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Skep Aliquot"
 
@@ -1423,7 +1490,7 @@ msgstr "Skep Aliquot"
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1435,7 +1502,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr "Skep nuwe gebruiker"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1465,7 +1532,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Skepper"
 
@@ -1474,7 +1541,7 @@ msgstr "Skepper"
 msgid "Criteria"
 msgstr "Kriteria"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Geldeenheid"
 
@@ -1482,13 +1549,21 @@ msgstr "Geldeenheid"
 msgid "Current"
 msgstr "Tans"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Eie desimale teken"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "WG"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1535,23 +1610,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Datum Geopen"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Datum gepreserveer"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Datum gedruk"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Datum Gepubliseer"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Datum Ontvang"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Datum Versoek"
 
@@ -1563,11 +1638,11 @@ msgstr "Datum Versoek"
 msgid "Date Sample Received"
 msgstr "Ontvangdatum"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Datum Gemonster"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "verifikasie datum"
 
@@ -1609,7 +1684,7 @@ msgstr "Datum waarop die sertifisering toegeken was"
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1632,11 +1707,11 @@ msgstr "De-aktiveer tot volgende kalibrasie toets"
 msgid "Deactivate"
 msgstr "De-aktiveer"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Desimale teken on in kliënte verslag te gebruik"
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1648,7 +1723,7 @@ msgstr "Verstekhouer"
 msgid "Default Department"
 msgstr "Verstek departement"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1660,7 +1735,7 @@ msgstr "Verstek Instrument"
 msgid "Default Method"
 msgstr "Verstek Metode"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1668,20 +1743,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Verstekpreservering"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Verstek hoeveelheid Monster om by te voeg"
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Verstek desimale teken"
 
@@ -1693,7 +1768,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr "Verstek groot plakker"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1725,15 +1800,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Verstek sample retention period"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Verstek wetenskaplike notasie vir verslae"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Verstek wetenskaplike notasie vir resultate"
 
@@ -1745,7 +1820,7 @@ msgstr "Verstek klein plakker"
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1754,7 +1829,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Verstek value"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1778,7 +1853,7 @@ msgstr "Definieer die presisie vir eksponensiele notering. Die verstek waarde is
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1790,8 +1865,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Grade"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1820,9 +1904,9 @@ msgstr "Departemente"
 msgid "Dependent Analyses"
 msgstr "Afhanklike Ontledings"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Beskrywing"
 
@@ -1869,7 +1953,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Afslag"
@@ -1887,7 +1975,7 @@ msgstr "Stuur"
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Versend"
@@ -1912,15 +2000,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr "Vertoon 'n waarnemings grens kiesskakelaar"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Gooi weg"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Verwyderd"
 
@@ -1990,11 +2086,15 @@ msgstr "Laai PDF af"
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Verwag"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Verwag op Datum"
@@ -2011,7 +2111,7 @@ msgstr "Duplikaat"
 msgid "Duplicate Analysis"
 msgstr "Duplikaatontledings"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2059,6 +2159,7 @@ msgstr "Bv. SANAS, APLAC, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2073,21 +2174,21 @@ msgstr "Hoogte"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "E-pos"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "E-posadres"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2095,27 +2196,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2128,16 +2229,20 @@ msgstr "Epos gekanselleer"
 msgid "Email notification"
 msgstr "Epos nota"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2148,27 +2253,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2176,8 +2281,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2201,7 +2314,7 @@ msgstr "Verskaf 'n epos adres. Dit is nodig ingeval die wagwoord verlore gaan. O
 msgid "Enter discount percentage value"
 msgstr "Sleutel afslag persentasie in"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2214,7 +2327,7 @@ msgstr "Sleutel 'n persentasie in, bv. 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Sleutel 'n persentasie in, bv. 14.0. Die persentasie word deur die hele stelsel gebruik, maar kan oorskryf word vir individuele items"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Sleutel 'n persentasie in, bv. 14.0. Die persentasie word deur die hele stelsel gebruik, maar kan oorskryf word vir individuele items"
 
@@ -2238,7 +2351,7 @@ msgstr "Tik die besonderhede in van elk van die ontleding dienste wat jy wil kop
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2250,15 +2363,15 @@ msgstr "Omgewing toestand"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Ontleding vordering"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Monster vordering"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Werkblad vordering"
 
@@ -2270,7 +2383,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Sluit uit van faktuur"
 
@@ -2280,7 +2393,7 @@ msgstr "Sluit uit van faktuur"
 msgid "Expected Result"
 msgstr "Verwagte Resultaat"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Verwagte Monster datum"
 
@@ -2306,7 +2419,7 @@ msgstr "Vervaldatum"
 msgid "Exponential format precision"
 msgstr "Eksponensiële formaat presisie "
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Eksponensiële formaat drumpel"
 
@@ -2314,7 +2427,7 @@ msgstr "Eksponensiële formaat drumpel"
 msgid "Export"
 msgstr "Uitvoer"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "Plakker kon nie laai nie"
 
@@ -2401,7 +2514,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "Grote"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2415,6 +2528,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2431,11 +2556,11 @@ msgstr "Voornaam"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Formaat instelling"
 
@@ -2458,13 +2583,17 @@ msgstr ""
 msgid "From"
 msgstr "Van"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Volle Naam"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2472,7 +2601,7 @@ msgstr ""
 msgid "Function"
 msgstr "Funksie"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Toekomstige monster"
 
@@ -2505,7 +2634,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Titel, bv. Mnr., Mv., Dr."
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Groepeer ontledings dienste per kategorie in tabelle, help baie waar dit 'n lang lys is"
 
@@ -2519,7 +2648,7 @@ msgid "Hazardous"
 msgstr "Skadelik"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Verskuilde veld"
@@ -2532,8 +2661,20 @@ msgstr "Verskuilde veld"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2557,7 +2698,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2565,7 +2706,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2585,15 +2726,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2601,7 +2742,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Geaktiveer, word die ontleding nam skuinsdruk geskryf."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2641,7 +2782,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2672,11 +2813,11 @@ msgstr "Laboratorium kalibrasie prosedure"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Onaktief"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Sluit prysinligting in en vertoon dit"
 
@@ -2873,7 +3014,7 @@ msgid "Internal Certificate"
 msgstr "Interne Sertifikaat"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2894,13 +3035,13 @@ msgstr ""
 msgid "Interval"
 msgstr "Interval"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Ongeldig"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2963,15 +3104,15 @@ msgstr "Faktureer"
 msgid "Invoice {} created"
 msgstr "Faktuur {} geskep"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "Geen Bondel Einddatum"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "Geen Bondel Begindatum"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "Faltuur Bondel sonder datum"
 
@@ -2983,7 +3124,7 @@ msgstr "Werkstitel"
 msgid "Job title"
 msgstr "Werkstitel"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2995,9 +3136,9 @@ msgstr "Sleutel"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Sleutelwoord"
 
@@ -3013,6 +3154,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Sleutelwoorde"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3057,8 +3202,8 @@ msgstr "Lab Produkte"
 msgid "Lab URL"
 msgstr "Lab URL"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Etiket"
@@ -3067,7 +3212,7 @@ msgstr "Etiket"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3075,13 +3220,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3094,7 +3239,7 @@ msgstr "Laboratorium"
 msgid "Laboratory Accredited"
 msgstr "Laboratorium Geakkrediteer"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3106,7 +3251,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Groot plakker"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3118,11 +3263,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Laat"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Laat Ontledings"
 
@@ -3168,15 +3313,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3200,7 +3345,7 @@ msgstr "Laai die Sertifikaat Dokument hier"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3227,6 +3372,14 @@ msgstr "Plek Tipe"
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3291,7 +3444,7 @@ msgstr "Manlik"
 msgid "Manage Analyses"
 msgstr "Bestuur Ontledings"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "Bestuur vorm uitleg"
 
@@ -3315,7 +3468,7 @@ msgstr "Bestuur Monster vorm uitleg en velde"
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3339,7 +3492,7 @@ msgstr "Bestuurder E-pos"
 msgid "Manager Phone"
 msgstr "Bestuurder Foon"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Handmatig"
 
@@ -3368,7 +3521,7 @@ msgstr "Vervaardigers"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3383,7 +3536,7 @@ msgstr "Maks Tyd"
 msgid "Max operator"
 msgstr "Maks funksie"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3418,15 +3571,15 @@ msgid "Member Discount"
 msgstr "Lede afslag"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Lid afslag %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Lid afslag toepaslik"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3434,7 +3587,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr "Boodskap gestuur aan {}"
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3465,7 +3618,7 @@ msgstr "Middel letter"
 msgid "Middle name"
 msgstr "Middel naam"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3476,7 +3629,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr "Min funksie"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3494,7 +3647,7 @@ msgstr "Minimum 5 karakters."
 msgid "Minimum Volume"
 msgstr "Minimumvolume"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Minimum aantal resultate vir kwaliteit statistiek berekeninge"
 
@@ -3525,6 +3678,10 @@ msgstr "Module"
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3538,11 +3695,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3578,13 +3735,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Naam"
 
@@ -3594,6 +3755,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3636,6 +3801,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3684,6 +3853,10 @@ msgstr "Geen veranderinge"
 msgid "No changes made."
 msgstr "Geen veranderinge"
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "Geen datum"
@@ -3728,6 +3901,16 @@ msgstr "Niks geselekteer"
 msgid "No items selected."
 msgstr "Niks gekies nie"
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "Geen nuwe items geskep"
@@ -3735,6 +3918,10 @@ msgstr "Geen nuwe items geskep"
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "Geen Aliquots geskep"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3751,6 +3938,10 @@ msgstr "Geen Monsters verwerp"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Geen monster funksie"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3778,7 +3969,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Geen"
 
@@ -3794,11 +3985,11 @@ msgstr ""
 msgid "Not defined"
 msgstr "Ongedefinieer"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Nie gestel"
@@ -3819,7 +4010,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3831,7 +4022,7 @@ msgstr "Hoeveelheid kolomme"
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Hoeveelheid ontledings"
 
@@ -3847,16 +4038,16 @@ msgstr "Aantal kopieë"
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3866,6 +4057,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3884,11 +4079,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3896,13 +4091,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr "Slegs vir leë of zero velde"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Oop"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3910,8 +4105,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3939,7 +4142,7 @@ msgstr "Ander redes"
 msgid "Other reasons:"
 msgstr "Ander redes"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Ander status"
 
@@ -3961,11 +4164,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4062,11 +4265,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Kies 'n gebruiker"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4079,6 +4282,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4098,12 +4302,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Punt van Monstering"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4142,31 +4350,31 @@ msgstr "Hoeveelheid desimale "
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Verkose desimale teken vir verslae."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Verkose desimale teken vir resultate."
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Verkose wetenskaplike notasie vir verslae."
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Verkose wetenskaplike notasie vir resultate."
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4199,7 +4407,7 @@ msgstr ""
 msgid "Preserve"
 msgstr "Preserveer"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Preserveerder"
 
@@ -4216,11 +4424,11 @@ msgstr "Voorkomend"
 msgid "Preventive maintenance procedure"
 msgstr "Voorkomende onderhoud prosdure"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4248,7 +4456,7 @@ msgstr "Pryslys vir"
 msgid "Pricelists"
 msgstr "Pryslys"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4257,7 +4465,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4279,11 +4487,11 @@ msgstr "Datum gedruk"
 msgid "Print pricelist"
 msgstr "Druk pryslys"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Gedruk"
 
@@ -4296,7 +4504,7 @@ msgstr "Datum gedruk"
 msgid "Priority"
 msgstr "Prioriteit"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Profiel"
 
@@ -4320,7 +4528,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Vordering"
 
@@ -4329,7 +4537,7 @@ msgstr "Vordering"
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "Protokol ID"
 
@@ -4337,7 +4545,7 @@ msgstr "Protokol ID"
 msgid "Province"
 msgstr "Provinsie"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4346,8 +4554,12 @@ msgstr ""
 msgid "Publish"
 msgstr "Publiseer"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Gepubliseer"
@@ -4363,6 +4575,10 @@ msgstr "Publikasie datum"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Gepubliseerde resultate"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4384,6 +4600,14 @@ msgstr ""
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "Kwaliteitsbeheer monster ID"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4409,7 +4633,7 @@ msgstr "Sleutel weer die wagwoord in. Maak seker die wagwoorde is identies."
 msgid "Reasons for rejection"
 msgstr "Verwerping rede"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Hertoewysing"
 
@@ -4421,30 +4645,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Ontvang"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Is Ontvang"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Ontvangs hanged"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Ontvangers"
 
@@ -4495,11 +4723,15 @@ msgstr "Verwysings waardes"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Verwysing monster waardes is nul of 'leeg'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registreer"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4525,9 +4757,9 @@ msgstr "Verwerp ontleding"
 msgid "Reject samples"
 msgstr "Verwerp Monsters"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Verworpe"
 
@@ -4543,7 +4775,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4604,8 +4836,16 @@ msgstr ""
 msgid "Remove"
 msgstr "Verwyder"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4641,11 +4881,11 @@ msgstr "Verslag ID"
 msgid "Report identification number"
 msgstr "Verslag identifikasie nommer"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4657,7 +4897,7 @@ msgstr "Verslag oplaai"
 msgid "Republish"
 msgstr "Herpubliseer"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4666,7 +4906,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "Versoek ID"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Versoek new Ontledings"
 
@@ -4682,8 +4922,20 @@ msgstr "Vereiste volume"
 msgid "Reset"
 msgstr "Herstel"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4691,15 +4943,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr "Verantwoordelikhede"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4724,15 +4977,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Resultaat in skouer gebied"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Resultaat buite toegelate bereik"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4740,7 +4993,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4756,16 +5009,20 @@ msgstr "Resultate"
 msgid "Results Interpretation"
 msgstr "Resultaat interpretasie"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Resultate teruggetrek"
 
@@ -4773,7 +5030,7 @@ msgstr "Resultate teruggetrek"
 msgid "Results interpretation"
 msgstr "Resultaat interpretasie"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Hangende Resultate"
 
@@ -4797,7 +5054,7 @@ msgstr "Herontleed"
 msgid "Retract"
 msgstr "Trek terug"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4833,6 +5090,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4858,6 +5119,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4867,7 +5129,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4881,7 +5143,7 @@ msgstr "Aanspreekvorm"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Monster"
 
@@ -4918,7 +5180,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "Monster ID"
 
@@ -4938,7 +5200,7 @@ msgstr "Monstermatriks"
 msgid "Sample Partitions"
 msgstr "Monsterafdelings"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4965,7 +5227,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Monster Tipe"
@@ -5026,7 +5288,7 @@ msgstr "Monster tipe"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Monsternemer"
 
@@ -5038,8 +5300,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Monsters"
@@ -5056,6 +5318,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5065,7 +5339,23 @@ msgstr "Monsters van hierdie tipe moet as gevaarlik beskou word"
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5073,7 +5363,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Monstering Datum"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Monsterafwyking"
@@ -5086,7 +5376,7 @@ msgstr "Monsterafwykings"
 msgid "Sampling Frequency"
 msgstr "Monstering Reelmaat"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5094,14 +5384,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Stoor"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5116,7 +5415,7 @@ msgstr "Skedule"
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5133,6 +5432,10 @@ msgstr "Wetenskaplike naam"
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5141,7 +5444,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Sekondes"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5231,11 +5534,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Kies Templaat"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Kies die verstek land vir die stelsel"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Kies geldeenheid waarin pryse vertoon word"
 
@@ -5247,11 +5550,11 @@ msgstr "Kies die verstekhouer om te gebruik vir hierdie ontledingsdiens. Spesifi
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Kies die verstek bestemming bladsy. Dit word gebruik wanneer 'n kliënt gebruiker inteken op die stelsel, of wanneer 'n kliënt gekies word uit die kliënte lys."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5259,31 +5562,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Kies om monster-versameling werksvloei stappe te aktiveer"
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5295,7 +5606,7 @@ msgstr "Kies die ontledings om in te sluit op die Werkskaart"
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5307,11 +5618,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5333,7 +5644,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Afsonderlike houer"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5347,7 +5658,7 @@ msgstr "Reeksnommer"
 msgid "Service"
 msgstr "Diens"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5375,7 +5686,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr "Sluit die onderhoud taak"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5423,28 +5734,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5467,11 +5790,11 @@ msgstr "Werf Kode"
 msgid "Site Description"
 msgstr "Werf Beskrywing"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5492,7 +5815,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Klein plakkertjie"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5509,6 +5832,14 @@ msgstr ""
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Sorteer Orde"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5534,7 +5865,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "Spesifikasies"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5542,7 +5873,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5559,17 +5890,17 @@ msgstr "Begin datum"
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Staat"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Status"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Plakker"
@@ -5578,7 +5909,11 @@ msgstr "Plakker"
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Stoorplek"
@@ -5618,7 +5953,11 @@ msgstr "Handig In"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5626,7 +5965,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotaal"
@@ -5668,7 +6007,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5694,7 +6033,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr "Tegniese beskrywing en instruksies vir ontleders"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5776,7 +6115,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Die desimale teken in die Bika opstelling sal gebruik word"
 
@@ -5784,7 +6123,7 @@ msgstr "Die desimale teken in die Bika opstelling sal gebruik word"
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "Die afslagpersentasie wat hier ingevoer word, word toegepas op kliënte wat as 'lede' aangedui is, normaalweg koöperasielede of medewerkers waarop hierdie afslag van toepassing is."
 
@@ -5812,7 +6151,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5820,11 +6163,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Die hoogte of diepte waarop die monster geneem is"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5861,11 +6204,11 @@ msgstr "Die mimimum monstervolume nodig vir analise bv. '10 ml' of '1 kg'"
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Die aantal dae voordat 'n monster verval en nie meer ontleed kan word nie. Hierdie verstelling kan oorskryf word per enkele monstertipe in die monstertipe opstelling."
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Die tyd in minute voor 'n dormante gebruiker sessie outomaties afgeteken word. 'n Waarde van 0 kanselleer die outo-afteken funksie"
 
@@ -5905,7 +6248,7 @@ msgstr "Die akkreditasie verwysingsnommer aan die laboratorium"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5929,11 +6272,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Die instrument se unieke volgnommer (serial number)"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5985,11 +6328,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6013,11 +6356,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6049,8 +6392,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Titel"
@@ -6077,34 +6420,42 @@ msgstr "Titel vir die werf"
 msgid "To"
 msgstr "Tot"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Om gepreserveer te word"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Om gemonster te word"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Te Bevestig"
@@ -6117,7 +6468,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Totaal"
 
@@ -6139,7 +6490,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Tipe"
@@ -6164,6 +6515,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6172,7 +6527,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6184,6 +6539,7 @@ msgstr "Kan nie die templaat laai nie"
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Nie toegeken"
@@ -6216,8 +6572,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6234,12 +6594,16 @@ msgstr "Onherkenbare legger formaat ${file_format}"
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6250,7 +6614,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Laai 'n geskandeerde handtekening om op gedrukte resultaat verslae in te sluit. 'n Ideale grote is 250 by 150 'pixels'"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6258,7 +6622,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6296,7 +6660,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6304,15 +6668,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Om 'n klein hoeveelheid data te gebruik maak nie statisties sin nie. Stel hier die aanvaarbare minimum hoeveelheid resultate waarmee statistieke berekeninge gemaak en geplot kan word"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6320,7 +6684,7 @@ msgstr "BTW"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "BTW %"
 
@@ -6567,8 +6931,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Bevestig"
@@ -6577,10 +6941,18 @@ msgstr "Bevestig"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6595,6 +6967,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6630,6 +7010,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Hoeveelheis weke voor verval datum"
@@ -6642,19 +7026,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6705,10 +7089,18 @@ msgstr "Werksblad Template"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Werksblaaie"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6716,6 +7108,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6800,6 +7196,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6904,8 +7304,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "de-aktiveer"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6970,7 +7379,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7137,46 +7546,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7188,19 +7597,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7221,16 +7630,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7255,12 +7669,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7270,7 +7684,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7373,6 +7787,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7402,6 +7829,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7548,12 +7982,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7806,7 +8240,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7814,163 +8248,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7978,47 +8412,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8027,20 +8461,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8048,32 +8482,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8081,21 +8515,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8251,6 +8685,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8563,7 +9001,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8624,7 +9062,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8740,52 +9178,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8855,12 +9293,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8870,7 +9308,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9166,7 +9604,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9291,12 +9729,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9506,7 +9944,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9516,12 +9954,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9579,6 +10017,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10755,87 +11209,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10888,6 +11342,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10938,12 +11397,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11021,6 +11488,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11255,13 +11727,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11348,6 +11825,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11593,222 +12075,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12062,7 +12544,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12105,7 +12587,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ar/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ar/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Arabic (https://app.transifex.com/senaite/teams/87045/ar/)\n"

--- a/src/senaite/core/locales/ar/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ar/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Arabic (https://app.transifex.com/senaite/teams/87045/ar/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ar/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ar/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Arabic (https://app.transifex.com/senaite/teams/87045/ar/)\n"

--- a/src/senaite/core/locales/ar/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ar/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Arabic (https://app.transifex.com/senaite/teams/87045/ar/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ar\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr "%sلايوجد%s عامود"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -284,15 +290,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -551,6 +588,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -565,18 +606,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -800,7 +845,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1126,7 +1185,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1135,7 +1194,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1228,7 +1287,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1328,7 +1391,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1473,7 +1540,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1481,12 +1548,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "العنوان"
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr "إلى"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "الكلى"
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "نوع"
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6576,10 +6940,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,9 +7088,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "الغى التفعيل"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "من"
 
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
+
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "التأكيد موقف مؤقتاً"
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/bg_BG/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/bg_BG/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Georgi Murdzheff, 2026\n"
 "Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/senaite/teams/87045/bg_BG/)\n"

--- a/src/senaite/core/locales/bg_BG/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/bg_BG/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Georgi Murdzheff, 2026\n"
 "Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/senaite/teams/87045/bg_BG/)\n"
@@ -923,6 +923,11 @@ msgstr "Нуждаете се от акаунт?"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
 msgstr "Няма файл"
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
+msgstr ""
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82

--- a/src/senaite/core/locales/bg_BG/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/bg_BG/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/senaite/teams/87045/bg_BG/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: bg_BG\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr "<p>Сървърът за идентификатори (ID Server) предоставя уникални последователни идентификатори за обекти като Проби (Samples), Работни листове (Worksheets) и др., въз основа на формат, зададен за всеки тип съдържание.</p><p>Форматът е конструиран подобно на синтаксиса за форматиране в Python, като използва предварително дефинирани променливи за всеки тип съдържание и генерира идентификаторите чрез пореден номер „seq“ и неговото запълване като брой цифри, напр. „03d“ за последователност от идентификатори от 001 до 999.</p><p>Алфанумеричните префикси за идентификаторите се включват директно във форматите, напр. WS за Работен лист в WS-{seq:03d} генерира последователни идентификатори: WS-001, WS-002, WS-003 и т.н.</p><p>За динамично генериране на алфанумерични и последователни идентификатори може да се използва символът за заместване {alpha}. Напр. WS-{alpha:2a3d} генерира WS-AA001, WS-AA002, WS-AB034 и т.н.</p><p>Променливите, които могат да бъдат използвани, включват:<table><tr><th style='width:150px'>Тип съдържание</th><th>Променливи</th></tr><tr><td>Идентификатор на клиент</td><td>{clientId}</td></tr><tr><td>Година</td><td>{year}</td></tr><tr><td>Идентификатор на проба</td><td>{sampleId}</td></tr><tr><td>Тип проба</td><td>{sampleType}</td></tr><tr><td>Дата на вземане на проба</td><td>{samplingDate}</td></tr><tr><td>Дата на пробовземане</td><td>{dateSampled}</td></tr></table></p><p>Настройки на конфигурацията:<ul><li>формат:<ul><li>низ за форматиране на Python, конструиран от предварително дефинирани променливи като sampleId, clientId, sampleType.</li><li>специалната променлива „seq“ трябва да бъде разположена последна в низа за форматиране</li></ul></li><li>тип последователност: [generated|counter]</li><li>контекст: ако типът е брояч (counter), предоставя контекст на функцията за броене</li><li>тип брояч: [backreference|contained]</li><li>референция на брояча: параметър към функцията за броене</li><li>префикс: префикс по подразбиране, ако не е предоставен такъв в низа за форматиране</li><li>дължина на разделяне: броят на частите, които да бъдат включени в префикса</li></ul></p>"
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} прикачени файлове с общ размер: ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -55,6 +56,7 @@ msgid "%s has no '%s' column."
 msgstr "%s няма колона '%s'."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Назад"
@@ -124,6 +126,10 @@ msgstr "*** Това е автоматично генериран имейл, м
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr "... Изберете инструмент ..."
@@ -141,7 +147,7 @@ msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Отиди в наст�
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Добре дошли в SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -199,7 +205,7 @@ msgid "Account Type"
 msgstr "Тип сметка"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr "Счетоводство"
 
@@ -244,21 +250,21 @@ msgstr "Активиране"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Активен"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Извършител"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Добави"
 
@@ -286,15 +292,19 @@ msgstr "Добави дубликат"
 msgid "Add Samples"
 msgstr "Добави проби"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Добавяне на поле за забележки към всички анализи"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "Добавете персонализирани CSS правила за логото, напр. height:15px; width:150px;"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "Добави етикети за избиране по подразбиране"
 
@@ -307,8 +317,11 @@ msgstr "Добави нов прикачен файл"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Добавете един или повече прикачени файлове, за да опишете пробата в тази заявка или да уточните искането си."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Добави забележки"
 
@@ -372,13 +385,21 @@ msgstr "Тук са изброени всички акредитирани ус�
 msgid "All Analyses of Service"
 msgstr "Всички анализи на услугата"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Всички анализи са възложени"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Разреши ръчно въвеждане на граница на откриване"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -396,11 +417,11 @@ msgstr "Разреши на един и същ потребител да вер�
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Разреши на един и същ потребител да верифицира многократно, но не последователно"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Разреши самоверификация на резултати"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -429,15 +450,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Анализирано от"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Анализи"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Заявени анализи"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -506,7 +543,7 @@ msgstr "Условия на анализ"
 msgid "Analysis conditions updated: {}"
 msgstr "Условията на анализа са обновени: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Спецификации на анализ, които се редактират директно в Пробата."
 
@@ -543,7 +580,7 @@ msgstr "Трябва да бъде посочен анализатор."
 msgid "Any"
 msgstr "Всякакъв"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "Външен вид"
 
@@ -554,6 +591,10 @@ msgstr "Приложи"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Приложи шаблон"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -567,19 +608,15 @@ msgstr "Инвентарен номер"
 msgid "Assign"
 msgstr "Възложи"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Възложен"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Възложено на: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Чакащо възлагане"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -593,7 +630,7 @@ msgstr "Прикачи към проба"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr "Прикачени етикети"
 
@@ -681,11 +718,15 @@ msgstr "Поведение за автоматично генериране на
 msgid "Auto-Import Logs"
 msgstr "Автоматично импортиране на логове"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Автоматично разделяне при получаване"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Автоматично получаване на проби"
 
@@ -693,15 +734,15 @@ msgstr "Автоматично получаване на проби"
 msgid "Autofill"
 msgstr "Автоматично попълване"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr "Автоматично разпечатване на етикети"
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Автоматично излизане"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr "Автоматична верификация на проби"
 
@@ -752,7 +793,7 @@ msgstr "Партида"
 msgid "Batch Book"
 msgstr "Книга за партиди"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID на партида"
 
@@ -782,6 +823,10 @@ msgstr "Имайте предвид, че диапазоните, предост
 msgid "Bearing"
 msgstr "Посока"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Адрес за фактуриране"
@@ -802,7 +847,7 @@ msgstr "Марка"
 msgid "Bulk Discount"
 msgstr "Отстъпка за количество"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Важи отстъпка за количество"
@@ -820,19 +865,19 @@ msgstr "Служебен телефон"
 msgid "Business address"
 msgstr "Служебен адрес"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr "По 'Показана стойност' възходящо"
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr "По 'Показана стойност' низходящо"
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr "По 'Стойност на резултата' възходящо"
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr "По 'Стойност на резултата' низходящо"
 
@@ -840,12 +885,12 @@ msgstr "По 'Стойност на резултата' низходящо"
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "Имейли за копие (CC)"
 
@@ -901,23 +946,23 @@ msgstr "Калибрирания"
 msgid "Calibrator"
 msgstr "Калибратор"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Може да верифицира, но е подадено от текущия потребител"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Може да верифицира, но вече е верифицирано от текущия потребител"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Отказ"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Отказан"
 
@@ -937,15 +982,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr "Не може да се изпрати имейл за ${sample_id}: ${error}"
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "Не може да се верифицира, последно верифицирано от текущия потребител"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "Не може да се верифицира, подадено от текущия потребител"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "Не може да се верифицира, беше верифицирано от текущия потребител"
 
@@ -971,7 +1016,7 @@ msgstr "Каталогизиране на Dexterity съдържание в мн
 msgid "Catalogue Number"
 msgstr "Каталожен номер"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Категоризиране на услуги за анализ"
 
@@ -1003,11 +1048,11 @@ msgid "Changes Saved"
 msgstr "Промените са запазени"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Промените са запазени."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Промените ще бъдат разпространени към частите"
 
@@ -1044,31 +1089,31 @@ msgstr "Поле за отметка"
 msgid "Choices"
 msgstr "Избори"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr "Изберете шаблона по подразбиране за 'големи' етикети.<br/><strong>Забележка:</strong> Специфичните за пробата 'големи' етикети се конфигурират въз основа на нейния тип проба."
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr "Изберете шаблона по подразбиране за 'малки' етикети.<br/><strong>Забележка:</strong> Специфичните за пробата 'малки' етикети се конфигурират въз основа на нейния тип проба."
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Изберете тип на многократна верификация за един и същ потребител. Тази настройка може да активира/деактивира верифицирането/последователното верифициране повече от веднъж за един и същ потребител."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr "Изберете кога етикетите да се отпечатват автоматично:<br/><ul><li><strong>Регистрация:</strong> Етикетите се отпечатват автоматично при създаване на нови проби.</li><li><strong>Получаване:</strong> Етикетите се отпечатват автоматично при получаване на проби.</li><li><strong>Никога:</strong> Деактивира автоматичното отпечатване на етикети.</li></ul>"
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1081,20 +1126,34 @@ msgstr "Град"
 msgid "Classic"
 msgstr "Класически"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "Изчисти селекцията"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Кликнете, за да разгънете тази категория"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "Кликнете, за да превключите видимостта или плъзнете и пуснете, за да промените реда"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Клиент"
@@ -1106,7 +1165,7 @@ msgstr "Клиентско ID на партида"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Идентификатор на клиент"
 
@@ -1118,7 +1177,7 @@ msgstr "Начална страница на клиент"
 msgid "Client Name"
 msgstr "Име на клиент"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Клиентска поръчка"
 
@@ -1128,7 +1187,7 @@ msgstr "Клиентска поръчка"
 msgid "Client Order Number"
 msgstr "Номер на клиентска поръчка"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Клиентска реф."
 
@@ -1137,7 +1196,7 @@ msgstr "Клиентска реф."
 msgid "Client Reference"
 msgstr "Клиентска референция"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Клиентски SID"
 
@@ -1230,7 +1289,7 @@ msgstr "Коментари"
 msgid "Comments or results interpretation"
 msgstr "Коментари или интерпретация на резултати"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "Търговско ID"
@@ -1268,6 +1327,10 @@ msgstr "Конфигурация за информацията в заглавк
 msgid "Configuration restored to default values."
 msgstr "Конфигурацията е възстановена до стойностите по подразбиране."
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr "Конфигуриране на колоните в таблицата"
@@ -1286,7 +1349,7 @@ msgstr "Потвърди парола"
 msgid "Considerations"
 msgstr "Съображения"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Контакт"
@@ -1330,7 +1393,7 @@ msgstr "Контейнери"
 msgid "Contents of the file {}"
 msgstr "Съдържание на файла {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1363,15 +1426,15 @@ msgstr "Копирай услуги за анализ"
 msgid "Copy from"
 msgstr "Копирай от"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr "Копирайте стойността на текущо показаната колона към другите колони отдясно"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr "Копирай стойността на първата проба към другите"
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Копирай в нов"
 
@@ -1381,6 +1444,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1399,11 +1466,11 @@ msgstr "Пробите не можаха да преминат в състоян
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1416,7 +1483,7 @@ msgstr "Държава"
 msgid "Create Invoice PDF"
 msgstr "Създай фактура PDF"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Създай части"
 
@@ -1424,7 +1491,7 @@ msgstr "Създай части"
 msgid "Create SENAITE Site"
 msgstr "Създай SENAITE сайт"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr "Създай работен лист"
 
@@ -1436,7 +1503,7 @@ msgstr "Създаване на нов SENAITE сайт"
 msgid "Create a new User"
 msgstr "Създаване на нов потребител"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr "Създаване на нов работен лист за избраните проби"
 
@@ -1466,7 +1533,7 @@ msgid "Created {} partitions: {}"
 msgstr "Създадени {} части: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Създател"
 
@@ -1475,7 +1542,7 @@ msgstr "Създател"
 msgid "Criteria"
 msgstr "Критерии"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Валута"
 
@@ -1483,13 +1550,21 @@ msgstr "Валута"
 msgid "Current"
 msgstr "Текущ"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Персонализиран десетичен знак"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "GO"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1536,23 +1611,23 @@ msgstr "Дата на промяна"
 msgid "Date Opened"
 msgstr "Дата на отваряне"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Дата на консервация"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Дата на отпечатване"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Дата на публикуване"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Дата на получаване"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Дата на регистрация"
 
@@ -1564,11 +1639,11 @@ msgstr "Дата на заявяване"
 msgid "Date Sample Received"
 msgstr "Дата на получаване на пробата"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Дата на пробовземане"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Дата на верификация"
 
@@ -1610,7 +1685,7 @@ msgstr "Дата, на която е издаден сертификатът з�
 msgid "Date when the certificate is valid"
 msgstr "Дата, на която сертификатът е валиден"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1633,11 +1708,11 @@ msgstr "Деактивиране до следващия тест за кали�
 msgid "Deactivate"
 msgstr "Деактивиране"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Десетичен знак за използване в докладите от този Клиент."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1649,7 +1724,7 @@ msgstr "Контейнер по подразбиране"
 msgid "Default Department"
 msgstr "Отдел по подразбиране"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Имейли по подразбиране за копие на всички публикувани проби за този клиент"
 
@@ -1661,7 +1736,7 @@ msgstr "Инструмент по подразбиране"
 msgid "Default Method"
 msgstr "Метод по подразбиране"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr "Брой копия по подразбиране"
 
@@ -1669,20 +1744,20 @@ msgstr "Брой копия по подразбиране"
 msgid "Default Preservation"
 msgstr "Консервация по подразбиране"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr "Шаблон за етикет по подразбиране"
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Брой проби за добавяне по подразбиране."
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Десетичен знак по подразбиране"
 
@@ -1694,7 +1769,7 @@ msgstr "Инструмент по подразбиране, използван �
 msgid "Default large sticker"
 msgstr "Голям етикет по подразбиране"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Оформление по подразбиране в изгледа на работния лист"
 
@@ -1726,15 +1801,15 @@ msgstr "Резултатът по подразбиране трябва да б�
 msgid "Default result to display on result entry"
 msgstr "Резултат по подразбиране за показване при въвеждане на резултат"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Период на съхранение на проби по подразбиране"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Формат за научно записване по подразбиране за доклади"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Формат за научно записване по подразбиране за резултати"
 
@@ -1746,7 +1821,7 @@ msgstr "Малък етикет по подразбиране"
 msgid "Default timezone"
 msgstr "Часова зона по подразбиране"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Време за изпълнение на анализи по подразбиране."
 
@@ -1755,7 +1830,7 @@ msgstr "Време за изпълнение на анализи по подра
 msgid "Default value"
 msgstr "Стойност по подразбиране"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "Стойност по подразбиране на 'Брой проби', когато потребителите кликнат върху бутона 'ДОБАВИ' за създаване на нови проби"
 
@@ -1779,7 +1854,7 @@ msgstr "Дефинирайте точността при преобразува�
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Определете пробовземащия, който трябва да вземе пробата на планираната дата"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1791,8 +1866,17 @@ msgstr "Определя етикетите, които да се използв
 msgid "Degrees"
 msgstr "Градуси"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1821,9 +1905,9 @@ msgstr "Отдели"
 msgid "Dependent Analyses"
 msgstr "Зависими анализи"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Описание"
 
@@ -1870,7 +1954,11 @@ msgstr "Изключи автоматично извличане на прехо
 msgid "Disable multi-verification for the same user"
 msgstr "Забрани многократна верификация за един и същ потребител"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Отстъпка"
@@ -1888,7 +1976,7 @@ msgstr "Изпрати"
 msgid "Dispatch samples"
 msgstr "Изпрати проби"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Изпратен"
@@ -1913,15 +2001,23 @@ msgstr "Показваната стойност трябва да е уника�
 msgid "Display a Detection Limit selector"
 msgstr "Покажи селектор за граница на откриване"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr "Показвай частите на пробите на клиентите"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Унищожи"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Унищожен"
 
@@ -1991,11 +2087,15 @@ msgstr "Изтегли PDF"
 msgid "Download selected reports"
 msgstr "Изтегли избраните доклади"
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Краен срок"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Крайна дата"
@@ -2012,7 +2112,7 @@ msgstr "Дубликат"
 msgid "Duplicate Analysis"
 msgstr "Дублиран анализ"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2060,6 +2160,7 @@ msgstr "Напр. SANAS, APLAC и т.н."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "Всеки интерфейс за импортиране може да дефинира папка, където системата търси файловете с резултати при автоматично импортиране на резултати при извикване на изгледа <code>auto_import_results</code>."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Редактирай"
@@ -2074,21 +2175,21 @@ msgstr "Надморска височина"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Имейл"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Имейл адрес"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2096,27 +2197,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "Имейл лог"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "Тяло на имейла за уведомления за анулиране на проба"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr "Тяло на имейла за уведомления за отхвърляне на проба"
 
@@ -2129,17 +2230,21 @@ msgstr "Имейлът е отказан"
 msgid "Email notification"
 msgstr "Имейл уведомление"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "Имейл уведомление при отхвърляне на проба"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
 msgstr "Имейлът е изпратен"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2149,27 +2254,27 @@ msgstr "Празни ключове не се поддържат"
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Активирай многократно използване на инструмент в работни листове."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Активирай консервация на проби"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "Активирай спецификации на проби"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "Активирай пробовземане"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "Активирай планиране на пробовземане"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr "Активирай глобален одитен журнал"
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr "Активирай глобален одитен журнал"
 
@@ -2177,9 +2282,17 @@ msgstr "Активирай глобален одитен журнал"
 msgid "Enable sampling workflow for the created sample"
 msgstr "Активирай работен процес за пробовземане за създадената проба"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "Активирай работния процес за печат на доклади с резултати"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2202,7 +2315,7 @@ msgstr "Въведете имейл адрес. Това е необходимо
 msgid "Enter discount percentage value"
 msgstr "Въведете процентна стойност на отстъпката"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr "Въведете индивидуални стойности за това поле за всяка проба"
 
@@ -2215,7 +2328,7 @@ msgstr "Въведете процентна стойност, напр. 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Въведете процентна стойност, напр. 14.0. Този процент се прилага само към Профила за анализ, като отменя системния ДДС"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Въведете процентна стойност, напр. 14.0. Този процент се прилага за цялата система, но може да бъде презаписан за отделни елементи"
 
@@ -2239,7 +2352,7 @@ msgstr "Въведете детайлите за всяка от услугит�
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Въведете детайлите за акредитациите на вашата лаборатория тук. Налични са следните полета: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr "Въведете резултата в десетично или научно записване, напр. 0.00005 или 1e-5, 10000 или 1e5"
 
@@ -2251,15 +2364,15 @@ msgstr "Условия на околната среда"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr "Публикуване на грешен резултат: ${sample_id}"
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Еволюция на анализите"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Еволюция на пробите"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Еволюция на работните листове"
 
@@ -2271,7 +2384,7 @@ msgstr "Примерен Cronjob за изпълнение на автомати
 msgid "Example content"
 msgstr "Примерно съдържание"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Изключи от фактура"
 
@@ -2281,7 +2394,7 @@ msgstr "Изключи от фактура"
 msgid "Expected Result"
 msgstr "Очакван резултат"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Очаквана дата на пробовземане"
 
@@ -2307,7 +2420,7 @@ msgstr "Дата на изтичане"
 msgid "Exponential format precision"
 msgstr "Точност на експоненциален формат"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Праг на експоненциален формат"
 
@@ -2315,7 +2428,7 @@ msgstr "Праг на експоненциален формат"
 msgid "Export"
 msgstr "Експортиране"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "Неуспешно зареждане на етикет"
 
@@ -2402,7 +2515,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "Размер на файла"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr "Филтриране на анализи по име..."
 
@@ -2416,6 +2529,18 @@ msgstr "Филтриране по услуги от шаблон"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2432,11 +2557,11 @@ msgstr "Име"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Стойност с плаваща запетая от 0.0 до 1000.0, указваща реда на сортиране. Дублираните стойности се подреждат по азбучен ред."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Конфигурация на форматирането"
 
@@ -2459,13 +2584,17 @@ msgstr "Петък"
 msgid "From"
 msgstr "От"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Пълно име"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Пълно име"
 
@@ -2473,7 +2602,7 @@ msgstr "Пълно име"
 msgid "Function"
 msgstr "Функция"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Проба с бъдеща дата"
 
@@ -2506,7 +2635,7 @@ msgstr "Към вашата инстанция"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Обръщение, напр. г-н, г-жа, д-р"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Групиране на услугите за анализ по категория в таблиците на LIMS, полезно, когато списъкът е дълъг"
 
@@ -2520,7 +2649,7 @@ msgid "Hazardous"
 msgstr "Опасен"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Скрит"
@@ -2533,8 +2662,20 @@ msgstr "Скрито поле"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2558,7 +2699,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2566,7 +2707,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr "Стойности на сървъра за ID"
 
@@ -2586,15 +2727,15 @@ msgstr "Ако е избрано, ще се показва списък за и�
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Ако е избрано, инструментът няма да бъде наличен, докато не бъде извършено следващото валидно калибриране. Тази отметка автоматично ще бъде премахната."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Ако е активирано, ще се показва поле за свободен текст до всеки анализ в изгледа за въвеждане на резултати"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Ако е активирано, потребител, който е подал резултат за този анализ, също ще може да го верифицира. Тази настройка важи за потребители с назначена роля, която им позволява да верифицират резултати (по подразбиране мениджъри, лабораторни мениджъри и верификатори). Зададената тук опция има приоритет пред опцията, зададена в настройките на Bika"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Ако е активирано, потребител, който е подал резултат, също ще може да го верифицира. Тази настройка важи само за потребители с назначена роля, която им позволява да верифицират резултати (по подразбиране мениджъри, лабораторни мениджъри и верификатори). Тази настройка може да бъде презаписана за даден анализ в изгледа за редакция на Услуга за анализ. По подразбиране е деактивирано."
 
@@ -2602,7 +2743,7 @@ msgstr "Ако е активирано, потребител, който е по
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Ако е активирано, името на анализа ще бъде изписано с курсив."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "Ако е активирано, този анализ и неговите резултати няма да се показват по подразбиране в докладите. Тази настройка може да бъде презаписана в Профила за анализ и/или Пробата"
 
@@ -2642,7 +2783,7 @@ msgstr "Ако не е избрано, лабораторните мениджъ
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "Ако формулата ви се нуждае от специална функция от външна Python библиотека, можете да я импортирате тук. Напр. ако искате да използвате функцията 'floor' от Python модула 'math', добавяте 'math' в полето Модул и 'floor' в полето Функция. Еквивалентът в Python би бил 'from math import floor'. След това във вашето изчисление можете да използвате 'floor([Ca] + [Mg])'. "
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr "Незабавно въвеждане на резултати"
 
@@ -2673,11 +2814,11 @@ msgstr "Процедура за вътрешнолабораторно кали�
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Неактивен"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Включване и показване на информация за ценообразуване"
 
@@ -2874,7 +3015,7 @@ msgid "Internal Certificate"
 msgstr "Вътрешен сертификат"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "Вътрешна употреба"
 
@@ -2895,13 +3036,13 @@ msgstr "Шаблони за интерпретация"
 msgid "Interval"
 msgstr "Интервал"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Невалиден"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2964,15 +3105,15 @@ msgstr "Фактуриране на"
 msgid "Invoice {} created"
 msgstr "Фактура {} е създадена"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "InvoiceBatch няма крайна дата"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "InvoiceBatch няма начална дата"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "InvoiceBatch няма заглавие"
 
@@ -2984,7 +3125,7 @@ msgstr "Длъжност"
 msgid "Job title"
 msgstr "Длъжност"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr "Запази реда по-горе"
 
@@ -2996,9 +3137,9 @@ msgstr "Ключ"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Ключова дума"
 
@@ -3014,6 +3155,10 @@ msgstr "Изисква се ключова дума"
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Ключови думи"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3058,8 +3203,8 @@ msgstr "Лабораторни продукти"
 msgid "Lab URL"
 msgstr "URL на лабораторията"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Етикет"
@@ -3068,7 +3213,7 @@ msgstr "Етикет"
 msgid "Label configuration"
 msgstr "Конфигурация на етикет"
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr "Имената на етикетите трябва да са уникални"
 
@@ -3076,13 +3221,13 @@ msgstr "Имената на етикетите трябва да са уника
 msgid "Label schema extender"
 msgstr "Разширение на схема за етикети"
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr "Обекти с етикети"
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr "Етикети"
 
@@ -3095,7 +3240,7 @@ msgstr "Лаборатория"
 msgid "Laboratory Accredited"
 msgstr "Лабораторията е акредитирана"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Лабораторни работни дни"
 
@@ -3107,7 +3252,7 @@ msgstr "Език"
 msgid "Large Sticker"
 msgstr "Голям етикет"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr "Шаблон за голям етикет"
 
@@ -3119,11 +3264,11 @@ msgstr "Логове от последното авто-импортиране"
 msgid "Last Login Time"
 msgstr "Време на последно влизане"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Закъснял"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Закъснели анализи"
 
@@ -3169,15 +3314,15 @@ msgstr "Свързване на потребител"
 msgid "Link an existing User"
 msgstr "Свързване на съществуващ потребител"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr "Списък на всички обекти с етикети"
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr "Списък с възможни крайни резултати. Когато е зададено, не се допуска персонализиран резултат при въвеждане и потребителят трябва да избере от тези стойности"
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3201,7 +3346,7 @@ msgstr "Заредете документа за сертификат тук"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3229,6 +3374,14 @@ msgstr "Тип местоположение"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Местоположение, където е архивиран наборът от документи"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3292,7 +3445,7 @@ msgstr "Мъжки"
 msgid "Manage Analyses"
 msgstr "Управление на анализи"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "Управление на полета във формата"
 
@@ -3316,7 +3469,7 @@ msgstr "Управление на полета във формата за про
 msgid "Manage linked User"
 msgstr "Управление на свързан потребител"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3340,7 +3493,7 @@ msgstr "Имейл на мениджър"
 msgid "Manager Phone"
 msgstr "Телефон на мениджър"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Ръчно"
 
@@ -3369,7 +3522,7 @@ msgstr "Производители"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "Маркирайте пробата само за вътрешна употреба. Това означава, че тя е достъпна само за лабораторния персонал, а не за клиенти."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3384,7 +3537,7 @@ msgstr "Макс време"
 msgid "Max operator"
 msgstr "Макс оператор"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3419,15 +3572,15 @@ msgid "Member Discount"
 msgstr "Отстъпка за член"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Отстъпка за член %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Важи отстъпка за член"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Членът е регистриран и свързан с текущия Контакт."
 
@@ -3435,7 +3588,7 @@ msgstr "Членът е регистриран и свързан с текущи
 msgid "Message sent to {}, "
 msgstr "Съобщението е изпратено до {}, "
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3466,7 +3619,7 @@ msgstr "Инициал на презиме"
 msgid "Middle name"
 msgstr "Презиме"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3477,7 +3630,7 @@ msgstr "Мин"
 msgid "Min operator"
 msgstr "Мин оператор"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3495,7 +3648,7 @@ msgstr "Минимум 5 знака."
 msgid "Minimum Volume"
 msgstr "Минимален обем"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Минимален брой резултати за изчисляване на QC статистика"
 
@@ -3526,6 +3679,10 @@ msgstr "Модул"
 msgid "Monday"
 msgstr "Понеделник"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3539,11 +3696,11 @@ msgstr "Multi Catalog поведение за Dexterity съдържание"
 msgid "Multi Results"
 msgstr "Множество резултати"
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "Тип мулти-верификация"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Изисква се мулти-верификация"
 
@@ -3579,13 +3736,17 @@ msgstr "Моята организация"
 msgid "My Profile"
 msgstr "Моят профил"
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Име"
 
@@ -3596,6 +3757,10 @@ msgstr ""
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
 msgstr "Новите диапазони няма да бъдат приложени нито към нови, нито към текущи анализи. Назначете отново Спецификацията, ако искате да приложите последните промени."
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
@@ -3638,6 +3803,10 @@ msgstr "Няма подгрупа"
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "Няма дефинирано действие."
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3685,6 +3854,10 @@ msgstr "Не са направени промени"
 msgid "No changes made."
 msgstr "Не са направени промени."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "Няма зададена дата"
@@ -3729,6 +3902,16 @@ msgstr "Няма избрани елементи"
 msgid "No items selected."
 msgstr "Няма избрани елементи."
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "Не бяха създадени нови елементи."
@@ -3736,6 +3919,10 @@ msgstr "Не бяха създадени нови елементи."
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "Не бяха създадени части"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3752,6 +3939,10 @@ msgstr "Няма отхвърлени проби"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Няма работен процес за пробовземане"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3779,7 +3970,7 @@ msgstr "Няма видими анализи за тази проба"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Няма"
 
@@ -3795,11 +3986,11 @@ msgstr "Не е разрешено обновяването на условия:
 msgid "Not defined"
 msgstr "Не е дефинирано"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Не е зададено"
@@ -3820,7 +4011,7 @@ msgstr "Бележка: Настройките са глобални и се п�
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "Бележка: Можете също да влачите и пускате редовете с прикачени файлове, за да промените реда, в който се появяват в доклада."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr "Уведомления"
 
@@ -3832,7 +4023,7 @@ msgstr "Брой колони"
 msgid "Number"
 msgstr "Число"
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Брой анализи"
 
@@ -3848,16 +4039,16 @@ msgstr "Брой копия"
 msgid "Number of prominent columns"
 msgstr "Брой основни колони"
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Брой изисквани верификации"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Брой изисквани верификации, преди даден резултат да се счита за 'верифициран'. Тази настройка може да бъде презаписана за всеки анализ в изгледа за редакция на Услуга за анализ. По подразбиране е 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Брой изисквани верификации от различни потребители с достатъчно привилегии, преди даден резултат за този анализ да се счита за 'верифициран'. Зададената тук опция има приоритет пред опцията, зададена в настройките на Bika"
 
@@ -3868,6 +4059,10 @@ msgstr "Брой стандартни колони"
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
 msgstr "Числово"
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
+msgstr ""
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -3885,11 +4080,11 @@ msgstr "Само изображения могат да се рендират д
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr "Показват се само инструменти, които имат конфигуриран интерфейс за импортиране"
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "За изчисляване на времето за изпълнение на анализа се вземат предвид само лабораторните работни дни. "
 
@@ -3897,13 +4092,13 @@ msgstr "За изчисляване на времето за изпълнени�
 msgid "Only to empty or zero fields"
 msgstr "Само за празни или нулеви полета"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Отворен"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr "Отворени / За верификация / Верифицирани / Общо"
 
@@ -3911,9 +4106,17 @@ msgstr "Отворени / За верификация / Верифициран�
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Уеб базирана лабораторна информационна система с отворен код"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "Отворете имейл форма за изпращане на избраните доклади до получателите. Това също ще публикува съдържащите се проби от докладите, след като имейлът бъде успешно изпратен."
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3940,7 +4143,7 @@ msgstr "Други причини"
 msgid "Other reasons:"
 msgstr "Други причини:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Друг статус"
 
@@ -3962,11 +4165,11 @@ msgstr "Презаписване на непразни резултати от �
 msgid "Override non-empty analysis results, also with empty"
 msgstr "Презаписване на непразни резултати от анализ, също и с празни"
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4063,11 +4266,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Моля, изберете потребител от списъка"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4080,6 +4283,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr "Моля, изберете броя на частите за създаване и натиснете бутона за преглед"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr "Моля, посочете причина"
 
@@ -4099,12 +4303,16 @@ msgstr "Моля, използвайте следния формат за опц
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr "Моля, напишете коментар къде са изпратени изброените проби"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Място на отчитане"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4143,31 +4351,31 @@ msgstr "Точност като брой десетични знаци"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Точност като брой на значимите цифри според неопределеността. Десетичната позиция се определя от първото число, различно от нула в неопределеността, като на тази позиция системата ще закръгли неопределеността и резултатите. Например, при резултат 5.243 и неопределеност 0.22, системата ще покаже правилно 5.2+-0.2. Ако няма зададен диапазон на неопределеност за резултата, системата ще използва зададената фиксирана точност."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr "Предварително дефинирани резултати"
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Предпочитан десетичен знак за доклади."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Предпочитан десетичен знак за резултати"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "Предпочитано оформление на таблицата за въвеждане на резултати в изгледа на Работния лист. Класическото оформление показва Пробите в редове, а анализите в колони. Транспонираното оформление показва Пробите в колони, а анализите в редове."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Предпочитан формат за научно записване за доклади"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Предпочитан формат за научно записване за резултати"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4200,7 +4408,7 @@ msgstr "Консервация според типа проба"
 msgid "Preserve"
 msgstr "Консервирай"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Консервиращ"
 
@@ -4217,11 +4425,11 @@ msgstr "Превантивна"
 msgid "Preventive maintenance procedure"
 msgstr "Процедура за превантивна поддръжка"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "Преглед"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4249,7 +4457,7 @@ msgstr "Ценоразпис за"
 msgid "Pricelists"
 msgstr "Ценоразписи"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4258,7 +4466,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "Първична проба"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4280,11 +4488,11 @@ msgstr "Дата на печат:"
 msgid "Print pricelist"
 msgstr "Печат на ценоразпис"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Печат на етикети"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Отпечатан"
 
@@ -4297,7 +4505,7 @@ msgstr "Отпечатан на"
 msgid "Priority"
 msgstr "Приоритет"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Профил"
 
@@ -4321,7 +4529,7 @@ msgstr "Име на профил"
 msgid "Profile keyword must be unique"
 msgstr "Ключовата дума на профила трябва да е уникална"
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Напредък"
 
@@ -4330,7 +4538,7 @@ msgstr "Напредък"
 msgid "Prominent fields"
 msgstr "Основни полета"
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "ID на протокол"
 
@@ -4338,7 +4546,7 @@ msgstr "ID на протокол"
 msgid "Province"
 msgstr "Област"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4347,8 +4555,12 @@ msgstr ""
 msgid "Publish"
 msgstr "Публикувай"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Публикуван"
@@ -4364,6 +4576,10 @@ msgstr "Дата на публикуване"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Публикувани резултати"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4385,6 +4601,14 @@ msgstr "QC резултати"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "QC ID на проба"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4410,7 +4634,7 @@ msgstr "Въведете паролата отново. Уверете се, ч�
 msgid "Reasons for rejection"
 msgstr "Причини за отхвърляне"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Преназначи"
 
@@ -4422,30 +4646,34 @@ msgstr "Слот за преназначаване"
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr "Преизчисли"
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Получаване"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Получен"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Чакащо приемане"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Получатели"
 
@@ -4496,11 +4724,15 @@ msgstr "Референтни стойности"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Стойностите на референтната проба са нула или 'празни'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Регистрирай"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4526,9 +4758,9 @@ msgstr "Отхвърли анализ"
 msgid "Reject samples"
 msgstr "Отхвърли проби"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Отхвърлен"
 
@@ -4544,7 +4776,7 @@ msgstr "Отхвърлена проба"
 msgid "Rejected {} samples: {}"
 msgstr "Отхвърлени {} проби: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4605,8 +4837,16 @@ msgstr "Отдалечен IP"
 msgid "Remove"
 msgstr "Премахни"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4642,11 +4882,11 @@ msgstr "ID на доклад"
 msgid "Report identification number"
 msgstr "Идентификационен номер на доклад"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4658,7 +4898,7 @@ msgstr "Качване на доклад"
 msgid "Republish"
 msgstr "Препубликувай"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "Препубликуван след последния печат"
 
@@ -4667,7 +4907,7 @@ msgstr "Препубликуван след последния печат"
 msgid "Request ID"
 msgstr "ID на заявка"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Заяви нови анализи"
 
@@ -4683,24 +4923,37 @@ msgstr "Изискван обем"
 msgid "Reset"
 msgstr "Нулиране"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr "Нулиране на колони"
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
 msgstr "Отговорни лица"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr "Възстанови"
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4725,15 +4978,15 @@ msgstr "Стойността на резултата трябва да е чис
 msgid "Result Value must be unique"
 msgstr "Стойността на резултата трябва да е уникална"
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Резултат в допустимия обхват"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Резултат извън обхвата"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr "Диапазонът на резултата е различен от Спецификацията: {}"
 
@@ -4741,7 +4994,7 @@ msgstr "Диапазонът на резултата е различен от С
 msgid "Result type"
 msgstr "Тип резултат"
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Стойностите на резултатите с поне този брой значими цифри се показват в научно записване, използвайки буквата 'e' за обозначаване на експонентата. Точността може да се конфигурира в индивидуалните Услуги за анализ."
 
@@ -4757,16 +5010,20 @@ msgstr "Резултати"
 msgid "Results Interpretation"
 msgstr "Интерпретация на резултати"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Резултатите са оттеглени"
 
@@ -4774,7 +5031,7 @@ msgstr "Резултатите са оттеглени"
 msgid "Results interpretation"
 msgstr "Интерпретация на резултати"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Чакащи резултати"
 
@@ -4798,7 +5055,7 @@ msgstr "Повторно тестван"
 msgid "Retract"
 msgstr "Оттегли"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4834,6 +5091,10 @@ msgstr "Връщане назад"
 msgid "Routine Analyses"
 msgstr "Рутинни анализи"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr "SENAITE CORE"
@@ -4859,6 +5120,7 @@ msgstr "SENAITE LIMS начална страница"
 msgid "SENAITE Registry"
 msgstr "SENAITE Регистър"
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4868,7 +5130,7 @@ msgstr "SENAITE Настройки"
 msgid "SENAITE front-page"
 msgstr "SENAITE начална страница"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "SMTP сървърът прекъсна връзката. Създаването на потребител е прекратено."
 
@@ -4882,7 +5144,7 @@ msgstr "Поздрав"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Проба"
 
@@ -4919,7 +5181,7 @@ msgid "Sample Header"
 msgstr "Заглавка на проба"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "ID на проба"
 
@@ -4939,7 +5201,7 @@ msgstr "Матрица на проба"
 msgid "Sample Partitions"
 msgstr "Части на проба"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4966,7 +5228,7 @@ msgid "Sample Templates"
 msgstr "Шаблони за проби"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Тип проба"
@@ -5027,7 +5289,7 @@ msgstr "Тип проба"
 msgid "SampleTypes"
 msgstr "Типове проби"
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Пробовземащ"
 
@@ -5039,8 +5301,8 @@ msgstr "Пробовземащ за планирано пробовземане"
 msgid "Sampler required for sample %s"
 msgstr "Изисква се пробовземащ за проба %s"
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Проби"
@@ -5057,6 +5319,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5066,7 +5340,23 @@ msgstr "Пробите от този тип трябва да се третир�
 msgid "Samples rejection reporting form"
 msgstr "Формуляр за докладване на отхвърляне на проби"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5074,7 +5364,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Дата на пробовземане"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Отклонение при пробовземане"
@@ -5087,7 +5377,7 @@ msgstr "Отклонения при пробовземане"
 msgid "Sampling Frequency"
 msgstr "Честота на пробовземане"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "Планирано пробовземане"
 
@@ -5095,15 +5385,24 @@ msgstr "Планирано пробовземане"
 msgid "Saturday"
 msgstr "Събота"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Запази"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
 msgstr "Запази и копирай"
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5117,7 +5416,7 @@ msgstr "График"
 msgid "Schedule sampling"
 msgstr "Планирай пробовземане"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Планирано пробовземане"
@@ -5134,6 +5433,10 @@ msgstr "Научно име"
 msgid "Search"
 msgstr "Търсене"
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5142,7 +5445,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Секунди"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5232,11 +5535,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Избери шаблон"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Изберете държавата, която сайтът ще показва по подразбиране"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Изберете валутата, която сайтът ще използва за показване на цени."
 
@@ -5248,11 +5551,11 @@ msgstr "Изберете контейнера по подразбиране, к�
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Изберете началната страница по подразбиране. Тя се използва, когато Клиентски потребител влезе в системата или когато клиент е избран от списъка с клиентски папки."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr "Изберете шаблона за етикет по подразбиране, използван за автоматично отпечатване.<br/>"
 
@@ -5260,31 +5563,39 @@ msgstr "Изберете шаблона за етикет по подразби�
 msgid "Select the types that this ID is used to identify."
 msgstr "Изберете типовете, които това ID идентифицира."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "Изберете това, за да активирате автоматични уведомления по имейл до Клиента, когато Проба бъде отхвърлена."
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "Изберете това, за да активирате таблото за управление като начална страница по подразбиране."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Изберете това, за да активирате стъпките на работния процес за събиране на проби."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Изберете това, за да позволите на Координатор по пробовземане да планира пробовземане. Тази функционалност влиза в сила само когато 'Работен процес за пробовземане' е активен"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr "Изберете това, за да позволите на потребителя да зададе допълнителен статус 'Отпечатан' за тези Заявки за анализ, които са били Публикувани. Деактивирано по подразбиране."
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "Изберете, за да получавате пробите автоматично, когато са създадени от лабораторния персонал и работният процес за пробовземане е деактивиран. Пробите, създадени от клиентски контакти, няма да бъдат получавани автоматично"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr "Изберете, за да показвате частите на пробите на клиентските контакти. Ако е деактивирано, частите няма да бъдат включени в списъците и няма да се показва информационно съобщение с връзки към първичната проба за клиентските контакти."
 
@@ -5296,7 +5607,7 @@ msgstr "Изберете кои анализи да бъдат включени 
 msgid "Selection list"
 msgstr "Списък за избор"
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Самоверификация на резултати"
 
@@ -5308,11 +5619,11 @@ msgstr "Изпрати"
 msgid "Send Analysis Reports via Email"
 msgstr "Изпрати доклади от анализи по имейл"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5334,7 +5645,7 @@ msgstr "Изпратено до"
 msgid "Separate Container"
 msgstr "Отделен контейнер"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5348,7 +5659,7 @@ msgstr "Сериен №"
 msgid "Service"
 msgstr "Услуга"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "Услугата не може да бъде деселектирана. Моля, кликнете върху бутона за информация за повече подробности"
 
@@ -5376,7 +5687,7 @@ msgstr "Задай работния процес за отхвърляне на 
 msgid "Set the maintenance task as closed."
 msgstr "Задай задачата за поддръжка като затворена."
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr "Задайте текста за тялото на имейла, който ще бъде изпратен до клиентския контакт на Пробата, ако опцията 'Имейл уведомление при отхвърляне на проба' е активирана. Можете да използвате запазени ключови думи: $sample_id, $sample_link, $reasons, $lab_address"
 
@@ -5424,29 +5735,41 @@ msgstr "Трябва ли анализите да бъдат изключени 
 msgid "Should the default example content be added to the site?"
 msgstr "Трябва ли да се добави примерното съдържание по подразбиране към сайта?"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
 msgstr "Покажи всички"
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr "Покажи логовете от последното автоматично импортиране"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr "Покажи повече"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
 msgstr "Покажи стандартни полета"
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5468,11 +5791,11 @@ msgstr "Код на обекта"
 msgid "Site Description"
 msgstr "Описание на обекта"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr "Лого на сайта"
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr "CSS за лого на сайта"
 
@@ -5493,7 +5816,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Малък етикет"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr "Шаблон за малък етикет"
 
@@ -5510,6 +5833,14 @@ msgstr "Някои анализи използват остарели или н�
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Ключ за сортиране"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5535,7 +5866,7 @@ msgstr "Диапазоните на спецификацията са проме
 msgid "Specifications"
 msgstr "Спецификации"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr "Посочете колко копия на всеки етикет да се отпечатват по подразбиране."
 
@@ -5543,7 +5874,7 @@ msgstr "Посочете колко копия на всеки етикет да
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Посочете размера на Работния лист, напр. отговарящ на размера на таблата на конкретен инструмент. След това изберете 'тип' Анализ за всяка позиция в Работния лист. Когато са избрани QC проби, изберете и коя Референтна проба трябва да се използва. Ако е избран дублиращ анализ, посочете на коя позиция на пробата той трябва да бъде дубликат"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5560,17 +5891,17 @@ msgstr "Начална дата"
 msgid "Start date must be before End Date"
 msgstr "Началната дата трябва да е преди крайната дата"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Щат/Провинция"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Статус"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Етикет"
@@ -5579,7 +5910,11 @@ msgstr "Етикет"
 msgid "Stickers preview"
 msgstr "Преглед на етикети"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Място за съхранение"
@@ -5619,7 +5954,11 @@ msgstr "Подай"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr "Подайте валиден Open XML (.XLSX) файл, съдържащ записи за настройка, за да продължите."
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "Подадено и верифицирано от същия потребител: {}"
 
@@ -5627,7 +5966,7 @@ msgstr "Подадено и верифицирано от същия потре�
 msgid "Submitter"
 msgstr "Подател"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Междинна сума"
@@ -5669,7 +6008,7 @@ msgstr "Превключи към табло за управление"
 msgid "Switch to transposed view"
 msgstr "Превключи към транспониран изглед"
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "Системно по подразбиране"
 
@@ -5695,7 +6034,7 @@ msgstr "Данъци"
 msgid "Technical description and instructions intended for analysts"
 msgstr "Техническо описание и инструкции, предназначени за анализатори"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5777,7 +6116,7 @@ msgstr "Датата, когато пробата е консервирана"
 msgid "The date when the sample was received"
 msgstr "Датата, когато пробата е получена"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Ще бъде използван десетичният знак, избран в Настройките на Bika."
 
@@ -5785,7 +6124,7 @@ msgstr "Ще бъде използван десетичният знак, изб
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr "Настройката за часова зона по подразбиране на портала. Потребителите ще могат да задават своя собствена часова зона, ако са дефинирани налични часови зони в настройките за дата и час."
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "Въведеният тук процент на отстъпка се прилага към цените за клиенти, отбелязани като 'членове', обикновено членове на кооперации или сътрудници, заслужаващи тази отстъпка"
 
@@ -5813,7 +6152,11 @@ msgstr "Следните части са създадени от тази Про
 msgid "The following sample(s) will be dispatched"
 msgstr "Следните проби ще бъдат изпратени"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr "Глобалният одитен журнал показва всички модификации на системата. Когато е активиран, всички обекти ще бъдат индексирани в отделен каталог. Това ще увеличи времето при създаване или модифициране на обекти."
 
@@ -5821,11 +6164,11 @@ msgstr "Глобалният одитен журнал показва всичк
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Височината или дълбочината, на която трябва да се вземе пробата"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr "Срокът за съхранение за тази проба и анализ е изтекъл. Продължаването с анализа може да компрометира надеждността на резултатите."
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr "Срокът за съхранение за тази проба и анализ е на път да изтече. Моля, завършете анализа възможно най-скоро, за да гарантирате точността и надеждността на данните."
 
@@ -5862,11 +6205,11 @@ msgstr "Минималният обем на пробата, необходим 
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Броят дни преди пробата да изтече и да не може да бъде анализирана повече. Тази настройка може да бъде презаписана за всеки отделен тип проба в настройките на типовете проби"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Броят минути преди потребителят да бъде автоматично изписан. 0 деактивира автоматичното изписване"
 
@@ -5906,7 +6249,7 @@ msgstr "Референтният код, издаден на лаборатор�
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "Резултатът след извършване на изчислението с тестови стойности. Трябва да запазите изчислението, преди тази стойност да бъде изчислена."
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr "Резултатът е въведен след изтичане на срока за съхранение."
 
@@ -5930,11 +6273,11 @@ msgstr "Пробата е смес от подпроби"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Серийният номер, който уникално идентифицира инструмента"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "ID на аналитичния протокол на услугата"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "Търговското ID на услугата за счетоводни цели"
 
@@ -5986,11 +6329,11 @@ msgstr "Това е Вторична проба на"
 msgid "This is a detached partition from Sample"
 msgstr "Това е отделена част от Проба"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "Това е максималното допустимо време по подразбиране за извършване на анализи. Използва се само за анализи, където услугата за анализ не посочва време за изпълнение. Вземат се предвид само лабораторните работни дни."
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6014,11 +6357,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr "Тази услуга не може да бъде избрана, за да се предотврати извършването на анализа след изтичане на аналитичното време за съхранение."
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr "Това показва персонализирано лого на вашия SENAITE сайт."
 
@@ -6050,8 +6393,8 @@ msgstr "Време"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Съвет. Прикачените документи няма да бъдат заредени, освен ако не присъстват в инстанцията."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Заглавие"
@@ -6078,34 +6421,42 @@ msgstr "Заглавие на сайта"
 msgid "To"
 msgstr "До"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "За консервация"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "За пробовземане"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Да се показва под всеки раздел Категория на анализ в докладите за резултати."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "За консервация"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "За печат"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "За пробовземане"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "За верификация"
@@ -6118,7 +6469,7 @@ msgstr "За да тествате изчислението, въведете с
 msgid "Toggle visibility of standard sample header fields"
 msgstr "Превключване на видимостта на стандартните полета в заглавката на пробата"
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Общо"
 
@@ -6140,7 +6491,7 @@ msgid "Tuesday"
 msgstr "Вторник"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Тип"
@@ -6165,6 +6516,10 @@ msgstr "Тип на контейнера"
 msgid "Type to filter ..."
 msgstr "Въведете за филтриране ..."
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr "Типове, които поддържат етикети директно.<br/>ЗАБЕЛЕЖКА: В клъстерни конфигурации, другите инстанции трябва да бъдат рестартирани ръчно, за да влязат промените в сила!"
@@ -6173,7 +6528,7 @@ msgstr "Типове, които поддържат етикети директ�
 msgid "Types with labels"
 msgstr "Типове с етикети"
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6185,6 +6540,7 @@ msgstr "Неуспешно зареждане на шаблона"
 msgid "Unassign"
 msgstr "Отмени назначаване"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Невъзложени"
@@ -6217,9 +6573,13 @@ msgstr "Непозната IBAN държава %s"
 msgid "Unlink User"
 msgstr "Разкачи потребител"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
 msgstr "Разкачен потребител"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6235,13 +6595,17 @@ msgstr "Неразпознат файлов формат ${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr "Неразпознат файлов формат ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "Невъзложени"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Обнови прикачените файлове"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6251,7 +6615,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Качете сканиран подпис, който да се използва в отпечатаните доклади за резултати от анализ. Идеалният размер е 250 пиксела ширина на 150 височина"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6259,7 +6623,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Използвай цена от профил за анализ"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Използвай таблото за управление като начална страница по подразбиране"
 
@@ -6297,7 +6661,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "Потребител, свързан с този Контакт"
 
@@ -6305,15 +6669,15 @@ msgstr "Потребител, свързан с този Контакт"
 msgid "User name"
 msgstr "Потребителско име"
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Използването на твърде малко точки от данни няма статистически смисъл. Задайте приемлив минимален брой резултати, преди да се изчисляват и чертаят QC статистики"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6321,7 +6685,7 @@ msgstr "ДДС"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "ДДС %"
 
@@ -6568,8 +6932,8 @@ msgstr "Стойността за секунди трябва да е между
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Тук могат да бъдат въведени стойности, които ще заменят стойностите по подразбиране, посочени в Междинните полета за изчисление."
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Верифициран"
@@ -6578,11 +6942,19 @@ msgstr "Верифициран"
 msgid "Verified By"
 msgstr "Верифициран от"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Верифицирай"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6597,6 +6969,14 @@ msgstr "Преглед"
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
 msgstr "Прегледайте вашия SENAITE сайт"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr ""
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -6631,6 +7011,10 @@ msgstr "Уебсайт"
 msgid "Wednesday"
 msgstr "Сряда"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Седмици до изтичане"
@@ -6643,19 +7027,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr "Добре дошли в SENAITE"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr "Когато е активирано, пробата се верифицира автоматично веднага щом всички резултати бъдат верифицирани. В противен случай потребителите с достатъчно права трябва да верифицират пробата ръчно след това. По подразбиране: активирано"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6706,10 +7090,18 @@ msgstr "Шаблони за работни листове"
 msgid "Worksheet printing templates order"
 msgstr "Ред на шаблоните за печат на работен лист"
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Работни листове"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6718,6 +7110,10 @@ msgstr "Грешна дължина на IBAN за %s: %s"
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Грешна дължина на IBAN за %s: %sпо-къс с %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6801,6 +7197,10 @@ msgstr "Дубликат"
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6905,8 +7305,17 @@ msgstr "дни"
 msgid "deactivate"
 msgstr "деактивиране"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr "Прикачени етикети"
 
@@ -6972,7 +7381,7 @@ msgstr "Тази услуга няма да се появява за избор 
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 #, fuzzy
 msgid "description_analysis_results_options_sorting"
 msgstr "Критерии, които да се използват, когато опциите за резултати се показват за избор в списъците за въвеждане на резултати. Имайте предвид, че това се отнася само за опциите, показани в списъка за избор. Това не оказва влияние върху реда, в който се показват резултатите след подаването им"
@@ -7148,27 +7557,27 @@ msgstr "Изберете клиента на тази партида"
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 #, fuzzy
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr "Ако тази опция е активирана, датата на въвеждане на резултата може да бъде въведена ръчно за анализи"
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 #, fuzzy
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr "Когато е избрано, отговорните лица от всички участващи лабораторни отдели ще получават имейли за публикуване."
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr "Групиране на анализи по категория за проби"
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 #, fuzzy
 msgid "description_bikasetup_date_sampled_required"
 msgstr "Изберете това, за да направите полето Дата на пробовземане задължително при създаване на проба. Тази функционалност влиза в сила само когато 'Работен процес за пробовземане' не е активен"
@@ -7176,7 +7585,7 @@ msgstr "Изберете това, за да направите полето Д�
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 #, fuzzy
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr "Задайте текста на тялото на имейла, който да се използва по подразбиране при изпращане на доклади за резултати до избраните получатели. Можете да използвате запазени ключови думи: $client_name, $recipients, $lab_name, $lab_address"
@@ -7184,7 +7593,7 @@ msgstr "Задайте текста на тялото на имейла, кой�
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 #, fuzzy
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr "Имейл, който да се използва като адрес 'От' за изходящи имейли при публикуване на доклади за резултати. Този адрес отменя стойността, зададена в 'Настройки за поща' на портала."
@@ -7192,7 +7601,7 @@ msgstr "Имейл, който да се използва като адрес '�
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 #, fuzzy
 msgid "description_bikasetup_immediateresultsentry"
 msgstr "Разрешаване на потребителя директно да въвежда резултати след създаване на проба, напр. за незабавно въвеждане на полеви резултати или лабораторни резултати, когато е активирано автоматичното получаване на проби."
@@ -7205,19 +7614,19 @@ msgstr "Разрешаване на потребителя директно да
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr "Изискват се анализи за регистрация на проба"
 
@@ -7238,16 +7647,21 @@ msgstr "Зависими услуги на това изчисление"
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7272,12 +7686,12 @@ msgid "description_category_department"
 msgstr "Изберете отговорния отдел"
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr "Винаги разгъвай избраните категории"
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr "Показвай само избраните категории"
 
@@ -7287,7 +7701,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr "Контакти в копие (CC) за нови проби"
 
@@ -7394,6 +7808,19 @@ msgstr "Изберете отдел по подразбиране за този 
 msgid "description_labcontact_departments"
 msgstr "Назначени лабораторни отдели"
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7425,6 +7852,13 @@ msgstr "Моля, предоставете цената без ДДС"
 #, fuzzy
 msgid "description_labproduct_vat"
 msgstr "Моля, предоставете ДДС в проценти, който се добавя към цената на лабораторния продукт"
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
+msgstr ""
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
@@ -7575,12 +8009,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7844,7 +8278,7 @@ msgstr "Изберете матрицата на пробата за този т
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 #, fuzzy
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr "Ако тази опция е активирана, датата на въвеждане на резултата може да бъде въведена ръчно за анализи"
@@ -7853,111 +8287,111 @@ msgstr "Ако тази опция е активирана, датата на в
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 #, fuzzy
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr "Когато е избрано, отговорните лица от всички участващи лабораторни отдели ще получават имейли за публикуване."
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr "Групиране на анализи по категория за проби"
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 #, fuzzy
 msgid "description_senaitesetup_date_sampled_required"
 msgstr "Изберете това, за да направите полето Дата на пробовземане задължително при създаване на проба. Тази функционалност влиза в сила само когато 'Работен процес за пробовземане' не е активен"
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 #, fuzzy
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr "Имейл, който да се използва като адрес 'От' за изходящи имейли при публикуване на доклади за резултати. Този адрес отменя стойността, зададена в 'Настройки за поща' на портала."
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 #, fuzzy
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr "Разрешаване на потребителя директно да въвежда резултати след създаване на проба, напр. за незабавно въвеждане на полеви резултати или лабораторни резултати, когато е активирано автоматичното получаване на проби."
@@ -7965,21 +8399,21 @@ msgstr "Разрешаване на потребителя директно да
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 #, fuzzy
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr "Максимален брой проби, които могат да бъдат създадени в съответствие със стойността, зададена за полето 'Брой проби' във формата за регистрация на проба"
@@ -7987,35 +8421,35 @@ msgstr "Максимален брой проби, които могат да б�
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 #, fuzzy
 msgid "description_senaitesetup_publication_email_text"
 msgstr "Задайте текста на тялото на имейла, който да се използва по подразбиране при изпращане на доклади за резултати до избраните получатели. Можете да използвате запазени ключови думи: $client_name, $recipients, $lab_name, $lab_address"
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -8023,47 +8457,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr "Изискват се анализи за регистрация на проба"
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8072,13 +8506,13 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 #, fuzzy
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr "Когато е избрано, името на лабораторията ще се показва на страницата за вход, над данните за достъп."
@@ -8086,7 +8520,7 @@ msgstr "Когато е избрано, името на лабораторият
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8094,32 +8528,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8127,21 +8561,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 #, fuzzy
 msgid "description_setup_landingpage"
 msgstr "Началната страница се показва за неаутентифицирани потребители, ако Таблото за управление не е избрано като начална страница по подразбиране. Ако не е избрана начална страница, се показва началната страница по подразбиране."
@@ -8304,6 +8738,10 @@ msgstr ""
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
 msgstr "Съдържание на файла"
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
+msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8616,7 +9054,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr "Етикети"
 
@@ -8679,7 +9117,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr "Максимален срок за съхранение"
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr "Критерии за сортиране"
 
@@ -8797,52 +9235,52 @@ msgid "label_batch_client"
 msgstr "Клиент"
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr "Разреши задаване на дата на въвеждане на резултат"
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr "Винаги изпращай имейл за публикуване до отговорните лица"
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr "Категоризиране на анализи на проби"
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr "Изисква се дата на пробовземане"
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr "Тяло на имейла за уведомления за публикуване на проба"
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr "Адрес 'От' за публикуване"
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr "Незабавно въвеждане на резултати"
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr "Изискват се анализи на проба"
 
@@ -8912,12 +9350,12 @@ msgid "label_category_department"
 msgstr "Отдел"
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr "Категории по подразбиране"
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr "Ограничи категории"
 
@@ -8927,7 +9365,7 @@ msgid "label_confirm_password"
 msgstr "Потвърди парола"
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr "Контакти за копие (CC)"
 
@@ -9223,7 +9661,7 @@ msgid "label_powered_by_plone"
 msgstr "Plone & Python"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9348,12 +9786,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9563,7 +10001,7 @@ msgid "label_sampletype_title"
 msgstr "Име"
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr "Запази"
 
@@ -9573,12 +10011,12 @@ msgid "label_senaite"
 msgstr "SENAITE LIMS"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr "Максимална стойност за полето 'Брой проби' при регистрация"
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr "Начална страница"
 
@@ -9637,6 +10075,22 @@ msgstr "Предпочитан инструмент"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
 msgstr "Ограничи до метод"
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
+msgstr ""
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
@@ -10812,87 +11266,87 @@ msgid "listing_suppliers_title"
 msgstr "Доставчици"
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10945,6 +11399,11 @@ msgstr "Шаблони за работни листове"
 msgid "minutes"
 msgstr "минути"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "месечно"
@@ -10995,13 +11454,21 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr "Задай"
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "от"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "преглед"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11079,6 +11546,11 @@ msgstr "Код на интерфейс"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
 msgstr "Тази проба е изпратена от ${actor} на ${date}"
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
+msgstr ""
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11312,13 +11784,18 @@ msgstr "Лабораторен служител"
 msgid "title_lab_manager_role"
 msgstr "Лабораторен мениджър"
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr "Описание"
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr "Име"
 
@@ -11406,6 +11883,11 @@ msgstr "Референция"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
 msgstr "Тип анализ"
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
+msgstr ""
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
@@ -11650,222 +12132,222 @@ msgid "title_samplingdeviation_title"
 msgstr "Име"
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr "Разреши задаване на дата на въвеждане на резултат"
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr "Винаги изпращай имейл за публикуване до отговорните лица"
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr "Категоризиране на анализи на проби"
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr "Изисква се дата на пробовземане"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr "Адрес 'От' за публикуване"
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr "Текст на имейла за публикуване"
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr "Изискват се анализи на проба"
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr "Показвай името на лабораторията на страницата за вход"
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12122,7 +12604,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr "Горната граница на количествено определяне (ULOQ) не може да бъде по-голяма от Горната граница на откриване (ULOD)."
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "чакащи верификация"
 
@@ -12165,7 +12647,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr "{} (С изтекъл срок)"
 

--- a/src/senaite/core/locales/bg_BG/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/bg_BG/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/senaite/teams/87045/bg_BG/)\n"

--- a/src/senaite/core/locales/bn/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/bn/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Bengali (https://app.transifex.com/senaite/teams/87045/bn/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/bn/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/bn/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Bengali (https://app.transifex.com/senaite/teams/87045/bn/)\n"

--- a/src/senaite/core/locales/bn/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/bn/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Bengali (https://app.transifex.com/senaite/teams/87045/bn/)\n"

--- a/src/senaite/core/locales/bn/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/bn/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Bengali (https://app.transifex.com/senaite/teams/87045/bn/)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: bn\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -27,6 +27,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -52,6 +53,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -121,6 +123,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -138,7 +144,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -196,7 +202,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -241,21 +247,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -283,15 +289,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -304,8 +314,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -369,12 +382,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -393,11 +414,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -426,14 +447,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -503,7 +540,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -540,7 +577,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -550,6 +587,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -564,18 +605,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -590,7 +627,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -678,11 +715,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -690,15 +731,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -749,7 +790,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -779,6 +820,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -799,7 +844,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -817,19 +862,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -837,12 +882,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -898,23 +943,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -934,15 +979,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -968,7 +1013,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1000,11 +1045,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1041,31 +1086,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1078,12 +1123,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1091,7 +1150,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1103,7 +1162,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1115,7 +1174,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1125,7 +1184,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1134,7 +1193,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1227,7 +1286,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1265,6 +1324,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1283,7 +1346,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1327,7 +1390,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1360,15 +1423,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1378,6 +1441,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1396,11 +1463,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1413,7 +1480,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1421,7 +1488,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1433,7 +1500,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1463,7 +1530,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1472,7 +1539,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1480,12 +1547,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1533,23 +1608,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1561,11 +1636,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1607,7 +1682,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1630,11 +1705,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1646,7 +1721,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1658,7 +1733,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1666,20 +1741,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1691,7 +1766,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1723,15 +1798,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1743,7 +1818,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1752,7 +1827,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1776,7 +1851,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1788,8 +1863,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1818,9 +1902,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1867,7 +1951,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1885,7 +1973,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1910,15 +1998,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1988,11 +2084,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2009,7 +2109,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2057,6 +2157,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2071,21 +2172,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2093,27 +2194,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2126,16 +2227,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2146,27 +2251,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2174,8 +2279,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2199,7 +2312,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2212,7 +2325,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2236,7 +2349,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2248,15 +2361,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2268,7 +2381,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2278,7 +2391,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2304,7 +2417,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2312,7 +2425,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2399,7 +2512,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2413,6 +2526,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2429,11 +2554,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2456,13 +2581,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2470,7 +2599,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2503,7 +2632,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2517,7 +2646,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2530,8 +2659,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2555,7 +2696,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2563,7 +2704,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2583,15 +2724,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2599,7 +2740,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2639,7 +2780,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2670,11 +2811,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2871,7 +3012,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2892,13 +3033,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2961,15 +3102,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2981,7 +3122,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2993,9 +3134,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3010,6 +3151,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3055,8 +3200,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3065,7 +3210,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3073,13 +3218,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3092,7 +3237,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3104,7 +3249,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3116,11 +3261,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3166,15 +3311,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3198,7 +3343,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3225,6 +3370,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3289,7 +3442,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3313,7 +3466,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3337,7 +3490,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3366,7 +3519,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3381,7 +3534,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3416,15 +3569,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3432,7 +3585,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3463,7 +3616,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3474,7 +3627,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3492,7 +3645,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3523,6 +3676,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3536,11 +3693,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3576,13 +3733,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3592,6 +3753,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3634,6 +3799,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3682,6 +3851,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3726,12 +3899,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3748,6 +3935,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3776,7 +3967,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3792,11 +3983,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3817,7 +4008,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3829,7 +4020,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3845,16 +4036,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3864,6 +4055,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3882,11 +4077,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3894,13 +4089,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3908,8 +4103,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3937,7 +4140,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3959,11 +4162,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4060,11 +4263,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4077,6 +4280,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4096,12 +4300,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4140,31 +4348,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4197,7 +4405,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4214,11 +4422,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4246,7 +4454,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4255,7 +4463,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4277,11 +4485,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4294,7 +4502,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4318,7 +4526,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4327,7 +4535,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4335,7 +4543,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4344,8 +4552,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4360,6 +4572,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4381,6 +4597,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4407,7 +4631,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4419,30 +4643,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4493,11 +4721,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4523,9 +4755,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4541,7 +4773,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4602,8 +4834,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4639,11 +4879,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4655,7 +4895,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4664,7 +4904,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4680,8 +4920,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4689,15 +4941,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4722,15 +4975,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4738,7 +4991,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4754,16 +5007,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4771,7 +5028,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4795,7 +5052,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4831,6 +5088,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4856,6 +5117,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4865,7 +5127,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4879,7 +5141,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4916,7 +5178,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4936,7 +5198,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4963,7 +5225,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5024,7 +5286,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5036,8 +5298,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5054,6 +5316,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5063,7 +5337,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5071,7 +5361,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5084,7 +5374,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5092,14 +5382,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5114,7 +5413,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5131,6 +5430,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5139,7 +5442,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5229,11 +5532,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5245,11 +5548,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5257,31 +5560,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5293,7 +5604,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5305,11 +5616,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5331,7 +5642,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5345,7 +5656,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5373,7 +5684,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5421,28 +5732,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5465,11 +5788,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5490,7 +5813,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5506,6 +5829,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5532,7 +5863,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5540,7 +5871,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5557,17 +5888,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5576,7 +5907,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5616,7 +5951,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5624,7 +5963,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5666,7 +6005,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5692,7 +6031,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5774,7 +6113,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5782,7 +6121,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5810,7 +6149,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5818,11 +6161,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5859,11 +6202,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5903,7 +6246,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5927,11 +6270,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5983,11 +6326,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6011,11 +6354,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6047,8 +6390,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6075,34 +6418,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6115,7 +6466,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6137,7 +6488,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6162,6 +6513,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6170,7 +6525,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6182,6 +6537,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6214,8 +6570,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6232,12 +6592,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6248,7 +6612,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6256,7 +6620,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6294,7 +6658,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6302,15 +6666,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6318,7 +6682,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6565,8 +6929,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6575,10 +6939,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6593,6 +6965,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6628,6 +7008,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6640,19 +7024,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6703,9 +7087,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6714,6 +7106,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6798,6 +7194,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6902,8 +7302,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6968,7 +7377,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7135,46 +7544,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7186,19 +7595,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7219,16 +7628,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7253,12 +7667,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7268,7 +7682,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7371,6 +7785,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7400,6 +7827,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7546,12 +7980,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7804,7 +8238,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7812,163 +8246,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7976,47 +8410,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8025,20 +8459,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8046,32 +8480,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8079,21 +8513,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8249,6 +8683,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8561,7 +8999,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8622,7 +9060,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8738,52 +9176,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8853,12 +9291,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8868,7 +9306,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9164,7 +9602,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9289,12 +9727,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9504,7 +9942,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9514,12 +9952,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9577,6 +10015,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10753,87 +11207,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10886,6 +11340,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10936,12 +11395,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11019,6 +11486,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11253,13 +11725,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11346,6 +11823,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11591,222 +12073,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12060,7 +12542,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12103,7 +12585,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/bs/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/bs/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Bosnian (https://app.transifex.com/senaite/teams/87045/bs/)\n"

--- a/src/senaite/core/locales/bs/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/bs/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Bosnian (https://app.transifex.com/senaite/teams/87045/bs/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/bs/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/bs/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Bosnian (https://app.transifex.com/senaite/teams/87045/bs/)\n"

--- a/src/senaite/core/locales/bs/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/bs/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Bosnian (https://app.transifex.com/senaite/teams/87045/bs/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: bs\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} dodataka sa ukupnom veličinom ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr "%s nema '%s' kolonu."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Nazad"
@@ -122,6 +124,10 @@ msgstr "*** Ovo je automatski generirani email, molimo da ne odgovarate na ovau 
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" />Dobro došli u SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Vrsta računa"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr "Aktiviraj"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Aktivno"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Dodaj"
 
@@ -284,15 +290,19 @@ msgstr "Dodaj duplikat"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr "Dodaj novi dodatak"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Dodaj primjedbu"
 
@@ -370,13 +383,21 @@ msgstr "Sve akreditovane analize su navedene ovdje."
 msgid "All Analyses of Service"
 msgstr "Sve analize usluge"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Sve dodjeljene analize"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Dozvoli ručno postavljeni limit detekcije"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Dozvoli samo-verifikaciju rezultata"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,15 +448,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Analizirao"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analize"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Tražene analize"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr "Analitičar mora biti naveden"
 msgid "Any"
 msgstr "Bilo koji"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr "Primjeni"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Primjeni šablon"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,19 +606,15 @@ msgstr ""
 msgid "Assign"
 msgstr "Dodijeli"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Dodjeljeno"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Dodijeljeno: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Još uvijek nije dodijeljeno"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr "Auto-uvezi logove"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr "Serija"
 msgid "Batch Book"
 msgstr "Knjiga serije"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID serije"
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Adresa za račun"
@@ -800,7 +845,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr "Poslovni telefon"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -899,23 +944,23 @@ msgstr "Kalibracije"
 msgid "Calibrator"
 msgstr "Kalibrator"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Otkaži"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Otkazano"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr "Izmjene su snimljene"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Izmjene su snimljene"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr "Grad"
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Klijent"
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID klijenta"
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1126,7 +1185,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1135,7 +1194,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID klijenta"
 
@@ -1228,7 +1287,7 @@ msgstr "Komentari"
 msgid "Comments or results interpretation"
 msgstr "Komentari ili interpretacija rezultata"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "Komercijalni ID"
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Potvrdi password"
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kontakt"
@@ -1328,7 +1391,7 @@ msgstr "Kontejneri"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr "Kopiraj iz"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Kopiraj u novi"
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "Država"
 msgid "Create Invoice PDF"
 msgstr "Kreiraj PDF račun"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr "Kreiraj novog korisnika"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Kreator"
 
@@ -1473,7 +1540,7 @@ msgstr "Kreator"
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Valuta"
 
@@ -1481,12 +1548,20 @@ msgstr "Valuta"
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr "Datum izmjene"
 msgid "Date Opened"
 msgstr "Datum otvaranja"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Datum skladištenja"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Datum štampanja"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Datum objavljivanja"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Datum prijema"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Datum registracije"
 
@@ -1562,11 +1637,11 @@ msgstr "Datum zahtjeva"
 msgid "Date Sample Received"
 msgstr "Datum prijema uzorka"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Datum uzorkovanja"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Datum verifikacije"
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr "Deaktiviraj"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr "Standardni kontejner"
 msgid "Default Department"
 msgstr "Standardno odjeljenje"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr "Standardni instrument"
 msgid "Default Method"
 msgstr "Standardni metod"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Standarno čuvanje"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Standardni decimalni znak"
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Standardna vrijednost"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Stepeni"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr "Odjeljenja"
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Opis"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Popust"
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr "Preuzmi PDF"
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Istekli"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Datum isteka"
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Izmjeni"
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Email adresa"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "Email log"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr "Email otkazan"
 msgid "Email notification"
 msgstr "Email notifikacija"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr "Očekivani rezultat"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr "Datum isteka"
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr "Izvezi"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr "Ime"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr "Petak"
 msgid "From"
 msgstr "Od"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Puno ime"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Puno ime"
 
@@ -2471,7 +2600,7 @@ msgstr "Puno ime"
 msgid "Function"
 msgstr "Fukcija"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr "Opasno"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Skriveno"
@@ -2531,8 +2660,20 @@ msgstr "Skriveno polje"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr "Interval"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Poništeno"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr "Račun za"
 msgid "Invoice {} created"
 msgstr "Račun {} kreiran"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr "Lab proizvodi"
 msgid "Lab URL"
 msgstr "Lab URL"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Oznaka"
@@ -3066,7 +3211,7 @@ msgstr "Oznaka"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr "Laboratorija"
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Radni dani"
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Velika naljepnica"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Kasni"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr "Muško"
 msgid "Manage Analyses"
 msgstr "Upravljanje analizama"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Ručno"
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr "Max vrijeme"
 msgid "Max operator"
 msgstr "Max operator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr "Popust za članove"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Popust za članove %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Primjenjuje se popust"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Član registrovan i povezan na postojeći kontakt"
 
@@ -3433,7 +3586,7 @@ msgstr "Član registrovan i povezan na postojeći kontakt"
 msgid "Message sent to {}, "
 msgstr "Poruka poslana za {}"
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr "Min operator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr "Minimum 5 znakova"
 msgid "Minimum Volume"
 msgstr "Minimalni volumen"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr "ul"
 msgid "Monday"
 msgstr "Ponedjeljak"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Multi-verifikacija neophodna"
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Ime"
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3636,6 +3801,10 @@ msgstr ""
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "Nema definisane akcije"
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3683,6 +3852,10 @@ msgstr "Nisu nepravljene izmjene"
 msgid "No changes made."
 msgstr "Nisu napravljene izmjene."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "Nije podešen datum"
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr "Uzorci nisu odbačeni"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Nije podešeno"
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Otvori"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,9 +4104,17 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "Otvorite email formular za slanje izabranih izveštaja primaocima. Ovo će takođe objaviti izvještaje sadržanih uzoraka nakon što se email uspješno pošalje."
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "Primarni uzorak"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr "Štampaj cjenovnik"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Stanje"
 
@@ -4328,7 +4536,7 @@ msgstr "Stanje"
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr "Objavi"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Objavljeno"
@@ -4362,6 +4574,10 @@ msgstr "Datum objavljivanja"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Objavljeni rezultati"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4382,6 +4598,14 @@ msgstr "QC rezultati"
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Primi"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Primljeno"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Primaoci"
 
@@ -4494,11 +4722,15 @@ msgstr "Referentne vrijednosti"
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr "Odbaci analizu"
 msgid "Reject samples"
 msgstr "Odbaci uzorke"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Odbačeni"
 
@@ -4542,7 +4774,7 @@ msgstr "Odbačeni uzorak"
 msgid "Rejected {} samples: {}"
 msgstr "Odbačeni {} uzorci: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr "Ukloni"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr "Ponovo objavi"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "ID zahtjeva"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Unesi zahtjev za nove analize"
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr "Razultati"
 msgid "Results Interpretation"
 msgstr "Interpretacija rezultata"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Rezultati su povučeni"
 
@@ -4772,7 +5029,7 @@ msgstr "Rezultati su povučeni"
 msgid "Results interpretation"
 msgstr "Interpretacija rezultata"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Rezultati se čekaju"
 
@@ -4796,7 +5053,7 @@ msgstr "Retestirano"
 msgid "Retract"
 msgstr "Povuci"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr "Rutinske analize"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr "SENAITE LIMS naslovnica"
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr "SENAITE naslovnica"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Uzorak"
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "Broj uzorka"
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Vrsta uzorka"
@@ -5025,7 +5287,7 @@ msgstr "Vrsta uzorka"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Uzorak uzeo"
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Uzorci"
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Datum uzorka"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr "Subota"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Snimi"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr "Pošalji"
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr ""
 msgid "Service"
 msgstr "Usluga"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "Usluga se ne može isključiti. Kliknite na info dugme za više detalja"
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "Specifikacije"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Stanje"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Status"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr "Pošalji"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr "Poslao"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Cijena bez poreza"
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr "Vrijeme"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Naziv"
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Za Čuvanje"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Za uzimanje uzorka"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Za čuvanje"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "Za štampanje"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Za uzimanje uzorka"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Za verifikaciju"
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Ukupno"
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr "Utorak"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Vrsta"
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Koristi cijenu profila analize"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr "Porez"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "Porez %"
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verificirano"
@@ -6576,11 +6940,19 @@ msgstr "Verificirano"
 msgid "Verified By"
 msgstr "Verificirao"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Verificiraj"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6594,6 +6966,14 @@ msgstr "Pregled"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "Srijeda"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,9 +7088,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr "dani"
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr "minute"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "mjesečno"
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "od"
 
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
+
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ca/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ca/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2024\n"
 "Language-Team: Catalan (https://app.transifex.com/senaite/teams/87045/ca/)\n"
@@ -923,6 +923,11 @@ msgstr "Voleu crear un compte d'usuari?"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
 msgstr "No hi ha cap fitxer"
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
+msgstr ""
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82

--- a/src/senaite/core/locales/ca/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ca/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2024\n"
 "Language-Team: Catalan (https://app.transifex.com/senaite/teams/87045/ca/)\n"

--- a/src/senaite/core/locales/ca/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ca/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Catalan (https://app.transifex.com/senaite/teams/87045/ca/)\n"

--- a/src/senaite/core/locales/ca/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ca/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Catalan (https://app.transifex.com/senaite/teams/87045/ca/)\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ca\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr "<p>El servidor d'Identificadors (ID) de SENAITE LIMS proporciona identificadors seqüencials únics per a recursos com mostres, fulls de treball, etc. en funció del format especificat per a cada tipus de contingut.</p><p>La sintaxi és similar a la que s'utilitza per al formatatge de cadenes amb Python, amb variables predefinides per tipus de contingut. El comodí 'seq',  permet definir el nombre de dígits que cal mantenir en incrementar el valor de l'identificador. Per exemple, utilitzeu 'seq:03d' si voleu que la seqüència d'identificadors sigui entre 001 i 999.</p><p>També podeu utilitzar prefixes. Així, amb el format 'WS-{seq:03d}' es generaran els identificadors seqüencials següents: WS-001, WS-002, WS-003, etc.</p>Amb el comodí '{alpha}' podeu generar identificadors seqüencials alfanumèrics. Per exemple, utilitzeu el format 'WS{alpha:2a3d}' per a generar identificadors tals com aquests: WS-AA001, WS-AA002, WS-AB034, etc.</p><p>També podeu utilitzar qualsevol de les variables següents:<table><tr><th style='width:150px'>Tipus de contingut (Content Type)</th><th>Variables</th></tr><tr><td>Client</td><td>{clientId}</td></tr><tr><td>Any</td><td>{year}</td></tr><tr><td>Identificador de mostra</td><td>{sampleId}</td></tr><tr><td>Tipus de mostra</td><td>{sampleType}</td></tr><tr><td>Data prevista de mostreig</td><td>{samplingDate}</td></tr><tr><td>Data de mostreig</td><td>{dateSampled}</td></tr></table></p><p>Paràmetres de configuració:<ul><li>Format:<ul><li>cadena de text expressada en format Python amb comodins i variables predefinides com 'sampleId', 'clientId' o 'sampleType'.</li><li>Cal que poseu la variable especial 'seq' al final de l'expressió.</li></ul></li><li>Tipus de seqüència:  [Generador; Comptador]</li><li>Context: proporciona el contingut que s'haurà d'utilitzar per al recompte quan el tipus de seqüència indicada sigui 'Comptador'.</li><li>Modalitat de recompte: [Per referència; Per contingut]</li><li>Referència de recompte: el nom de la clau de referència quan la modalitat indicada sigui 'Per referència' o el tipus de contingut a utilitzar per a comptar quan la modalitat indicada sigui 'Per contingut'.</li><li>Prefix: prefix predeterminat si no se'n proporciona cap en el format.</li><li>Nombre de trossos: quantitat de fragments que cal considerar com a part del prefix.</li></ul></p>"
 
@@ -29,6 +29,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} fitxers adjunts, amb una mida total de ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -54,6 +55,7 @@ msgid "%s has no '%s' column."
 msgstr "No existeix la columna «%s» per a %s."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Torna"
@@ -123,6 +125,10 @@ msgstr "*** Aquest correu electrònic ha estat generat automàticament, no el re
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr "Trieu un instrument de mesura..."
@@ -140,7 +146,7 @@ msgstr "Ves a la vista de configuració de plantilles de fulls de treball"
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "Us donem la benvinguda a SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -201,7 +207,7 @@ msgid "Account Type"
 msgstr "Tipus de compte"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr "Comptabilitat"
 
@@ -246,21 +252,21 @@ msgstr "Activa"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Actiu/va"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Actor"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Afegeix"
 
@@ -288,15 +294,19 @@ msgstr "Afegeix un duplicat"
 msgid "Add Samples"
 msgstr "Afegeix mostres"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Afegeix un camp de comentaris per a totes les anàlisis"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "Afegeix regles d'estil CSS personalitzades pel logotip, p. ex. <q>height:15px; width:150px;</q>"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "Afegeix etiquetes seleccionables per defecte"
 
@@ -309,8 +319,11 @@ msgstr "Afegeix un fitxer adjunt nou"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Afegeix un o més fitxers adjunts amb informació addicional sobre la mostra."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Afegeix comentaris"
 
@@ -374,13 +387,21 @@ msgstr "Es mostren totes les anàlisis acreditades."
 msgid "All Analyses of Service"
 msgstr "Totes les anàlisis del servei"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Totes les anàlisis estan assignades"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Permet la introducció manual d'incertesa"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -398,11 +419,11 @@ msgstr "Permet que un mateix usuari pugui verificar més d'una vegada"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Permet que un mateix usuari pugui verificar més d'una vegada, però no consecutivament"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Permet la verificació de resultats al mateix usuari"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -431,15 +452,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Analitzat per"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Anàlisis"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Anàlisis sol·licitades"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -508,7 +545,7 @@ msgstr "Condicions d'anàlisi"
 msgid "Analysis conditions updated: {}"
 msgstr "Condicions d'anàlisi actualitzades: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Marqueu aquesta casella de selecció si voleu que es puguin modificar els rangs de validesa per a cada anàlisi de manera individualitzada i directament des de la vista de mostra."
 
@@ -545,7 +582,7 @@ msgstr "Heu d'indicar un analista."
 msgid "Any"
 msgstr "Cap"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "Aparença"
 
@@ -556,6 +593,10 @@ msgstr "Aplica els canvis"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Aplica plantilla"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -569,19 +610,15 @@ msgstr "Número de lot"
 msgid "Assign"
 msgstr "Assigna"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Assignada"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Assignat a: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Per assignar"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -595,7 +632,7 @@ msgstr "Adjunta a la mostra"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr "Etiquetes assignades al contingut"
 
@@ -683,11 +720,15 @@ msgstr "Generació automàtica d'identificadors per a continguts de tipus Dexter
 msgid "Auto-Import Logs"
 msgstr "Registre d'importacions automàtiques"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "En recepcionar la mostra, genera les alíquotes automàticament"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Recepció automàtica de mostres"
 
@@ -695,15 +736,15 @@ msgstr "Recepció automàtica de mostres"
 msgid "Autofill"
 msgstr "Omple automàticament"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr "Impressió automàtica d'etiquetes de codificació"
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Desconnexió automàtica"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr "Verificació automàtica de mostres"
 
@@ -754,7 +795,7 @@ msgstr "Lot"
 msgid "Batch Book"
 msgstr "Llibre de lots"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Identificador de lot"
 
@@ -784,6 +825,10 @@ msgstr "Tingueu present que els rangs de validesa indicats al full de càlcul ad
 msgid "Bearing"
 msgstr "Retard"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Adreça de facturació"
@@ -804,7 +849,7 @@ msgstr "Marca"
 msgid "Bulk Discount"
 msgstr "Descompte per volum"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Descompte per volum aplicable"
@@ -822,19 +867,19 @@ msgstr "Telèfon del negoci"
 msgid "Business address"
 msgstr "Adreça del negoci"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr "Per valor a mostrar, ascendent"
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr "Per valor a mostrar, descendent"
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr "Per valor, ascendent"
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr "Per valor, descendent"
 
@@ -842,12 +887,12 @@ msgstr "Per valor, descendent"
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "Correus en còpia"
 
@@ -903,23 +948,23 @@ msgstr "Calibratges"
 msgid "Calibrator"
 msgstr "Calibrador"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Podeu verificar l'anàlisi, tot i haver-ne tramès el resultat"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Podeu verificar l'anàlisi, tot i haver-lo verificat abans"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Cancel·la"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Cancel·lada"
 
@@ -939,15 +984,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr "No es pot enviar el correu electrònic per a la mostra ${sample_id}: ${error}"
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "Ja l'heu verificat"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "No podeu verificar l'anàlisi perquè n'heu tramès el resultat"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "Ja l'heu verificat"
 
@@ -973,7 +1018,7 @@ msgstr "Cataloga els continguts de tipus Dexterity en múltiples catàlegs"
 msgid "Catalogue Number"
 msgstr "Número del catàleg"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Agrupa els serveis d'anàlisi en categories"
 
@@ -1005,11 +1050,11 @@ msgid "Changes Saved"
 msgstr "S'han desat els canvis"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "S'han desat els canvis."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Els canvis es propagaran a les alíquotes"
 
@@ -1046,31 +1091,31 @@ msgstr "Casella de selecció"
 msgid "Choices"
 msgstr "Opcions de selecció"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr "Escull la plantilla per defecte per les etiquetes de codificació grans. <br/><strong>Nota: </strong>Les etiquetes grans específiques de cada mostra es configuren segons el tipus de mostra."
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr "Escull la plantilla per defecte per les etiquetes de codificació petites. <br/><strong>Nota: </strong>Les etiquetes petites específiques de cada mostra es configuren segons el tipus de mostra."
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Seleccioneu el tipus de verificació múltiple a aplicar per a un mateix usuari."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr "Escull quan les etiquetes haurien de ser impreses de manera automàtica: <br/><ul><li><strong>Registre:</strong> Les etiquetes són impreses automàticament quan noves mostres són creades. </li><li><strong>Recepció:</strong> Les etiquetes són impreses automàticament quan les mostres són recepcionades. </li><li><strong>Cap:</strong>Desactiva la impressió automàtica d'etiquetes. </li></ul>"
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1083,20 +1128,34 @@ msgstr "Ciutat"
 msgid "Classic"
 msgstr "Clàssic"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "Neteja la selecció"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Feu clic per a desplegar aquesta categoria"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "Feu clic per a canviar-ne la visibilitat o arrossega els elements per a modificar-ne l'ordre"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Client"
@@ -1108,7 +1167,7 @@ msgstr "ID del lot de client"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Identificador del client"
 
@@ -1120,7 +1179,7 @@ msgstr "Pàgina d'entrada del client"
 msgid "Client Name"
 msgstr "Nom del client"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Comanda de client"
 
@@ -1130,7 +1189,7 @@ msgstr "Comanda de client"
 msgid "Client Order Number"
 msgstr "Número de comanda del client"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Referència del client"
 
@@ -1139,7 +1198,7 @@ msgstr "Referència del client"
 msgid "Client Reference"
 msgstr "Referència del client"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Identificador de mostra del client"
 
@@ -1232,7 +1291,7 @@ msgstr "Comentaris"
 msgid "Comments or results interpretation"
 msgstr "Comentaris o interpretació de resultats"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "ID comercial"
@@ -1270,6 +1329,10 @@ msgstr "Configuració de la secció de l'encapçalament de mostra"
 msgid "Configuration restored to default values."
 msgstr "S'ha restablert la configuració als valors per defecte."
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr "Configuració de les columnes de la taula"
@@ -1288,7 +1351,7 @@ msgstr "Confirmeu la paraula de pas"
 msgid "Considerations"
 msgstr "Consideracions"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contacte"
@@ -1332,7 +1395,7 @@ msgstr "Recipients"
 msgid "Contents of the file {}"
 msgstr "Continguts del fitxer {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1365,15 +1428,15 @@ msgstr "Copia serveis d'anàlisi"
 msgid "Copy from"
 msgstr "Còpia de"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr "Copia el valor de la columna actual a les altres columnes de la dreta"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr "Copia el valor de la primera mostra a les altres"
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Fes una còpia"
 
@@ -1383,6 +1446,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1401,11 +1468,11 @@ msgstr "No s'ha pogut executar la transició de les mostres a l'estat de mostrej
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1418,7 +1485,7 @@ msgstr "País"
 msgid "Create Invoice PDF"
 msgstr "Crea factura en PDF"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Crea les alíquotes"
 
@@ -1426,7 +1493,7 @@ msgstr "Crea les alíquotes"
 msgid "Create SENAITE Site"
 msgstr "Crea un lloc SENAITE"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr "Crea un full de treball"
 
@@ -1438,7 +1505,7 @@ msgstr "Crea un nou lloc SENAITE"
 msgid "Create a new User"
 msgstr "Crea un usuari"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr "Crea un full de treball amb les mostres seleccionades"
 
@@ -1468,7 +1535,7 @@ msgid "Created {} partitions: {}"
 msgstr "S'han creat {} alíquotes: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Creat per"
 
@@ -1477,7 +1544,7 @@ msgstr "Creat per"
 msgid "Criteria"
 msgstr "Criteri"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1485,13 +1552,21 @@ msgstr "Moneda"
 msgid "Current"
 msgstr "Disponible"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Caràcter de puntuació decimal personalitzat"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "Límit de Detecció"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1538,23 +1613,23 @@ msgstr "Data de modificació"
 msgid "Date Opened"
 msgstr "Data d'obertura"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Data de conservació"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Data d'impressió"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Data de publicació"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Data de recepció"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Data de registre"
 
@@ -1566,11 +1641,11 @@ msgstr "Data de sol·licitud"
 msgid "Date Sample Received"
 msgstr "Data de recepció"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Data de mostreig"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Data de verificació"
 
@@ -1612,7 +1687,7 @@ msgstr "Data d'expedició del certificat de calibratge"
 msgid "Date when the certificate is valid"
 msgstr "Data d'inici de validesa del certificat de calibratge"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1635,11 +1710,11 @@ msgstr "Desactiva l'instrument de mesura fins al pròxim test intern de calibrat
 msgid "Deactivate"
 msgstr "Desactiva"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Caràcter de puntuació decimal que cal utilitzar en els informes de resultats per aquest client."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1651,7 +1726,7 @@ msgstr "Recipient per defecte"
 msgid "Default Department"
 msgstr "Departament predeterminat"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Introduïu els correus electrònics que voleu que s'afegeixin en còpia quan s'enviïn informes de resultats d'anàlisi de mostres que pertanyin a aquest client."
 
@@ -1663,7 +1738,7 @@ msgstr "Instrument de mesura predeterminat"
 msgid "Default Method"
 msgstr "Mètode predeterminat"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr "Nombre de còpies per defecte"
 
@@ -1671,20 +1746,20 @@ msgstr "Nombre de còpies per defecte"
 msgid "Default Preservation"
 msgstr "Mètode de conservació predeterminat"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr "Plantilla predeterminada d’etiquetes de codificació"
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Nombre de mostres a crear de manera predeterminada."
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Caràcter de puntuació decimal predeterminat"
 
@@ -1696,7 +1771,7 @@ msgstr "Instrument de mesura predeterminat per a anàlisis d'aquest tipus"
 msgid "Default large sticker"
 msgstr "Etiqueta de codificació gran per defecte"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Disposició predeterminada dels fulls de treball"
 
@@ -1728,15 +1803,15 @@ msgstr "Heu de seleccionar un resultat predeterminat de les opcions següents: {
 msgid "Default result to display on result entry"
 msgstr "El resultat a mostrar per defecte a la vista d'entrada de resultats"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Període de retenció predeterminat de la mostra"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Notació científica predeterminada en els informes de resultats"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Notació científica predeterminada per a resultats"
 
@@ -1748,7 +1823,7 @@ msgstr "Etiqueta de codificació petita per defecte"
 msgid "Default timezone"
 msgstr "Zona horària predeterminada"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Temps necessari i predeterminat per a completar el processament de les anàlisis."
 
@@ -1757,7 +1832,7 @@ msgstr "Temps necessari i predeterminat per a completar el processament de les a
 msgid "Default value"
 msgstr "Valor predeterminat"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "Nombre predeterminat de mostres (columnes) a la pàgina de registre de mostra."
 
@@ -1781,7 +1856,7 @@ msgstr "Precisió a partir de la qual s'ha d'utilitzar la notació exponencial. 
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Persona que efectuarà el mostreig en la data programada"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1793,8 +1868,17 @@ msgstr "Etiquetes de codificació predeterminades per aquest tipus de mostra."
 msgid "Degrees"
 msgstr "Graus"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1823,9 +1907,9 @@ msgstr "Departaments"
 msgid "Dependent Analyses"
 msgstr "Anàlisis dependents"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Descripció"
 
@@ -1872,7 +1956,11 @@ msgstr "Desactiva la consulta automàtica de transicions"
 msgid "Disable multi-verification for the same user"
 msgstr "No permetis la verificació múltiple per part d'un mateix usuari"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Descompte"
@@ -1890,7 +1978,7 @@ msgstr "Envia"
 msgid "Dispatch samples"
 msgstr "Enviament de mostres"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Enviada"
@@ -1915,15 +2003,23 @@ msgstr "El text a mostrar ha de ser únic"
 msgid "Display a Detection Limit selector"
 msgstr "Mostra un selector per al límit de detecció"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr "Mostra les alíquotes als clients"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Elimina"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminada"
 
@@ -1993,11 +2089,15 @@ msgstr "Descarrega PDF"
 msgid "Download selected reports"
 msgstr "Descarrega els informes seleccionats"
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Pendents"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Data de venciment"
@@ -2014,7 +2114,7 @@ msgstr "Duplicat"
 msgid "Duplicate Analysis"
 msgstr "Anàlisi duplicada"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2062,6 +2162,7 @@ msgstr "P. ex. ENAC, Applus+, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "Per a cada interfície d'importació pot definir un directori concret on el sistema busqui, de manera automàtica, fitxers amb resultats a ser importats en executar la vista <code>auto_import_results</code>."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Edita"
@@ -2076,21 +2177,21 @@ msgstr "Elevació"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Correu electrònic"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Adreça de correu electrònic"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2098,27 +2199,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "Registre de correu electrònic"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "Cos del missatge de correu electrònic que s'envia automàticament en invalidar una mostra i els seus resultats"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr "Cos del missatge de correu electrònic que s'envia automàticament en rebutjar una mostra"
 
@@ -2131,17 +2232,21 @@ msgstr "S'ha cancel·lat el correu electrònic"
 msgid "Email notification"
 msgstr "Notificació per correu electrònic"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "En rebutjar mostres, notifica automàticament mitjançant un correu electrònic"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
 msgstr "S'ha enviat el correu electrònic"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2151,27 +2256,27 @@ msgstr "Introduïu un valor per a les claus"
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Habilita el suport per a múltiples instruments de mesura en fulls de treball."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Habilita la funcionalitat de conservació de mostres"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "Habilita la funcionalitat de rangs de validesa específics de mostra"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "Habilita la funcionalitat de recol·lecció de mostres"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "Habilita la funcionalitat de planificació periòdica de recol·lecció de mostres"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr "Habilita el registre general d'auditoria"
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr "Habilita el registre general d'auditoria"
 
@@ -2179,9 +2284,17 @@ msgstr "Habilita el registre general d'auditoria"
 msgid "Enable sampling workflow for the created sample"
 msgstr "Habilita la funcionalitat de recol·lecció per a la mostra enregistrada en el sistema"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "Habilita la funcionalitat de seguiment i impressió d'informes de resultats"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2204,7 +2317,7 @@ msgstr "Introduïu una adreça de correu electrònic. Això és necessari en cas
 msgid "Enter discount percentage value"
 msgstr "Introduïu el percentatge de descompte"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr "Introdueix valors individuals en aquest camp per a cada mostra"
 
@@ -2217,7 +2330,7 @@ msgstr "Introduïu un percentatge, p. ex. 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Introduïu un valor de percentatge, p. ex. 14.0. Aquest percentatge només s'aplicarà a aquest perfil d'anàlisi, sobreescrivint el valor per defecte del sistema."
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Introduïu un percentatge, p. ex. 14.0. Aquest percentatge s'aplicarà a tot el sistema, però el podreu sobreescriure individualment a cada element."
 
@@ -2241,7 +2354,7 @@ msgstr "Introduïu els detalls de cada una de les anàlisis que desitgeu copiar.
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Introduïu la informació relativa a les acreditacions del laboratori. Podeu utilitzar qualsevol de les màscares següents: <code>lab_is_accredited</code>, <code>lab_name</code>, <code>lab_country</code>, <code>confidence</code>, <code>accreditation_body_name</code>, <code>accreditation_standard</code>, <code>accreditation_reference</code><br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr "Introduïu el resultat en format decimal o en notació científica, per exemple 0.00005 o 1e-5, 10000 o 1e5"
 
@@ -2253,15 +2366,15 @@ msgstr "Condicions ambientals"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr "La publicació de resultats ha finalitzat amb error: ${sample_id}"
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Evolució de les anàlisis"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Evolució de les mostres"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Evolució dels fulls de treball"
 
@@ -2273,7 +2386,7 @@ msgstr "Exemple de cronjob per a l'execució de la importació automàtica de re
 msgid "Example content"
 msgstr "Contingut d'exemple"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "No facturable"
 
@@ -2283,7 +2396,7 @@ msgstr "No facturable"
 msgid "Expected Result"
 msgstr "Resultat esperat"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Data estimada de mostreig"
 
@@ -2309,7 +2422,7 @@ msgstr "Data de caducitat"
 msgid "Exponential format precision"
 msgstr "Precisió en notació exponencial"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Llindar en notació exponencial"
 
@@ -2317,7 +2430,7 @@ msgstr "Llindar en notació exponencial"
 msgid "Export"
 msgstr "Exporta"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "No s'ha pogut carregar l'etiqueta de codificació"
 
@@ -2404,7 +2517,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "Mida del fitxer"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr "Filtra els anàlisis pel nom..."
 
@@ -2418,6 +2531,18 @@ msgstr "Filtra pels serveis de la plantilla"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2434,11 +2559,11 @@ msgstr "Nom"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Introduïu un valor numèric entre 0.0 i 1000.0 per a indicar l'ordre dels elements. Els elements duplicats s'ordenaran alfabèticament."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Format dels identificadors"
 
@@ -2461,13 +2586,17 @@ msgstr "Divendres"
 msgid "From"
 msgstr "Des de"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Nom complet"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Nom complet"
 
@@ -2475,7 +2604,7 @@ msgstr "Nom complet"
 msgid "Function"
 msgstr "Funció"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "El mostreig s'ha planificat per a més endavant"
 
@@ -2508,7 +2637,7 @@ msgstr "Ves a la instància"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Títol de cortesia, com p. ex. Sr., Sra. o Dr."
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Podeu agrupar els serveis d'anàlisi en categories des de la pàgina de configuració del LIMS. Això és útil quan la llista de serveis d'anàlisi és massa llarga"
 
@@ -2522,7 +2651,7 @@ msgid "Hazardous"
 msgstr "Perillós"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Ocult"
@@ -2535,8 +2664,20 @@ msgstr "Camp ocult"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2560,7 +2701,7 @@ msgstr "IBAN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2568,7 +2709,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr "Valors del servidor d'identificadors"
 
@@ -2588,15 +2729,15 @@ msgstr "Marqueu aquesta casella de selecció si voleu que es mostri una llista d
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Marqueu aquesta casella de selecció si voleu que l'instrument de mesura no estigui disponible fins que s'hagi realitzat un calibratge amb èxit."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Marqueu aquesta casella de selecció si voleu que es mostri un camp de text per a la introducció de comentaris al costat de cada anàlisi."
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Marqueu aquesta casella de selecció si voleu que l'usuari que ha tramès un resultat, també pugui verificar-lo. Aquest paràmetre de configuració només és aplicable a usuaris que tenen el rol de verificador assignat. Aquest rol el tenen garantit per defecte els usuaris que pertanyen ja sigui al grup de responsables de laboratori o al grup de verificadors. Aquest paràmetre de configuració té prioritat sobre el valor indicat a la configuració general."
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Marqueu aquesta casella de selecció si voleu que l'usuari que ha tramès un resultat, també pugui verificar-lo. Aquest paràmetre de configuració només és aplicable a usuaris que tenen el rol de verificador assignat. Aquest rol el tenen garantit per defecte els usuaris que pertanyen ja sigui al grup de responsables de laboratori o al grup de verificadors. Podeu sobreescriure aquest paràmetre de configuració en l'àmbit de servei d'anàlisi."
 
@@ -2604,7 +2745,7 @@ msgstr "Marqueu aquesta casella de selecció si voleu que l'usuari que ha tramè
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Marqueu aquesta casella de selecció si voleu que el nom de l'anàlisi es mostri en cursiva a l'informe de resultats i a les llistes d'anàlisis."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "Marqueu aquesta casella de selecció si voleu que aquesta anàlisi no es mostri als informes de resultats. Podeu sobreescriure aquest paràmetre de configuració a la vista de perfil d'anàlisi o de mostra."
 
@@ -2644,7 +2785,7 @@ msgstr "Marqueu aquesta casella de selecció si voleu que els usuaris que pertan
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "Afegiu els mòduls Python externs addicionals que vulgueu utilitzar en la fórmula. Per exemple, si voleu utilitzar la funció 'floor' del mòdul 'math' de Python, afegiu el mòdul 'math' al camp \"Mòdul\" i 'floor' al camp \"Funció\". (l'equivalent en Python seria 'from math import floor'). D'aquesta manera podreu utilitzar, per exemple, l'expressió 'floor([Ca] + [Mg])'."
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr "Entrada immediata de resultats"
 
@@ -2675,11 +2816,11 @@ msgstr "Procediment de calibratge intern"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Inactius"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Mostra els preus"
 
@@ -2876,7 +3017,7 @@ msgid "Internal Certificate"
 msgstr "Certificat intern"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "Ús intern"
 
@@ -2897,13 +3038,13 @@ msgstr "Plantilles d'interpretació de resultats"
 msgid "Interval"
 msgstr "Interval"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "No vàlides"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2966,15 +3107,15 @@ msgstr "Client"
 msgid "Invoice {} created"
 msgstr "S'ha creat la factura {}"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "No heu indicat la data de finalització de l'InvoiceBatch"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "No heu indicat la data d'inici de l'InvoiceBatch"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "No heu indicat el títol de l'InvoiceBatch"
 
@@ -2986,7 +3127,7 @@ msgstr "Càrrec"
 msgid "Job title"
 msgstr "Càrrec"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr "Manté el mateix ordre de dalt"
 
@@ -2998,9 +3139,9 @@ msgstr "Clau"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Paraula clau"
 
@@ -3016,6 +3157,10 @@ msgstr "Heu d'establir una paraula clau de l'anàlisi."
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Paraules clau"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3060,8 +3205,8 @@ msgstr "Productes del laboratori"
 msgid "Lab URL"
 msgstr "URL del laboratori"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Etiqueta"
@@ -3070,7 +3215,7 @@ msgstr "Etiqueta"
 msgid "Label configuration"
 msgstr "Gestió d'etiquetes"
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr "Els noms de les etiquetes han de ser únics"
 
@@ -3078,13 +3223,13 @@ msgstr "Els noms de les etiquetes han de ser únics"
 msgid "Label schema extender"
 msgstr "Extensor d'etiquetes"
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr "Continguts etiquetats"
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr "Etiquetes"
 
@@ -3097,7 +3242,7 @@ msgstr "Laboratori"
 msgid "Laboratory Accredited"
 msgstr "Laboratori acreditat"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Dies laborables"
 
@@ -3109,7 +3254,7 @@ msgstr "Idioma"
 msgid "Large Sticker"
 msgstr "Etiqueta de codificació gran"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr "Plantilla d’etiqueta de codificació gran"
 
@@ -3121,11 +3266,11 @@ msgstr "Últim registre d'importacions automàtiques"
 msgid "Last Login Time"
 msgstr "Data i hora d'últim accés"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Amb retard"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Anàlisis amb retard"
 
@@ -3171,15 +3316,15 @@ msgstr "Usuari vinculat"
 msgid "Link an existing User"
 msgstr "Vincula amb un usuari existent"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr "Mostra la llista d'objectes amb etiquetes"
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr "Ompliu la llista amb els resultats admesos per aquesta anàlisi que voleu que es mostrin en una llista desplegable durant l'entrada de resultats."
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3203,7 +3348,7 @@ msgstr "Utilitzeu aquest camp per a pujar i guardar el fitxer que conté el cert
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3231,6 +3376,14 @@ msgstr "Tipus d'ubicació"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Ubicació on està emmagatzemat el conjunt de documents"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3294,7 +3447,7 @@ msgstr "Home"
 msgid "Manage Analyses"
 msgstr "Gestió d'anàlisis"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "Gestiona els camps del formulari"
 
@@ -3318,7 +3471,7 @@ msgstr "Gestiona els camps de la mostra"
 msgid "Manage linked User"
 msgstr "Gestiona l'usuari vinculat"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3342,7 +3495,7 @@ msgstr "Correu electrònic del responsable"
 msgid "Manager Phone"
 msgstr "Telèfon del responsable"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Manual"
 
@@ -3371,7 +3524,7 @@ msgstr "Fabricant"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "Marqueu aquesta casella de selecció si voleu que la mostra s'utilitzi només per a ús intern, que només hi pugui accedir el personal del laboratori."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3386,7 +3539,7 @@ msgstr "Temps màxim"
 msgid "Max operator"
 msgstr "Operador màx."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3421,15 +3574,15 @@ msgid "Member Discount"
 msgstr "Descompte per a soci"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "% de descompte per a clients habituals"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Aplicar descompte de client habitual"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "S'ha registrat i vinculat l'usuari al contacte."
 
@@ -3437,7 +3590,7 @@ msgstr "S'ha registrat i vinculat l'usuari al contacte."
 msgid "Message sent to {}, "
 msgstr "El missatge s'ha enviat a {},"
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3468,7 +3621,7 @@ msgstr "Inicials"
 msgid "Middle name"
 msgstr "Mig"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3479,7 +3632,7 @@ msgstr "Mín."
 msgid "Min operator"
 msgstr "Operador mín."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3497,7 +3650,7 @@ msgstr "Mida mínima de 5 caràcters."
 msgid "Minimum Volume"
 msgstr "Volum mínim"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Nombre mínim de resultats per als càlculs estadístics de QC"
 
@@ -3528,6 +3681,10 @@ msgstr "Mòdul"
 msgid "Monday"
 msgstr "dilluns"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3541,11 +3698,11 @@ msgstr "Comportament que permet la indexació de continguts de tipus Dexterity a
 msgid "Multi Results"
 msgstr "Multiresultats"
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "Tipus de verificació múltiple"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Es necessita verificació múltiple"
 
@@ -3581,13 +3738,17 @@ msgstr "La meva organització"
 msgid "My Profile"
 msgstr "El meu perfil"
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nom"
 
@@ -3598,6 +3759,10 @@ msgstr ""
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
 msgstr "Els nous rangs de validesa no s'aplicaran ni a les anàlisis actuals de la mostra ni a les que s'hi afegeixin més endavant. Reassigna l’especificació d’anàlisis a la mostra si vols aplicar els canvis més recents.."
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
@@ -3640,6 +3805,10 @@ msgstr "Sense subgrup"
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "No s'ha indicat cap acció."
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3687,6 +3856,10 @@ msgstr "Sense canvis."
 msgid "No changes made."
 msgstr "Sense canvis."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "No heu indicat la data"
@@ -3731,6 +3904,16 @@ msgstr "No heu seleccionat cap element"
 msgid "No items selected."
 msgstr "No heu seleccionat cap element."
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "No s'ha creat cap servei d'anàlisi."
@@ -3738,6 +3921,10 @@ msgstr "No s'ha creat cap servei d'anàlisi."
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "No s'ha creat cap alíquota"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3754,6 +3941,10 @@ msgstr "No s'ha rebutjat cap mostra"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Envia al laboratori"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3781,7 +3972,7 @@ msgstr "Aquesta mostra no té anàlisis visibles"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Cap"
 
@@ -3797,11 +3988,11 @@ msgstr "No teniu permís per a modificar les condicions: {}"
 msgid "Not defined"
 msgstr "Cap"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Cap"
@@ -3822,7 +4013,7 @@ msgstr "Important: els canvis que feu aquí s'aplicaran de forma global a totes 
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "Arrossegueu i deixeu anar els fitxers adjunts per a canviar-ne l'ordre en l'informe de resultats."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr "Notificacions"
 
@@ -3834,7 +4025,7 @@ msgstr "Nombre de columnes"
 msgid "Number"
 msgstr "Número"
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Nombre d'anàlisis"
 
@@ -3850,16 +4041,16 @@ msgstr "Nombre de còpies"
 msgid "Number of prominent columns"
 msgstr "Nombre de columnes destacades"
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Nombre de verificacions necessàries"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Indiqueu el nombre de verificacions necessàries abans que el sistema pugui considerar el resultat com a totalment verificat. Podeu sobreescriure aquest paràmetre de configuració en l'àmbit de servei d'anàlisi. El valor per defecte és 1."
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Indiqueu el nombre de verificacions de diferents usuaris amb privilegis adients que seran necessàries abans que el resultat de l'anàlisi es pugui considerar com a 'verificat'. Aquest paràmetre de configuració té prioritat sobre el valor que hàgiu configurat a la vista de configuració general."
 
@@ -3870,6 +4061,10 @@ msgstr "Nombre de columnes estàndard"
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
 msgstr "Numeric"
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
+msgstr ""
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -3887,11 +4082,11 @@ msgstr "Marqueu aquesta casella de selecció si voleu que el fitxer d'imatge s'e
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr "Només es mostren els instruments de mesura que tenen configurada, com a mínim, una interfície d'importació"
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "Només els dies laborables del laboratori es tenen en compte per calcular el temps màxim de resposta."
 
@@ -3899,13 +4094,13 @@ msgstr "Només els dies laborables del laboratori es tenen en compte per calcula
 msgid "Only to empty or zero fields"
 msgstr "Només per camps amb un valor buit o zero"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "En actiu"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr "En curs / Per verificar / Verificades / Total"
 
@@ -3913,9 +4108,17 @@ msgstr "En curs / Per verificar / Verificades / Total"
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Un Sistema de Gestió d'Informació de Laboratori web i de codi obert"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "Obre el formulari per a enviar per correu electrònic els informes que heu seleccionat. Aquesta acció també farà que, una vegada s'hagin enviat els correus electrònics, el sistema també canviï l'estat de les mostres corresponents a l'estat \"publicada\"."
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3942,7 +4145,7 @@ msgstr "Altres motius"
 msgid "Other reasons:"
 msgstr "Altres raons:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Altres estats"
 
@@ -3964,11 +4167,11 @@ msgstr "Substitueix resultats existents"
 msgid "Override non-empty analysis results, also with empty"
 msgstr "Substitueix resultats existents, fins i tot els buits"
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4065,11 +4268,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Seleccioneu un usuari de la llista"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4082,6 +4285,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr "Seleccioneu el nombre d'alíquotes que voleu crear i premeu el botó \"Previsualitza\""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr "Motiu de l'enviament"
 
@@ -4101,12 +4305,16 @@ msgstr "Utilitzeu el format següent per a les opcions de selecció: clau1:valor
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr "Indiqueu on han de ser enviades les mostres"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Punt de mostreig"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4145,31 +4353,31 @@ msgstr "Precisió en nombre de decimals"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Marqueu aquesta casella de selecció si voleu que la precisió com a nombre de dígits significatius es calculi automàticament d'acord amb el valor de la incertesa. La posició decimal es calcularà com el primer dígit diferent de zero del valor de la incertesa, que indicarà la posició a la qual s'efectuarà l'arrodoniment de tant la incertesa com del resultat. Per exemple, per a un resultat de 5.243 i una incertesa de 0.22, el sistema mostrarà 5.2 ± 0.2. El sistema utilitzarà el valor del paràmetre de configuració de precisió fixa si el resultat de l'anàlisi no cau dins de cap dels rangs d'incertesa definits."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr "Resultats predefinits"
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Punt decimal preferit per als resultats en els informes"
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Punt decimal preferit per als resultats"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "Estructura preferida de la taula de resultats a la vista Fulla de treball. El disseny Clàssic distribueix les mostres en les files i les anàlisis en les columnes. El disseny Transposat posa les mostres en les columnes i les anàlisis en les files."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Notació científica preferida per a resultats en els informes"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Notació científica preferida per als resultats"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4202,7 +4410,7 @@ msgstr "Conservació per tipus de mostra"
 msgid "Preserve"
 msgstr "Conserva"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Conservador"
 
@@ -4219,11 +4427,11 @@ msgstr "Preventiu"
 msgid "Preventive maintenance procedure"
 msgstr "Procediment de manteniment preventiu"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "Previsualitza"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4251,7 +4459,7 @@ msgstr "Llista de preus"
 msgid "Pricelists"
 msgstr "Llistes de preus"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4260,7 +4468,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "Mostra primària"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4282,11 +4490,11 @@ msgstr "Data d'impressió:"
 msgid "Print pricelist"
 msgstr "Imprimeix la llista de preus"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Imprimeix les etiquetes de codificació"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Impreses"
 
@@ -4299,7 +4507,7 @@ msgstr "Imprès el"
 msgid "Priority"
 msgstr "Prioritat"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Perfil"
 
@@ -4323,7 +4531,7 @@ msgstr "Nom del perfil"
 msgid "Profile keyword must be unique"
 msgstr "La paraula clau del perfil d'anàlisi ha de ser única."
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Progrés"
 
@@ -4332,7 +4540,7 @@ msgstr "Progrés"
 msgid "Prominent fields"
 msgstr "Camps destacats"
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "Identificador del protocol"
 
@@ -4340,7 +4548,7 @@ msgstr "Identificador del protocol"
 msgid "Province"
 msgstr "Província"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4349,8 +4557,12 @@ msgstr ""
 msgid "Publish"
 msgstr "Publica"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Publicada"
@@ -4366,6 +4578,10 @@ msgstr "Data de publicació"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Resultats publicats"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4386,6 +4602,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4412,7 +4636,7 @@ msgstr "Torneu a introduir la contrasenya i asseguri's que ambdues contrasenyes 
 msgid "Reasons for rejection"
 msgstr "Motius per al rebuig de mostres"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Reassigna"
 
@@ -4424,30 +4648,34 @@ msgstr "Posició buida"
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Recepciona"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Recepcionada"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Per recepcionar"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Destinataris"
 
@@ -4498,11 +4726,15 @@ msgstr "Valors de referència"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Marqueu aquesta casella de selecció si voleu que els resultats esperats de les anàlisis per a mostres de referència d'aquest tipus hagin de ser zero o valor buit."
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registre"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4528,9 +4760,9 @@ msgstr "Anàlisi rebutjada"
 msgid "Reject samples"
 msgstr "Rebuig de mostres"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Rebutjada"
 
@@ -4546,7 +4778,7 @@ msgstr "Mostra rebutjada"
 msgid "Rejected {} samples: {}"
 msgstr "S'han rebutjat {} mostres: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4607,8 +4839,16 @@ msgstr "IP remota"
 msgid "Remove"
 msgstr "Elimina"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4644,11 +4884,11 @@ msgstr "Identificador de l'informe"
 msgid "Report identification number"
 msgstr "Número d'identificació de l'informe"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4660,7 +4900,7 @@ msgstr ""
 msgid "Republish"
 msgstr "Torna a publicar"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "La mostra s'ha publicat de nou després de l'última impressió"
 
@@ -4669,7 +4909,7 @@ msgstr "La mostra s'ha publicat de nou després de l'última impressió"
 msgid "Request ID"
 msgstr "ID de la sol·licitud"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Sol·licita noves anàlisis"
 
@@ -4685,24 +4925,37 @@ msgstr "Volum necessari"
 msgid "Reset"
 msgstr "Reinicialitza"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr "Reinicialitza les columnes"
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
 msgstr "Responsables"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr "Recupera"
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4727,15 +4980,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr "El valor ha de ser únic"
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "El resultat està fora de rang"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4743,7 +4996,7 @@ msgstr ""
 msgid "Result type"
 msgstr "Tipus de resultat"
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4759,16 +5012,20 @@ msgstr "Resultats"
 msgid "Results Interpretation"
 msgstr "Interpretació de resultats"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Els resultats s'han anul·lat"
 
@@ -4776,7 +5033,7 @@ msgstr "Els resultats s'han anul·lat"
 msgid "Results interpretation"
 msgstr "Interpretació de resultats"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Sense resultat"
 
@@ -4800,7 +5057,7 @@ msgstr "Prova repetida"
 msgid "Retract"
 msgstr "Refés"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4836,6 +5093,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr "SENAITE CORE"
@@ -4861,6 +5122,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4870,7 +5132,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr "Pàgina inicial"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4884,7 +5146,7 @@ msgstr "Tractament"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Mostreja"
 
@@ -4921,7 +5183,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "Identificador de mostra"
 
@@ -4941,7 +5203,7 @@ msgstr "Categoria del tipus de mostra"
 msgid "Sample Partitions"
 msgstr "Particions de mostres"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4968,7 +5230,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Tipus de mostra"
@@ -5029,7 +5291,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Mostrejador"
 
@@ -5041,8 +5303,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Mostres"
@@ -5059,6 +5321,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5068,7 +5342,23 @@ msgstr "Aquest tipus de mostres són perilloses"
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5076,7 +5366,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Data de mostreig"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Variació en el mostreig"
@@ -5089,7 +5379,7 @@ msgstr "Orígens de mostreig"
 msgid "Sampling Frequency"
 msgstr "Freqüència de mostreig"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "Mostreig planificat"
 
@@ -5097,14 +5387,23 @@ msgstr "Mostreig planificat"
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Desa"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5119,7 +5418,7 @@ msgstr "Programació"
 msgid "Schedule sampling"
 msgstr "Planifica el mostreig"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5136,6 +5435,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5144,7 +5447,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Segons"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5234,11 +5537,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Seleccioneu una plantilla"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Seleccioneu el país que voleu que es mostri per defecte"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Seleccioneu la moneda que s'ha de mostrar en els preus."
 
@@ -5250,11 +5553,11 @@ msgstr "Seleccioneu el contenidor per defecte que cal utilitzar per a poder efec
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Seleccioneu la pàgina de destinació principal per als contactes de client."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5262,31 +5565,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr "Seleccioneu els tipus de contingut per als quals voleu que s'utilitzi aquest identificador."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "Marqueu aquesta casella de selecció si voleu que en rebutjar una mostra, el sistema enviï automàticament una notificació per correu electrònic al contacte del client."
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "Marqueu aquesta casella de selecció si voleu que la pàgina de destinació principal sigui el tauler."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Marqueu la casella de selecció si voleu habilitar la funcionalitat de recol·lecció de mostres."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Marqueu aquesta casella de selecció si voleu que els usuaris amb el rol \"Responsable de mostreig\" puguin planificar la recol·lecció de mostres."
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr "Marqueu aquesta casella de selecció si voleu que l'usuari pugui marcar les mostres com a impreses després d'haver estat publicades."
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "Marqueu aquesta casella de selecció si voleu que el sistema recepcioni automàticament les mostres creades per personal intern del laboratori si la funcionalitat de \"Recol·lecció de mostres\" no està activada. Tingueu en compte que encara que aquesta casella de selecció estigui marcada, les mostres que hagin estat registrades per usuaris vinculats a client mai seran recepcionades automàticament."
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr "Marqueu aquesta casella de selecció si voleu que es mostrin les alíquotes als usuaris vinculats a clients. En cas contrari, no se'ls hi mostraran ni les alíquotes ni tampoc els vincles a mostres primàries."
 
@@ -5298,7 +5609,7 @@ msgstr "Seleccioneu quines anàlisis voleu que s'afegeixin automàticament al fu
 msgid "Selection list"
 msgstr "Llista de selecció"
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5310,11 +5621,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5336,7 +5647,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Contenidor separat"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5350,7 +5661,7 @@ msgstr "Núm. de sèrie"
 msgid "Service"
 msgstr "Servei"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "No es pot desseleccionar el servei d'anàlisi. Premeu el botó d'informació per a més detalls."
 
@@ -5378,7 +5689,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr "Tanca la tasca de manteniment"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr "Text per defecte del cos del correu electrònic que s'enviarà al contacte de la mostra quan el paràmetre de configuració 'Notificació per correu electrònic en rebutjar la mostra' estigui habilitat. Variables de substitució admeses: $sample_id (identificador de la mostra), $sample_link (enllaç URL a la mostra), $reasons (motius de rebuig), $lab_address (adreça del laborarotori)."
 
@@ -5426,28 +5737,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr "Mostra'n més"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5470,11 +5793,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5495,7 +5818,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Etiqueta de codificació petita"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5511,6 +5834,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5537,7 +5868,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "Especificacions"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5545,7 +5876,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5562,17 +5893,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Estat"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Estat"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Etiqueta de codificació"
@@ -5581,7 +5912,11 @@ msgstr "Etiqueta de codificació"
 msgid "Stickers preview"
 msgstr "Previsualitza les etiquetes de codificació"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Ubicació d'emmagatzematge"
@@ -5621,7 +5956,11 @@ msgstr "Tramet"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5629,7 +5968,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotal"
@@ -5671,7 +6010,7 @@ msgstr "Commuta a la consola del sistema"
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5697,7 +6036,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descripció tècnica i instruccions pels analistes"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5779,7 +6118,7 @@ msgstr "Indiqueu la data quan es va conservar de la mostra."
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Marqueu aquesta casella de selecció si voleu utilitzar el símbol de separació decimal de la configuració general."
 
@@ -5787,7 +6126,7 @@ msgstr "Marqueu aquesta casella de selecció si voleu utilitzar el símbol de se
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr "La configuració del fus horari per defecte del portal. Els usuaris poden configurar un fus horari propi si definiu altres fusos horaris a la configuració de data i hora."
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "Aquest percentatge de descompte només s'aplicarà als clients que estiguin etiquetats com a 'clients habituals'."
 
@@ -5815,7 +6154,11 @@ msgstr "D'aquesta mostra s'han creat les alíquotes següents:"
 msgid "The following sample(s) will be dispatched"
 msgstr "Les mostres següents seran enviades"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr "Marqueu aquesta casella de selecció si voleu habilitar el registre general d'auditoria i així poder visualitzar les modificacions efectuades en qualsevol contingut des d'una única vista general. Tingueu en compte que l'activació d'aquest paràmetre de configuració farà que tots els continguts s'hagin d'indexar en un catàleg addicional, de manera que el sistema serà més lent en crear continguts o modificar-ne d'existents."
 
@@ -5823,11 +6166,11 @@ msgstr "Marqueu aquesta casella de selecció si voleu habilitar el registre gene
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Alçada o profunditat de mostreig"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5864,11 +6207,11 @@ msgstr "Volum mínim de mostra necessari per a efectuar l'anàlisi (per exemple,
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "El nombre de dies abans que caduqui la mostra, sense que pugui ser posteriorment analitzada. Aquesta propietat es pot sobreescriure individualment per a cada tipus de mostra a la pàgina de configuració de tipus de mostres."
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Introduïu la durada màxima en minuts que una sessió d'usuari pot romandre inactiva abans que el sistema n'efectuï la desconnexió de manera automàtica. Introduïu el valor '0' si desitgeu desactivar la desconnexió automàtica de sessions d'usuari inactives."
 
@@ -5908,7 +6251,7 @@ msgstr "Codi de referència que l'entitat d'acreditació ha concedit al laborato
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5932,11 +6275,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Número de sèrie que identifica unívocament l'instrument de mesura"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5988,11 +6331,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr "Aquesta mostra és una alíquota que s'ha desvinculat de la mostra primària"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6016,11 +6359,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6052,8 +6395,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Els documents adjunts només s'importaran si existeixen al servidor on s'allotja la instància."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Títol"
@@ -6080,34 +6423,42 @@ msgstr ""
 msgid "To"
 msgstr "Fins"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Per conservar"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Per mostrejar"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Per conservar"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "Per imprimir"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Per mostrejar"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Per verificar"
@@ -6120,7 +6471,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6142,7 +6493,7 @@ msgid "Tuesday"
 msgstr "dimarts"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Tipus"
@@ -6167,6 +6518,10 @@ msgstr "Tipus de recipient"
 msgid "Type to filter ..."
 msgstr "Cerca per ..."
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6175,7 +6530,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6187,6 +6542,7 @@ msgstr "No s'ha pogut carregar la plantilla"
 msgid "Unassign"
 msgstr "Desassigna"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Per assignar"
@@ -6219,8 +6575,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6237,13 +6597,17 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr "No es pot reconèixer el format del fitxer: ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "Sense assignar"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Actualitza els fitxers adjunts"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6253,7 +6617,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Utilitzeu aquest camp per a pujar un fitxer d'imatge amb la signatura digitalitzada del contacte. Aquesta imatge s'encastarà en els informes de resultats quan el contacte sigui cap de departament, hagi intervingut en la verificació o publicació de la mostra o d'algun dels resultats. Les dimensions recomanades són 250 x 150 píxels."
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6261,7 +6625,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Utilitza el preu del perfil d'anàlisis"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6299,7 +6663,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "Usuari vinculat al contacte"
 
@@ -6307,15 +6671,15 @@ msgstr "Usuari vinculat al contacte"
 msgid "User name"
 msgstr "Nom d'usuari"
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Tingueu present que l'ús d'un nombre baix de punts de dades pot fer que els resultats del càlcul estadístic no siguin representatius. Introduïu el nombre mínim de resultats necessaris per a executar els càlculs estadístics de Control de Qualitat (QC)"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6323,7 +6687,7 @@ msgstr "IVA"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "% IVA"
 
@@ -6570,8 +6934,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Els valors que introduïu aquí sobreescriuran aquells valors que es troben especificats per defecte en els paràmetres del càlcul."
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verificat"
@@ -6580,11 +6944,19 @@ msgstr "Verificat"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Verifica"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6598,6 +6970,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6633,6 +7013,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "dimecres"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6645,19 +7029,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr "Marqueu aquesta casella de selecció si voleu que s'efectuï la verificació automàtica de la mostra tan bon punt totes les seves anàlisis hagin estat verificades."
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6708,10 +7092,18 @@ msgstr "Plantilles per a fulls de treball"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Fulls de treball"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6719,6 +7111,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6803,6 +7199,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6907,8 +7307,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "desactiva"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6973,7 +7382,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7141,32 +7550,32 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 #, fuzzy
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr "Text per defecte del cos del correu electrònic que s'utilitzarà en enviar els informes de resultats als destinataris de la mostra. Variables de substitució admeses: $client_name (nom del client), $recipients (destinataris), $lab_name (nom del laboratori), $lab_address (adreça del laboratori)."
@@ -7174,14 +7583,14 @@ msgstr "Text per defecte del cos del correu electrònic que s'utilitzarà en env
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7193,19 +7602,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7226,16 +7635,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7260,12 +7674,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7275,7 +7689,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7379,6 +7793,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7408,6 +7835,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7554,12 +7988,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7814,7 +8248,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7822,165 +8256,165 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 #, fuzzy
 msgid "description_senaitesetup_date_sampled_required"
 msgstr "Marqueu aquesta casella de selecció si voleu que la introducció de la data de mostreig sigui obligatòria en el formulari de creació de mostres. Aquesta funcionalitat només té efecte quan el flux de treball associat al procés de mostreig no és actiu."
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 #, fuzzy
 msgid "description_senaitesetup_publication_email_text"
 msgstr "Text per defecte del cos del correu electrònic que s'utilitzarà en enviar els informes de resultats als destinataris de la mostra. Variables de substitució admeses: $client_name (nom del client), $recipients (destinataris), $lab_name (nom del laboratori), $lab_address (adreça del laboratori)."
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7988,47 +8422,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8037,20 +8471,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8058,32 +8492,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8091,21 +8525,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8261,6 +8695,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8573,7 +9011,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr "Etiquetes"
 
@@ -8634,7 +9072,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr "Criteri d'ordenació"
 
@@ -8750,52 +9188,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8865,12 +9303,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8880,7 +9318,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9176,7 +9614,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9301,12 +9739,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9516,7 +9954,7 @@ msgid "label_sampletype_title"
 msgstr "Nom"
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr "Desa"
 
@@ -9526,12 +9964,12 @@ msgid "label_senaite"
 msgstr "SENAITE LIMS"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9589,6 +10027,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10765,87 +11219,87 @@ msgid "listing_suppliers_title"
 msgstr "Proveïdors"
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10898,6 +11352,11 @@ msgstr "Plantilles de fulls de treball"
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "Cada mes"
@@ -10948,12 +11407,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "de"
 
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
+
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11032,6 +11499,11 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
 msgstr "${actor} va enviar la mostra el dia ${date}"
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
+msgstr ""
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11265,13 +11737,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr "Nom"
 
@@ -11358,6 +11835,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11603,222 +12085,222 @@ msgid "title_samplingdeviation_title"
 msgstr "Nom"
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr "Permet l'entrada manual de la data de captura del resultat"
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr "Data de mostreig obligatòria"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12072,7 +12554,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "anàlisis pendent(s) de verificar"
 
@@ -12115,7 +12597,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr "{} (Certificat caducat)"
 

--- a/src/senaite/core/locales/ca_ES/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ca_ES/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Catalan (Spain) (https://app.transifex.com/senaite/teams/87045/ca_ES/)\n"

--- a/src/senaite/core/locales/ca_ES/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ca_ES/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Catalan (Spain) (https://app.transifex.com/senaite/teams/87045/ca_ES/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ca_ES/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ca_ES/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: David Molins, 2024\n"
 "Language-Team: Catalan (Spain) (https://app.transifex.com/senaite/teams/87045/ca_ES/)\n"

--- a/src/senaite/core/locales/ca_ES/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ca_ES/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: David Molins, 2024\n"
 "Language-Team: Catalan (Spain) (https://app.transifex.com/senaite/teams/87045/ca_ES/)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ca_ES\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -27,6 +27,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -52,6 +53,7 @@ msgid "%s has no '%s' column."
 msgstr "No existeix la columna '%s' per a %s."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Torna"
@@ -121,6 +123,10 @@ msgstr "*** Aquest correu electrònic ha estat generat automàticament, no el re
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr "... Escull un equip ..."
@@ -138,7 +144,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -196,7 +202,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -241,21 +247,21 @@ msgstr "Activar"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Actiu"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Afegir"
 
@@ -283,15 +289,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr "Afegir mostres"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -304,8 +314,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -369,12 +382,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr "Totes les anàlisis del servei"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -393,11 +414,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -426,14 +447,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -503,7 +540,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -540,7 +577,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -550,6 +587,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -564,18 +605,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -590,7 +627,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -678,11 +715,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -690,15 +731,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -749,7 +790,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -779,6 +820,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -799,7 +844,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -817,19 +862,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -837,12 +882,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -898,23 +943,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -934,15 +979,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -968,7 +1013,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1000,11 +1045,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1041,31 +1086,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1078,12 +1123,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1091,7 +1150,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1103,7 +1162,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1115,7 +1174,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1125,7 +1184,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1134,7 +1193,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1227,7 +1286,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1265,6 +1324,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1283,7 +1346,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1327,7 +1390,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1360,15 +1423,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1378,6 +1441,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1396,11 +1463,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1413,7 +1480,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1421,7 +1488,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1433,7 +1500,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1463,7 +1530,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1472,7 +1539,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1480,12 +1547,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1533,23 +1608,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1561,11 +1636,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1607,7 +1682,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1630,11 +1705,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1646,7 +1721,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1658,7 +1733,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1666,20 +1741,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1691,7 +1766,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1723,15 +1798,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1743,7 +1818,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1752,7 +1827,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1776,7 +1851,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1788,8 +1863,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1818,9 +1902,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1867,7 +1951,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1885,7 +1973,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1910,15 +1998,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1988,11 +2084,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2009,7 +2109,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2057,6 +2157,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2071,21 +2172,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2093,27 +2194,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2126,16 +2227,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2146,27 +2251,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2174,8 +2279,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2199,7 +2312,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2212,7 +2325,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2236,7 +2349,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2248,15 +2361,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2268,7 +2381,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2278,7 +2391,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2304,7 +2417,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2312,7 +2425,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2399,7 +2512,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2413,6 +2526,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2429,11 +2554,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2456,13 +2581,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2470,7 +2599,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2503,7 +2632,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2517,7 +2646,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2530,8 +2659,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2555,7 +2696,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2563,7 +2704,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2583,15 +2724,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2599,7 +2740,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2639,7 +2780,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2670,11 +2811,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2871,7 +3012,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2892,13 +3033,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2961,15 +3102,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2981,7 +3122,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2993,9 +3134,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3010,6 +3151,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3055,8 +3200,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3065,7 +3210,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3073,13 +3218,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3092,7 +3237,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3104,7 +3249,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3116,11 +3261,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3166,15 +3311,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3198,7 +3343,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3225,6 +3370,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3289,7 +3442,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3313,7 +3466,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3337,7 +3490,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3366,7 +3519,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3381,7 +3534,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3416,15 +3569,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3432,7 +3585,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3463,7 +3616,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3474,7 +3627,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3492,7 +3645,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3523,6 +3676,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3536,11 +3693,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3576,13 +3733,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3592,6 +3753,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3634,6 +3799,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3682,6 +3851,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3726,12 +3899,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3748,6 +3935,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3776,7 +3967,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3792,11 +3983,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3817,7 +4008,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3829,7 +4020,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3845,16 +4036,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3864,6 +4055,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3882,11 +4077,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3894,13 +4089,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3908,8 +4103,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3937,7 +4140,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3959,11 +4162,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4060,11 +4263,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4077,6 +4280,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4096,12 +4300,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4140,31 +4348,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4197,7 +4405,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4214,11 +4422,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4246,7 +4454,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4255,7 +4463,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4277,11 +4485,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4294,7 +4502,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4318,7 +4526,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4327,7 +4535,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4335,7 +4543,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4344,8 +4552,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4360,6 +4572,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4381,6 +4597,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4407,7 +4631,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4419,30 +4643,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4493,11 +4721,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4523,9 +4755,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4541,7 +4773,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr "S'han rebutjat {} mostres: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4602,8 +4834,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4639,11 +4879,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4655,7 +4895,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4664,7 +4904,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4680,8 +4920,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4689,15 +4941,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4722,15 +4975,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4738,7 +4991,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4754,16 +5007,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4771,7 +5028,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4795,7 +5052,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4831,6 +5088,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4856,6 +5117,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4865,7 +5127,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4879,7 +5141,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4916,7 +5178,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4936,7 +5198,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4963,7 +5225,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5024,7 +5286,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5036,8 +5298,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5054,6 +5316,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5063,7 +5337,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5071,7 +5361,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5084,7 +5374,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5092,14 +5382,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5114,7 +5413,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5131,6 +5430,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5139,7 +5442,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5229,11 +5532,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5245,11 +5548,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5257,31 +5560,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5293,7 +5604,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5305,11 +5616,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5331,7 +5642,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5345,7 +5656,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5373,7 +5684,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5421,28 +5732,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5465,11 +5788,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5490,7 +5813,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5506,6 +5829,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5532,7 +5863,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5540,7 +5871,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5557,17 +5888,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5576,7 +5907,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5616,7 +5951,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5624,7 +5963,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5666,7 +6005,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5692,7 +6031,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5774,7 +6113,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5782,7 +6121,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5810,7 +6149,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5818,11 +6161,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5859,11 +6202,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5903,7 +6246,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5927,11 +6270,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5983,11 +6326,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6011,11 +6354,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6047,8 +6390,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6075,34 +6418,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6115,7 +6466,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6137,7 +6488,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6162,6 +6513,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6170,7 +6525,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6182,6 +6537,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6214,8 +6570,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6232,12 +6592,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6248,7 +6612,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6256,7 +6620,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6294,7 +6658,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6302,15 +6666,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6318,7 +6682,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6565,8 +6929,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6575,10 +6939,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6593,6 +6965,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6628,6 +7008,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6640,19 +7024,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6703,9 +7087,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6714,6 +7106,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6798,6 +7194,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6902,8 +7302,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6968,7 +7377,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7135,46 +7544,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7186,19 +7595,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7219,16 +7628,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7253,12 +7667,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7268,7 +7682,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7371,6 +7785,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7400,6 +7827,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7546,12 +7980,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7804,7 +8238,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7812,163 +8246,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7976,47 +8410,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8025,20 +8459,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8046,32 +8480,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8079,21 +8513,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8249,6 +8683,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8561,7 +8999,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8622,7 +9060,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8738,52 +9176,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8853,12 +9291,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8868,7 +9306,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9164,7 +9602,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9289,12 +9727,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9504,7 +9942,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9514,12 +9952,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9577,6 +10015,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10753,87 +11207,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10886,6 +11340,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10936,12 +11395,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11019,6 +11486,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11253,13 +11725,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11346,6 +11823,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11591,222 +12073,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12060,7 +12542,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12103,7 +12585,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/cs/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/cs/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Jiří Podhorecký <jirka.p@volny.cz>, 2023\n"
 "Language-Team: Czech (https://app.transifex.com/senaite/teams/87045/cs/)\n"

--- a/src/senaite/core/locales/cs/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/cs/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Jiří Podhorecký <jirka.p@volny.cz>, 2023\n"
 "Language-Team: Czech (https://app.transifex.com/senaite/teams/87045/cs/)\n"
@@ -919,6 +919,11 @@ msgstr "need_an_account"
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/cs/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/cs/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Czech (https://app.transifex.com/senaite/teams/87045/cs/)\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: cs\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr " <p>ID Server poskytuje jedinečné sekvenční ID pro objekty, jako jsou Vzorky, Pracovní listy atd., na základě formátu určeného pro každý typ obsahu.</p><p>Formát je konstruován podobně jako formátovací syntaxe jazyka Python pomocí předdefinovaných proměnných pro každý typ obsahu a postupuje ID pomocí sekvenčního čísla \"seq\" a jeho výplně v podobě počtu číslic, např. \"seq\". např. \"03d\" pro sekvenci ID od 001 do 999. </p><p>Alfanumerické předpony pro ID jsou zahrnuty stejně jako ve formátech, např. WS pro Worksheet v WS-{seq:03d} vytváří sekvenční ID Worksheet: WS-001, WS-002, WS-003 atd. </p><p>Pro dynamické generování alfanumerických a sekvenčních ID lze použít zástupný znak {alfa}. Např. WS-{alpha:2a3d} vytvoří WS-AA001, WS-AA002, WS-AB034 atd.</p><p>Mezi proměnné, které lze použít, patří:<table><tr><th style='width:150px'>Typ obsahu</th><th>Proměnné</th></tr><tr><td>Id klienta</td><td>{clientId}</td></tr><tr><td>Rok</td><td>{year}</td></tr><tr><td>Id vzorku</td><td>{sampleId}</td></tr><tr><td>Typ vzorku</td><td>{sampleType}</td></tr><tr><td>Datum vzorkování</td><td>{samplingDate}</td></tr><tr><td>Datum odběru vzorku</td><td>{dateSampled}</td></tr></table></p><p>Nastavení konfigurace:<ul><li>format:<ul><li>řetězec formátu pythonu vytvořený z předdefinovaných proměnných, jako je sampleId, clientId, sampleType. </li><li>Speciální proměnná 'seq' musí být umístěna jako poslední v typu řetězce theformat</li></ul></li><li>typ sequence: [generated|counter]</li><li>context: pokud je typ counter, poskytuje kontext počítací funkci</li><li>counter type: [backreference|contained]</li><li>counter reference: parametr počítací funkce</li><li>prefix: výchozí předpona, pokud není uveden ve formátu řetězce</li><li>split length: počet částí, které mají být zahrnuty do předpony</li></ul></p>"
 
@@ -29,6 +29,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} příloh o celkové velikosti ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -54,6 +55,7 @@ msgid "%s has no '%s' column."
 msgstr "%s nemá sloupec  '%s' ."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Zpět"
@@ -123,6 +125,10 @@ msgstr "*** Toto je automaticky generovaný e-mail, na tuto zprávu neodpovídej
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr "... Vyberte si nástroj ..."
@@ -140,7 +146,7 @@ msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Přejděte na nastaven�
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Vítejte v SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -198,7 +204,7 @@ msgid "Account Type"
 msgstr "Typ účtu"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr "Účtování"
 
@@ -243,21 +249,21 @@ msgstr "aktivovat"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Aktivní"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "osoba hrající roli"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Vložit"
 
@@ -285,15 +291,19 @@ msgstr "Vlož duplicitní vzorek"
 msgid "Add Samples"
 msgstr "Přidat vzorky"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Do všech analýz přidejte pole s poznámkami"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "Přidejte vlastní pravidla CSS pro logo, např. height:15px; width:150px;"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "Přidat výchozí vybíratelné štítky"
 
@@ -306,8 +316,11 @@ msgstr "Přidat novou přílohu"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Přidat jednu nebo více příloh k popisu vzorku v tomto vzorku nebo k zadání vašeho požadavku."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Přidat poznámky"
 
@@ -371,13 +384,21 @@ msgstr "Zde jsou uvedeny všechny služby akreditované analýzy."
 msgid "All Analyses of Service"
 msgstr "Všechny analýzy služeb"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Všechny vázané analýzy"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Povolit zápis ručního detekčního limitu"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -395,11 +416,11 @@ msgstr "Umožnit stejnému uživateli několikrát ověřit"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Umožněte stejnému uživateli, aby ověřoval vícekrát, ale ne postupně"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Povolit vlastní ověření výsledků"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -428,15 +449,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Analyzováno"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analýzy"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Požadované analýzy"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -505,7 +542,7 @@ msgstr "Podmínky analýzy"
 msgid "Analysis conditions updated: {}"
 msgstr "Podmínky analýzy aktualizovány: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Specifikace analýzy, které jsou editovány přímo na vzorku."
 
@@ -542,7 +579,7 @@ msgstr "Musí být zadán analytik."
 msgid "Any"
 msgstr "Jakýkoli"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "Vzhled"
 
@@ -553,6 +590,10 @@ msgstr "Použít"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Použij šablonu"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -566,19 +607,15 @@ msgstr "Číslo prostředku"
 msgid "Assign"
 msgstr "Přiřadit"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Přiděleno"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Přiřazeno na: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Úkol čeká na vyřízení"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -592,7 +629,7 @@ msgstr "Připojit ke vzorku"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr "Přiložené štítky"
 
@@ -680,11 +717,15 @@ msgstr "Automatické generování ID Behavior pro obsah Dexterity"
 msgid "Auto-Import Logs"
 msgstr "Protokoly automatického importu"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Automatické oddělování při příjmu"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Automatické přijímání vzorků"
 
@@ -692,15 +733,15 @@ msgstr "Automatické přijímání vzorků"
 msgid "Autofill"
 msgstr "Automatické vyplnění"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Automatické odhlášení"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr "Automatické ověřování vzorků"
 
@@ -751,7 +792,7 @@ msgstr "Dávka"
 msgid "Batch Book"
 msgstr "Kniha dávek"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID Dávky"
 
@@ -781,6 +822,10 @@ msgstr "Mějte na paměti, že rozsahy uvedené v tabulkovém souboru z dynamick
 msgid "Bearing"
 msgstr "Orientace"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Fakturační adresa"
@@ -801,7 +846,7 @@ msgstr "Značka"
 msgid "Bulk Discount"
 msgstr "Hromadná sleva"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Použita hromadná sleva"
@@ -819,19 +864,19 @@ msgstr "Služební telefon"
 msgid "Business address"
 msgstr "Obchodní adresa"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr "Podle \"Zobrazované hodnoty\" vzestupně"
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr "Podle \"Zobrazované hodnoty\" sestupně"
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr "Podle \"Výsledné hodnoty\" vzestupně"
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr "Podle \"Výsledné hodnoty\" sestupně"
 
@@ -839,12 +884,12 @@ msgstr "Podle \"Výsledné hodnoty\" sestupně"
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "V kopii"
 
@@ -900,23 +945,23 @@ msgstr "Kalibrace"
 msgid "Calibrator"
 msgstr "Kalibrátor"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Může ověřit, ale odesláno od aktuálního uživatele"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Lze to ověřit, ale byl již ověřen aktuálním uživatelem"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Zrušit"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Zrušen"
 
@@ -936,15 +981,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr "Nelze odeslat e-mail pro ${sample_id}: ${error}"
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "Nelze ověřit, naposledy ověřeno aktuálním uživatelem"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "Nelze ověřit, odeslal aktuální uživatel"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "Nelze ověřit, byl ověřen současným uživatelem"
 
@@ -970,7 +1015,7 @@ msgstr "Catalog Dexterity contents ve více katalozích"
 msgid "Catalogue Number"
 msgstr "Katalogové číslo"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Kategorizujte analytické služby"
 
@@ -1002,11 +1047,11 @@ msgid "Changes Saved"
 msgstr "Změny uloženy"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Změny uloženy."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Změny se budou rozšiřovat do oddělků"
 
@@ -1043,31 +1088,31 @@ msgstr "Zaškrtávací pole"
 msgid "Choices"
 msgstr "Možnosti"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Vyberte typ vícenásobného ověření pro stejného uživatele. Toto nastavení může povolit / zakázat ověřování / následně ověřovat více než jednou pro stejného uživatele."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1080,20 +1125,34 @@ msgstr "Město"
 msgid "Classic"
 msgstr "Typický"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "Vymazat výběr"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Klepnutím rozbalte tuto kategorii"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "Klepnutím přepnete viditelnost nebo přetažením změníte pořadí"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Zákazník"
@@ -1105,7 +1164,7 @@ msgstr "ID šarže klienta"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID zákazníka"
 
@@ -1117,7 +1176,7 @@ msgstr "Vstupní stránka klienta"
 msgid "Client Name"
 msgstr "Jméno klienta"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Objednávka zákazníka"
 
@@ -1127,7 +1186,7 @@ msgstr "Objednávka zákazníka"
 msgid "Client Order Number"
 msgstr "Číslo objednávky klienta"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Ref. zákazníka"
 
@@ -1136,7 +1195,7 @@ msgstr "Ref. zákazníka"
 msgid "Client Reference"
 msgstr "Reference zákazníka"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Zákaznické SID"
 
@@ -1229,7 +1288,7 @@ msgstr "Komentáře"
 msgid "Comments or results interpretation"
 msgstr "Interpretace komentářů nebo výsledků"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "Obchodní ID"
@@ -1267,6 +1326,10 @@ msgstr "Konfigurace informací v záhlaví vzorku"
 msgid "Configuration restored to default values."
 msgstr "Konfigurace obnovena na výchozí hodnoty."
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr "Konfigurovat sloupce tabulky"
@@ -1285,7 +1348,7 @@ msgstr "Potvrzení hesla"
 msgid "Considerations"
 msgstr "K úvaze"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kontakt"
@@ -1329,7 +1392,7 @@ msgstr "Kontejnery"
 msgid "Contents of the file {}"
 msgstr "Obsah souboru {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1362,15 +1425,15 @@ msgstr "Služby analýzy kopií"
 msgid "Copy from"
 msgstr "Kopírovat z"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Kopírovat do nového"
 
@@ -1380,6 +1443,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1398,11 +1465,11 @@ msgstr "Nepodařilo se převést vzorky do vzorkovaného stavu"
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1415,7 +1482,7 @@ msgstr "Země"
 msgid "Create Invoice PDF"
 msgstr "Vytvořit PDF fakturu "
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Vytvořit Oddělky"
 
@@ -1423,7 +1490,7 @@ msgstr "Vytvořit Oddělky"
 msgid "Create SENAITE Site"
 msgstr "Vytvořit stránky SENAITE"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr "Vytvořit pracovní list"
 
@@ -1435,7 +1502,7 @@ msgstr "Vytvoření nové stránky SENAITE"
 msgid "Create a new User"
 msgstr "Vytvořit nového uživatele"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr "Vytvoření nového pracovního listu pro vybrané vzorky"
 
@@ -1465,7 +1532,7 @@ msgid "Created {} partitions: {}"
 msgstr "Vytvořeno {} oddělků: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Tvůrce"
 
@@ -1474,7 +1541,7 @@ msgstr "Tvůrce"
 msgid "Criteria"
 msgstr "Kritéria"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Měna"
 
@@ -1482,13 +1549,21 @@ msgstr "Měna"
 msgid "Current"
 msgstr "Aktuální"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Vlastní desetinná značka"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "DL"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1535,23 +1610,23 @@ msgstr "Datum změnění"
 msgid "Date Opened"
 msgstr "Datum otevření"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Datum zachováno"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Datum tištění"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Datum vydání"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Datum doručení"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Datum registrace"
 
@@ -1563,11 +1638,11 @@ msgstr "Datum vyhotovení"
 msgid "Date Sample Received"
 msgstr "Datum přijetí vzorku"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Datum odběru"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Datum ověřeno"
 
@@ -1609,7 +1684,7 @@ msgstr "Datum udělení kalibračního certifikátu"
 msgid "Date when the certificate is valid"
 msgstr "Datum platnosti certifikátu"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1632,11 +1707,11 @@ msgstr "Deaktivovat až do dalšího kalibračního testu"
 msgid "Deactivate"
 msgstr "Deaktivovat"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Desetinné znaménko, které se použije v přehledech od tohoto klienta."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1648,7 +1723,7 @@ msgstr "Výchozí kontejner"
 msgid "Default Department"
 msgstr "Výchozí oddělení"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Výchozí e-maily pro CC všech publikovaných vzorků pro tohoto klienta"
 
@@ -1660,7 +1735,7 @@ msgstr "Výchozí přístroj"
 msgid "Default Method"
 msgstr "Výchozí metoda"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1668,20 +1743,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Výchozí uchování"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Výchozí počet vzorků k přidání."
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Výchozí desetinné znaménko"
 
@@ -1693,7 +1768,7 @@ msgstr "Výchozí nástroj používaný pro analýzy tohoto typu"
 msgid "Default large sticker"
 msgstr "Výchozí velký štítek"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Výchozí rozvržení v zobrazení pracovního listu"
 
@@ -1725,15 +1800,15 @@ msgstr "Výchozím výsledkem musí být jedna z následujících možností vý
 msgid "Default result to display on result entry"
 msgstr "Výchozí výsledek, který se zobrazí při zadání výsledku"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Standardní čas zdržení"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Výchozí formát vědeckého zápisu pro zprávy"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Výchozí formát vědeckého zápisu výsledků"
 
@@ -1745,7 +1820,7 @@ msgstr "Výchozí malý štítek"
 msgid "Default timezone"
 msgstr "Výchozí časové pásmo"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Výchozí časové cykly pro analýzy"
 
@@ -1754,7 +1829,7 @@ msgstr "Výchozí časové cykly pro analýzy"
 msgid "Default value"
 msgstr "Implicitní hodnota"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "Výchozí hodnota „Počet vzorků“, když uživatelé kliknou na tlačítko „PŘIDAT“ a vytvoří se nové vzorky"
 
@@ -1778,7 +1853,7 @@ msgstr "Definujte přesnost při převodu hodnot na notaci exponentů. Výchozí
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Definovat vzorkovač, který má vzorek připravit v naplánovaném datu"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1790,8 +1865,17 @@ msgstr "Definuje nálepky, které se mají použít pro tento typ vzorku."
 msgid "Degrees"
 msgstr "Stupně"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1820,9 +1904,9 @@ msgstr "Oddělení"
 msgid "Dependent Analyses"
 msgstr "Závislé analýzy"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Popis"
 
@@ -1869,7 +1953,11 @@ msgstr "Zakázat automatické načítání přechodů"
 msgid "Disable multi-verification for the same user"
 msgstr "Zakázat vícenásobné ověření stejného uživatele"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Sleva"
@@ -1887,7 +1975,7 @@ msgstr "Odeslat"
 msgid "Dispatch samples"
 msgstr "Expediční vzorky"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Odesláno"
@@ -1912,15 +2000,23 @@ msgstr "Hodnota zobrazení musí být jedinečná"
 msgid "Display a Detection Limit selector"
 msgstr "Zobrazit selekční limit detekce"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr "Zobrazení vzorových oddílů klientům"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Zlikvidovat"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Zlikvidován"
 
@@ -1990,11 +2086,15 @@ msgstr "Stáhnout  PDF"
 msgid "Download selected reports"
 msgstr "Stáhnout vybrané zprávy"
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Vypršeno"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Datum vypršení"
@@ -2011,7 +2111,7 @@ msgstr "Duplikát"
 msgid "Duplicate Analysis"
 msgstr "Duplikát analýzy"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2059,6 +2159,7 @@ msgstr "Např. značky SANAS, APLAC atd."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "Každé rozhraní importu může definovat složku, ve které systém hledá soubory s výsledky při automatickém importu výsledků při volání zobrazení <code>auto_import_results</code>."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Upravit"
@@ -2073,21 +2174,21 @@ msgstr "Nadmořská výška"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "E-mail"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "E-mailová adresa"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2095,27 +2196,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "Protokol e-mailů"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "Tělo e-mailu pro oznámení o zneplatnění vzorku"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr "Tělo e-mailu pro oznámení o odmítnutí vzorku"
 
@@ -2128,17 +2229,21 @@ msgstr "E-mail byl zrušen"
 msgid "Email notification"
 msgstr "Upozornění e-mailem"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "E-mailové oznámení o odmítnutí vzorku"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
 msgstr "E-mail odeslán"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2148,27 +2253,27 @@ msgstr "Prázdné klíče nejsou podporovány"
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Povolit vícenásobné použití přístroje v pracovních listech."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Povolit uchování vzorků"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "Povolit specifikace vzorku"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "Povolit odběr vzorků"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "Povolit plánování vzorkování"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr "Povolit globální protokol auditu"
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr "Povolit globální Auditlog"
 
@@ -2176,9 +2281,17 @@ msgstr "Povolit globální Auditlog"
 msgid "Enable sampling workflow for the created sample"
 msgstr "Povolit pracovní postup odběru vzorků pro vytvořený vzorek"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "Povolte pracovní postup Tisk sestavy výsledků"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2201,7 +2314,7 @@ msgstr "Zadejte e-mailovou adresu. To je nutné v případě ztráty hesla. Resp
 msgid "Enter discount percentage value"
 msgstr "Zadejte procentuální hodnotu slevy"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2214,7 +2327,7 @@ msgstr "Zadejte procentuální hodnotu, např. 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Zadejte procentuální hodnotu, např. 14.0. Toto procento se použije pouze na analytický profil a převede systémovou DPH"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Zadejte procentuální hodnotu, např. 14.0. Toto procento je použito v celém systému, ale může být přepsáno na jednotlivé položky"
 
@@ -2238,7 +2351,7 @@ msgstr "Zadat podrobnosti o všech analytických službách, které chcete zkop�
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Sem zadejte podrobnosti o akreditaci služeb vaší laboratoře. K dispozici jsou následující pole: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr "Výsledek zadejte v desítkové nebo vědecké notaci, např. 0,00005 nebo 1e-5, 10000 nebo 1e5."
 
@@ -2250,15 +2363,15 @@ msgstr "Ekologické předpoklady"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr "Chybné zveřejnění výsledku: ${sample_id}"
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Vývoj analýz"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Evoluce vzorků"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Evoluce pracovních listů"
 
@@ -2270,7 +2383,7 @@ msgstr "Příklad Cronjobu pro spuštění automatického importu každých 10 m
 msgid "Example content"
 msgstr "Příklad obsahu"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Vyloučit z faktury"
 
@@ -2280,7 +2393,7 @@ msgstr "Vyloučit z faktury"
 msgid "Expected Result"
 msgstr "Očekávaný výsledek"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Očekávané datum vzorkování"
 
@@ -2306,7 +2419,7 @@ msgstr "Datum vypršení platnosti"
 msgid "Exponential format precision"
 msgstr "Přesnost exponenciálního formátu"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Exponenciální prahová hodnota formátu"
 
@@ -2314,7 +2427,7 @@ msgstr "Exponenciální prahová hodnota formátu"
 msgid "Export"
 msgstr "Exportovat"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "Štítek se nepodařilo načíst"
 
@@ -2401,7 +2514,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "Velikost souboru"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2415,6 +2528,18 @@ msgstr "Filtrovat podle služby šablony"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2431,11 +2556,11 @@ msgstr "Jméno"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Plovoucí hodnota od 0,0 - 1000,0 která označuje pořadí řazení. Duplicitní hodnoty jsou řazeny abecedně."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Konfigurace formátování"
 
@@ -2458,13 +2583,17 @@ msgstr "Pátek"
 msgid "From"
 msgstr "Od"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Celé jméno"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Celé jméno"
 
@@ -2472,7 +2601,7 @@ msgstr "Celé jméno"
 msgid "Function"
 msgstr "Funkce"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Vzorek datovaný v budoucnosti"
 
@@ -2505,7 +2634,7 @@ msgstr "Přejděte do své instance"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Oslovující titul např. Pan, Paní, Dr."
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Služby skupinové analýzy podle kategorií v tabulkách LIMS, užitečné, když je seznam dlouhý"
 
@@ -2519,7 +2648,7 @@ msgid "Hazardous"
 msgstr "Nebezpečný"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "skryto"
@@ -2532,8 +2661,20 @@ msgstr "Skryté pole"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2557,7 +2698,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2565,7 +2706,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr "Hodnoty ID serveru"
 
@@ -2585,15 +2726,15 @@ msgstr "Pokud je zaškrtnuto, zobrazí se v zobrazeních výsledků výsledky ve
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Pokud je zaškrtnuto, nebude přístroj k dispozici, dokud nebude provedena další platná kalibrace. Toto zaškrtávací políčko bude automaticky zrušeno."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Pokud je tato možnost povolena, zobrazí se v zobrazení vstupu výsledků vedle každé analýzy pole volného textu"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Pokud je tato možnost povolena, bude ji moci ověřit také uživatel, který zadal výsledek této analýzy. Toto nastavení se projeví u uživatelů s přiřazenou rolí, která jim umožňuje ověřit výsledky (ve výchozím nastavení správci, správci laboratoří a ověřovatelé). Zde nastavená možnost má přednost před možností nastavenou v nastavení Bika"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Pokud je tato možnost povolena, bude ji moci ověřit také uživatel, který zadal výsledek. Toto nastavení se projeví pouze u uživatelů s přiřazenou rolí, která jim umožňuje ověřovat výsledky (ve výchozím nastavení jsou správci, správci laboratoří a ověřovatelé). Toto nastavení lze přepsat pro dané zobrazení analýzy v úpravě služby analýzy. Ve výchozím nastavení je zakázáno."
 
@@ -2601,7 +2742,7 @@ msgstr "Pokud je tato možnost povolena, bude ji moci ověřit také uživatel, 
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Pokud je tato možnost povolena, bude název analýzy psán kurzívou."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "Pokud je tato možnost povolena, tato analýza a její výsledky se ve zprávách ve výchozím nastavení nezobrazí. Toto nastavení lze přepsat v profilu analýzy a / nebo vzorku"
 
@@ -2641,7 +2782,7 @@ msgstr "Pokud není zaškrtnuto, nebudou moci správci laboratoře  při vytvá�
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "Pokud váš vzorec vyžaduje speciální funkci z externí knihovny Python, můžete ji importovat zde. Např. pokud chcete použít funkci 'floor' z modulu 'math' Python, přidáte do pole Module 'math' a do pole funkce 'floor'. Ekvivalent v Pythonu by byl 'from math import floor'. Při výpočtu byste pak mohli použít  'floor([Ca] + [Mg])'. "
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr "Okamžité zadání výsledků"
 
@@ -2672,11 +2813,11 @@ msgstr "Postup kalibrace v laboratoři"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Neaktivní"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Zahrnout a zobrazit informace o cenách"
 
@@ -2873,7 +3014,7 @@ msgid "Internal Certificate"
 msgstr "Interní certifikát"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "Vnitřní použití"
 
@@ -2894,13 +3035,13 @@ msgstr "Šablony interpretace"
 msgid "Interval"
 msgstr "Interval"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Neplatné"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2963,15 +3104,15 @@ msgstr "Faktura komu"
 msgid "Invoice {} created"
 msgstr "Faktura  {} vytvořena"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "InvoiceBatch nemá žádné datum ukončení"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "Dávka faktury nemá datum zahájení"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "InvoiceBatch nemá titul"
 
@@ -2983,7 +3124,7 @@ msgstr "Pracovní pozice"
 msgid "Job title"
 msgstr "Pracovní pozice"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr "Zachovat výše uvedené pořadí"
 
@@ -2995,9 +3136,9 @@ msgstr "Klíč"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Klíčové slovo"
 
@@ -3013,6 +3154,10 @@ msgstr "Vyžadované klíčové slovo"
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Klíčová slova"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3057,8 +3202,8 @@ msgstr "Laboratorní produkty"
 msgid "Lab URL"
 msgstr "URL laboratoře"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Štítek"
@@ -3067,7 +3212,7 @@ msgstr "Štítek"
 msgid "Label configuration"
 msgstr "Konfigurace štítků"
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr "Názvy štítků musí být jedinečné"
 
@@ -3075,13 +3220,13 @@ msgstr "Názvy štítků musí být jedinečné"
 msgid "Label schema extender"
 msgstr "Rozšíření schématu štítků"
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr "Objekty označené štítky"
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr "Štítky"
 
@@ -3094,7 +3239,7 @@ msgstr "Laboratoř"
 msgid "Laboratory Accredited"
 msgstr "Laboratorní akreditace"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Laboratorní pracovní dny"
 
@@ -3106,7 +3251,7 @@ msgstr "Jazyk"
 msgid "Large Sticker"
 msgstr "Velký štítek"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3118,11 +3263,11 @@ msgstr "Poslední protokoly automatického importu"
 msgid "Last Login Time"
 msgstr "Čas posledního přihlášení"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Poslední"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Pozdější  analýzy"
 
@@ -3168,15 +3313,15 @@ msgstr "Odkaz Uživatele"
 msgid "Link an existing User"
 msgstr "Propojit existujícího uživatele"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr "Seznam všech objektů se štítky"
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr "Seznam možných konečných výsledků. Pokud je nastaveno, není při zadávání výsledků povolen žádný vlastní výsledek a uživatel musí vybrat z těchto hodnot."
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3200,7 +3345,7 @@ msgstr "Vložte sem dokument certifikátu"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3228,6 +3373,14 @@ msgstr "Typ místa"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Místo, kde je sada dokumentů odložena"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3291,7 +3444,7 @@ msgstr "Samec"
 msgid "Manage Analyses"
 msgstr "Spravovat analýzy"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "Správa polí formuláře"
 
@@ -3315,7 +3468,7 @@ msgstr "Spravovat pole formulářů vzorků"
 msgid "Manage linked User"
 msgstr "Spravovat propojeného uživatele"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3339,7 +3492,7 @@ msgstr "Email správce"
 msgid "Manager Phone"
 msgstr "Telefon správce"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Ručně"
 
@@ -3368,7 +3521,7 @@ msgstr "Výrobci"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "Vzorek označte pouze pro interní použití. To znamená, že je přístupný pouze pracovníkům laboratoře a nikoli klientům."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3383,7 +3536,7 @@ msgstr "Max čas"
 msgid "Max operator"
 msgstr "Max operátor"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3418,15 +3571,15 @@ msgid "Member Discount"
 msgstr "Členská sleva"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Členská sleva %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Platí členské slevy"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Člen zaregistrován a propojen s aktuálním kontaktem."
 
@@ -3434,7 +3587,7 @@ msgstr "Člen zaregistrován a propojen s aktuálním kontaktem."
 msgid "Message sent to {}, "
 msgstr "Zpráva odeslána na {},"
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3465,7 +3618,7 @@ msgstr "Střední iniciála"
 msgid "Middle name"
 msgstr "Prostřední jméno"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3476,7 +3629,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr "Min operátor"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3494,7 +3647,7 @@ msgstr "Minimálně 5 znaků"
 msgid "Minimum Volume"
 msgstr "Minimální objem"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Minimální počet výsledků pro výpočty statistik QC"
 
@@ -3525,6 +3678,10 @@ msgstr "Modul"
 msgid "Monday"
 msgstr "Pondělí"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3538,11 +3695,11 @@ msgstr "Chování více katalogů pro Dexterity Contents"
 msgid "Multi Results"
 msgstr "Vícenásobné výsledky"
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "Typ vícenásobného ověření"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Vyžaduje se vícenásobné ověření"
 
@@ -3578,13 +3735,17 @@ msgstr "Moje organizace"
 msgid "My Profile"
 msgstr "Můj profil"
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Jméno"
 
@@ -3595,6 +3756,10 @@ msgstr ""
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
 msgstr "Nové rozsahy nebudou použity na nové ani současné analýzy. Pokud chcete použít nejnovější změny, přiřaďte specifikaci znovu."
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
@@ -3637,6 +3802,10 @@ msgstr "Žádná podskupina"
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "Nebyla definována žádná akce."
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3684,6 +3853,10 @@ msgstr "Nebyly provedeny žádné změny"
 msgid "No changes made."
 msgstr "Nebyly provedeny žádné změny."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "Není stanoveno datum"
@@ -3728,6 +3901,16 @@ msgstr "Nebyly vybrány žádné položky"
 msgid "No items selected."
 msgstr "Nebyly vybrány žádné položky."
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "Nebyly vytvořeny žádné nové položky."
@@ -3735,6 +3918,10 @@ msgstr "Nebyly vytvořeny žádné nové položky."
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "Nebyly vytvořeny žádné oddělky"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3751,6 +3938,10 @@ msgstr "Žádné vzorky nebyly odmítnuty"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Žádný pracovní postup odběru vzorků"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3778,7 +3969,7 @@ msgstr "Žádné viditelné analýzy pro tento vzorek"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Nic"
 
@@ -3794,11 +3985,11 @@ msgstr "Není povoleno aktualizovat podmínky: {}"
 msgid "Not defined"
 msgstr "Není určeno"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Nenastaveno"
@@ -3819,7 +4010,7 @@ msgstr "Poznámka: Nastavení jsou globální a platí pro všechna zobrazení v
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "Poznámka: Můžete také přetáhnout řádky příloh a změnit jejich pořadí v sestavě."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr "Oznámení"
 
@@ -3831,7 +4022,7 @@ msgstr "Počet sloupců"
 msgid "Number"
 msgstr "Číslo"
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Počet analýz"
 
@@ -3847,16 +4038,16 @@ msgstr "Počet kopií"
 msgid "Number of prominent columns"
 msgstr "Počet významných sloupců"
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Počet požadovaných ověření"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Počet požadovaných ověření před tím, než je daný výsledek považován za „ověřený“. Toto nastavení lze přepsat pro jakékoli analýzy v zobrazení úprav služby pro analýzu. Ve výchozím nastavení 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Počet požadovaných ověření od různých uživatelů s dostatečnými oprávněními před tím, než je daný výsledek považován za „ověřený“. Zde nastavená možnost má přednost před možností nastavenou v nastavení Bika"
 
@@ -3867,6 +4058,10 @@ msgstr "Počet standardních sloupců"
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
 msgstr "Číselný"
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
+msgstr ""
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -3884,11 +4079,11 @@ msgstr "V hlášení lze přímo zobrazit pouze obrázky."
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr "Zobrazí se pouze přístroje, které mají nakonfigurované importní rozhraní."
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "Pro výpočet časového cyklu analýzy se berou v úvahu pouze laboratorní pracovní dny."
 
@@ -3896,13 +4091,13 @@ msgstr "Pro výpočet časového cyklu analýzy se berou v úvahu pouze laborato
 msgid "Only to empty or zero fields"
 msgstr "Pouze do prázdných nebo nulových polí"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Otevřeno"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr "Otevřeno / K ověření / Ověřeno / Celkem"
 
@@ -3910,9 +4105,17 @@ msgstr "Otevřeno / K ověření / Ověřeno / Celkem"
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Open Source Web based Laboratory Information Management System"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "Otevřete e-mailový formulář a odešlete vybrané zprávy příjemcům. Po úspěšném odeslání e-mailu se také zveřejní obsažené vzorky zpráv."
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3939,7 +4142,7 @@ msgstr "Jiné důvody"
 msgid "Other reasons:"
 msgstr "Další důvody:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Jiný stav"
 
@@ -3961,11 +4164,11 @@ msgstr "Přepsat neprázdné výsledky analýzy"
 msgid "Override non-empty analysis results, also with empty"
 msgstr "Přepsat neprázdné výsledky analýzy, také s prázdným"
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4062,11 +4265,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Vyberte uživatele ze seznamu"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4079,6 +4282,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr "Vyberte počet oddílů, které chcete vytvořit, a stiskněte tlačítko náhledu."
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr "Uveďte důvod"
 
@@ -4098,12 +4302,16 @@ msgstr "Pro výběr možností použijte následující formát: key1:value1|key
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr "Napište prosím komentář, kam jsou uvedené vzorky (vzorek) odesílány."
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Bod zachycení"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4142,31 +4350,31 @@ msgstr "Přesnost jako počet desetinných míst"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Přesnost jako počet platných číslic podle neurčitosti. Desetinná pozice bude dána prvním číslem odlišným od nuly v neurčitosti, na této pozici systém zaokrouhlí nahoru neurčitost a výsledky. Například s výsledkem 5.243 a neurčitostí 0,22 se systém zobrazí správně jako 5.2 +/-0.2. Pokud není pro výsledek nastaven žádný rozsah neurčitosti, použije systém pevnou sadu přesnosti."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr "Předdefinované výsledky"
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Upřednostňovaný desetinná znak pro zprávy."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Preferované desetinné znaménko pro výsledky"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "Upřednostňované rozvržení tabulky pro zadání výsledků v zobrazení listu. Klasické rozvržení zobrazuje vzorky v řádcích a analýzy ve sloupcích. Transponované rozvržení zobrazuje vzorky ve sloupcích a analýzy v řádcích."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Preferovaný formát vědeckého zápisu pro zprávy"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Preferovaný formát vědecké notace pro výsledky"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4199,7 +4407,7 @@ msgstr "Uchovávání podle typu vzorku"
 msgid "Preserve"
 msgstr "Zachovat"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Ochránce"
 
@@ -4216,11 +4424,11 @@ msgstr "Preventivní"
 msgid "Preventive maintenance procedure"
 msgstr "Postup preventivní údržby"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "Náhled"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4248,7 +4456,7 @@ msgstr "Ceník pro"
 msgid "Pricelists"
 msgstr "Ceníky"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4257,7 +4465,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "Primární vzorek"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4279,11 +4487,11 @@ msgstr "Datum tisku:"
 msgid "Print pricelist"
 msgstr "Tisk ceníku"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Tisk štítků"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Tištěno"
 
@@ -4296,7 +4504,7 @@ msgstr "Vytištěno na"
 msgid "Priority"
 msgstr "Priorita"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Profil"
 
@@ -4320,7 +4528,7 @@ msgstr "Název profilu"
 msgid "Profile keyword must be unique"
 msgstr "Klíčové slovo profilu musí být jedinečné"
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Postup"
 
@@ -4329,7 +4537,7 @@ msgstr "Postup"
 msgid "Prominent fields"
 msgstr "Významná pole"
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "Protocol ID"
 
@@ -4337,7 +4545,7 @@ msgstr "Protocol ID"
 msgid "Province"
 msgstr "Provincie"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4346,8 +4554,12 @@ msgstr ""
 msgid "Publish"
 msgstr "Publikovat"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Publikováno"
@@ -4363,6 +4575,10 @@ msgstr "Datum vydání"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Publikované výsledky"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4384,6 +4600,14 @@ msgstr "Výsledky QC"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "ID vzorku QC"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4409,7 +4633,7 @@ msgstr "Znovu zadejte heslo. Ujistěte se, že hesla jsou identická."
 msgid "Reasons for rejection"
 msgstr "Důvody zamítnutí"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Znovu přiřadit"
 
@@ -4421,30 +4645,34 @@ msgstr "Přiřazitelný slot"
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Přijmout"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Přijato"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Čeká se na příjem"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Příjemci"
 
@@ -4495,11 +4723,15 @@ msgstr "Referenční hodnoty"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Hodnoty referenčních vzorků jsou nulové nebo „prázdné“"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registrovat"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4525,9 +4757,9 @@ msgstr "Odmítnout Analýzu"
 msgid "Reject samples"
 msgstr "Odmítnout vzorky"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Odmítnuto"
 
@@ -4543,7 +4775,7 @@ msgstr "Odmítnutý vzorek"
 msgid "Rejected {} samples: {}"
 msgstr "Odmítnuto {} vzorků: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4604,8 +4836,16 @@ msgstr "Vzdálené IP"
 msgid "Remove"
 msgstr "Odstranit"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4641,11 +4881,11 @@ msgstr "ID Zprávy"
 msgid "Report identification number"
 msgstr "Identifikační číslo Zprávy"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4657,7 +4897,7 @@ msgstr "Nahrát Zprávu"
 msgid "Republish"
 msgstr "Znovu publikovat"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "Znovu publikováno po posledním tisku"
 
@@ -4666,7 +4906,7 @@ msgstr "Znovu publikováno po posledním tisku"
 msgid "Request ID"
 msgstr "ID požadavku"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Vyžádat nové analýzy"
 
@@ -4682,24 +4922,37 @@ msgstr "Požadovaný objem"
 msgid "Reset"
 msgstr "Reset"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr "Reset sloupců"
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
 msgstr "Odpovědnosti"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr "Obnovit"
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4724,15 +4977,15 @@ msgstr "Výsledek Hodnota musí být číslo"
 msgid "Result Value must be unique"
 msgstr "Hodnota výsledku musí být jedinečná"
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Výsledek v rozpětí"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Výsledek mimo rozsah"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr "Rozsah výsledků se liší od specifikace: {}"
 
@@ -4740,7 +4993,7 @@ msgstr "Rozsah výsledků se liší od specifikace: {}"
 msgid "Result type"
 msgstr "Typ výsledku"
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Výsledné hodnoty s alespoň tímto počtem platných číslic jsou zobrazeny ve vědeckém zápisu pomocí písmene „e“ pro označení exponentu. Přesnost lze nakonfigurovat v jednotlivých analytických službách."
 
@@ -4756,16 +5009,20 @@ msgstr "Výsledek"
 msgid "Results Interpretation"
 msgstr "Interpretace výsledků"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Výsledky byly staženy"
 
@@ -4773,7 +5030,7 @@ msgstr "Výsledky byly staženy"
 msgid "Results interpretation"
 msgstr "Interpretace výsledků"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Výsledky čekají na vyřízení"
 
@@ -4797,7 +5054,7 @@ msgstr "Znovu testováno"
 msgid "Retract"
 msgstr "Odvolat"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4833,6 +5090,10 @@ msgstr "Zpět k předešlému stavu"
 msgid "Routine Analyses"
 msgstr "Rutinní analýzy"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr "SENAITE CORE"
@@ -4858,6 +5119,7 @@ msgstr "SENAITE LIMS Úvodní strana "
 msgid "SENAITE Registry"
 msgstr "Registr SENAITE"
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4867,7 +5129,7 @@ msgstr "Nastavení SENAITE"
 msgid "SENAITE front-page"
 msgstr "Vstupní strana SENAITE"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "Server SMTP byl odpojen. Vytvoření uživatele bylo přerušeno."
 
@@ -4881,7 +5143,7 @@ msgstr "Oslovení"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Vzorek"
 
@@ -4918,7 +5180,7 @@ msgid "Sample Header"
 msgstr "Záhlaví vzorku"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "ID vzorku"
 
@@ -4938,7 +5200,7 @@ msgstr "Matice vzorků"
 msgid "Sample Partitions"
 msgstr "Oddělky vzorků"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4965,7 +5227,7 @@ msgid "Sample Templates"
 msgstr "Šablony vzorku"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Typ vzorku"
@@ -5026,7 +5288,7 @@ msgstr "Typ vzorku"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Vzorkovač"
 
@@ -5038,8 +5300,8 @@ msgstr "Vzorkovač pro plánovaný odběr vzorků"
 msgid "Sampler required for sample %s"
 msgstr "Vzorkovač potřebný pro vzorek %s"
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Vzorky"
@@ -5056,6 +5318,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5065,7 +5339,23 @@ msgstr "Vzorky tohoto typu by měly být považovány za nebezpečné"
 msgid "Samples rejection reporting form"
 msgstr "Formulář hlášení odmítnutí vzorků"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5073,7 +5363,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Datum vzorkování"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Odchylka odběru vzorků"
@@ -5086,7 +5376,7 @@ msgstr "Odchylky odběru vzorků"
 msgid "Sampling Frequency"
 msgstr "Frekvence odběru vzorků"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "Odběr vzorků je naplánován"
 
@@ -5094,15 +5384,24 @@ msgstr "Odběr vzorků je naplánován"
 msgid "Saturday"
 msgstr "Sobota"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Uložit"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
 msgstr "Uložit a kopírovat"
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5116,7 +5415,7 @@ msgstr "Plán"
 msgid "Schedule sampling"
 msgstr "Plánování odběru vzorků"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Plánovaný odběr vzorků"
@@ -5133,6 +5432,10 @@ msgstr "Odborný název"
 msgid "Search"
 msgstr "Hledat"
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5141,7 +5444,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Sekundy"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5231,11 +5534,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Vyberte šablonu"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Vyberte zemi, ve které se bude web ve výchozím nastavení zobrazovat"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Vyberte měnu, kterou bude web používat k zobrazení cen."
 
@@ -5247,11 +5550,11 @@ msgstr "Vyberte výchozí kontejner, který bude použit pro tuto analytickou sl
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Vyberte výchozí vstupní stránku. To se používá, když se klient přihlásí do systému nebo když je klient vybrán ze seznamu klientských složek."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5259,31 +5562,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr "Vyberte typy, které se toto ID používá k identifikaci."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "Vyberte tuto možnost, chcete-li aktivovat automatická upozornění prostřednictvím e-mailu klientovi, když je vzorek odmítnut."
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "Tuto možnost vyberte, chcete-li aktivovat řídicí panel jako výchozí přední stránku."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Vyberte tuto možnost, chcete-li aktivovat kroky pracovního postupu kolekce vzorků."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Vyberte tuto možnost, aby koordinátor odběru vzorků mohl naplánovat odběr vzorků. Tato funkce se projeví pouze v případě, že je aktivní „Pracovní postup odběru vzorků“"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr "Tuto možnost vyberte, chcete-li uživateli umožnit nastavit dodatečný stav \"Vytištěno\" u těch žádostí o analýzu, které byly zveřejněny. Ve výchozím nastavení zakázáno."
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "Zvolte, chcete-li vzorky automaticky přijímat, když jsou vytvořeny pracovníky laboratoře a pracovní tok odběru vzorků je zakázán. Vzorky vytvořené přes kontakty klienta nebudou automaticky přijímány"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr "Vyberte, zda chcete klientským kontaktům zobrazit ukázkové oddíly. Pokud je tato možnost deaktivována, nebudou oddíly zahrnuty do výpisů a klientským kontaktům se nebude zobrazovat informační zpráva s odkazy na primární vzorek."
 
@@ -5295,7 +5606,7 @@ msgstr "Vyberte, které analýzy se mají na pracovním listu zahrnout"
 msgid "Selection list"
 msgstr "Výběrový seznam"
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Vlastní ověření výsledků"
 
@@ -5307,11 +5618,11 @@ msgstr "Odeslat"
 msgid "Send Analysis Reports via Email"
 msgstr "Odeslat analytické zprávy e-mailem"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5333,7 +5644,7 @@ msgstr "Odesláno na"
 msgid "Separate Container"
 msgstr "Samostatný kontejner"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5347,7 +5658,7 @@ msgstr "Seriové číslo"
 msgid "Service"
 msgstr "Služba"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "Službu nelze zrušit. Kliknutím na tlačítko info získáte další podrobnosti"
 
@@ -5375,7 +5686,7 @@ msgstr "Nastavte pracovní postup Odmítnutí vzorku a důvody"
 msgid "Set the maintenance task as closed."
 msgstr "Nastavte úkol údržby jako uzavřený."
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr "Pokud je aktivována možnost „Oznámení e-mailem o odmítnutí vzorku“, nastavte text pro e-mail, který má být zaslán klientskému kontaktu vzorku. Můžete použít vyhrazená klíčová slova: $sample_id, $sample_link, $reasons, $lab_address"
 
@@ -5423,29 +5734,41 @@ msgstr "Měly by být analýzy z faktury vyloučeny?"
 msgid "Should the default example content be added to the site?"
 msgstr "Měl by být na web přidán výchozí ukázkový obsah?"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr "Zobrazit poslední protokoly automatického importu"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr "Zobrazit více"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
 msgstr "Zobrazit standardní pole"
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5467,11 +5790,11 @@ msgstr "Kód webu"
 msgid "Site Description"
 msgstr "Popis webu"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr "Logo webu"
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr "CSS loga webu"
 
@@ -5492,7 +5815,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Malý štítek"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5509,6 +5832,14 @@ msgstr "Některé analýzy používají zastaralé nebo nekalibrované přístro
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Třídit klíč"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5534,7 +5865,7 @@ msgstr "Rozsahy specifikací se od přiřazení změnily"
 msgid "Specifications"
 msgstr "Specifikace"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5542,7 +5873,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Určete velikost pracovního listu, např. odpovídající velikosti zásobníku pro konkrétní přístroj. Poté vyberte „typ“ analýzy pro každou pozici pracovního listu. Pokud jsou vybrány vzorky QC, také vyberte, který referenční vzorek by měl být použit. Pokud je vybrána duplicitní analýza, uveďte, která pozice vzorku by měla být duplikátem"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5559,17 +5890,17 @@ msgstr "Datum zahájení"
 msgid "Start date must be before End Date"
 msgstr "Datum zahájení musí být před datem ukončení"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Stav"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Stav"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Štítek"
@@ -5578,7 +5909,11 @@ msgstr "Štítek"
 msgid "Stickers preview"
 msgstr "Náhled štítků"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Umístění úložiště"
@@ -5618,7 +5953,11 @@ msgstr "Odeslat"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr "Chcete-li pokračovat, odešlete platný soubor Open XML (.XLSX) obsahující záznamy o nastavení."
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "Odesláno a ověřeno stejným uživatelem: {}"
 
@@ -5626,7 +5965,7 @@ msgstr "Odesláno a ověřeno stejným uživatelem: {}"
 msgid "Submitter"
 msgstr "Zadavatel"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Mezisoučet"
@@ -5668,7 +6007,7 @@ msgstr "Přepnout na ovládací panel"
 msgid "Switch to transposed view"
 msgstr "Přepnout do převráceného zobrazení"
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "Systémově výchozí"
 
@@ -5694,7 +6033,7 @@ msgstr "Daně"
 msgid "Technical description and instructions intended for analysts"
 msgstr "Technický popis a pokyny určené analytikům"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5776,7 +6115,7 @@ msgstr "Datum, kdy byl vzorek uchován"
 msgid "The date when the sample was received"
 msgstr "Datum, kdy byl vzorek přijat"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Bude použita desetinné znaménko vybrané v nastavení Bika."
 
@@ -5784,7 +6123,7 @@ msgstr "Bude použita desetinné znaménko vybrané v nastavení Bika."
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr "Výchozí nastavení časového pásma portálu. Uživatelé si budou moci nastavit vlastní časové pásmo, pokud jsou v nastavení data a času definována dostupná časová pásma."
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "Zde zadané procento slevy se vztahuje na ceny pro klienty označené jako „členové“, běžně spolupracující členové nebo spolupracovníci, kteří si tuto slevu zaslouží"
 
@@ -5812,7 +6151,11 @@ msgstr "Z tohoto vzorku byly vytvořeny následující oddělky:"
 msgid "The following sample(s) will be dispatched"
 msgstr "Budou odeslány tyto vzorky (odeslán tento vzorek)"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr "Globální Auditlog zobrazuje všechny změny systému. Pokud je tato funkce povolena, budou všechny entity indexovány v samostatném katalogu. Tím se zvýší čas při vytváření nebo úpravě objektů."
 
@@ -5820,11 +6163,11 @@ msgstr "Globální Auditlog zobrazuje všechny změny systému. Pokud je tato fu
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Výška nebo hloubka, ve které musí být vzorek odebrán"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr "Doba uchovávání tohoto vzorku a analýzy uplynula. Pokračování v analýze může ohrozit spolehlivost výsledků."
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr "Doba uchovávání tohoto vzorku a analýzy právě vyprší. Analýzu dokončete co nejdříve, aby byla zajištěna přesnost a spolehlivost údajů."
 
@@ -5861,11 +6204,11 @@ msgstr "Minimální objem vzorku potřebný pro analýzu, např.  '10 ml' nebo '
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Počet dní před vypršením platnosti vzorku a již nelze analyzovat. Toto nastavení lze přepsat na jednotlivé typy vzorků v nastavení typů vzorků"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Počet minut před automatickým odhlášením uživatele. 0 deaktivuje automatické odhlášení"
 
@@ -5905,7 +6248,7 @@ msgstr "Referenční kód, který laboratoři vydává akreditační orgán"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "Výsledek po provedení výpočtu se zkušebními hodnotami. Před výpočtem této hodnoty budete muset uložit výpočet."
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr "Výsledek byl zachycen po uplynutí časového limitu."
 
@@ -5929,11 +6272,11 @@ msgstr "Vzorek je směsí dílčích vzorků"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Sériové číslo, které jedinečně identifikuje nástroj"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "ID analytického protokolu služby"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "Obchodní ID služby pro účely účetnictví"
 
@@ -5985,11 +6328,11 @@ msgstr "Toto je sekundární vzorek"
 msgid "This is a detached partition from Sample"
 msgstr "Toto je oddělený oddělek od vzorku"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "Toto je výchozí maximální čas povolený pro provádění analýz. Používá se pouze pro analýzy, kde analytická služba nestanoví časový cyklus. Zohledňují se pouze laboratorní pracovní dny."
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6013,11 +6356,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr "Tuto službu nelze zvolit, aby se zabránilo provedení analýzy po uplynutí doby uchovávání analýzy."
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr "Tím se na webu SENAITE zobrazí vlastní logo."
 
@@ -6049,8 +6392,8 @@ msgstr "Čas"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Tip: Připojené dokumenty nebudou načteny, pokud nejsou v instanci."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Název"
@@ -6077,34 +6420,42 @@ msgstr "Název webu"
 msgid "To"
 msgstr "do"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "K zachování"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "K odběru vzorků"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Zobrazí se pod každou částí Kategorie analýz ve zprávách o výsledcích."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Bude zachováno"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "K tisku"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "K odběru vzorků"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Bude ověřeno"
@@ -6117,7 +6468,7 @@ msgstr "Chcete-li provést výpočet, zadejte zde hodnoty pro všechny parametry
 msgid "Toggle visibility of standard sample header fields"
 msgstr "Přepínání viditelnosti standardních polí záhlaví vzorku"
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Celkem"
 
@@ -6139,7 +6490,7 @@ msgid "Tuesday"
 msgstr "Úterý"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Typ"
@@ -6164,6 +6515,10 @@ msgstr "Typ kontejneru"
 msgid "Type to filter ..."
 msgstr "Zadejte filtrování..."
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr "Typy, které přímo podporují štítky.<br/>POZNÁMKA: V nastaveních clusteru je třeba ručně restartovat ostatní instance, aby se změny provedly!"
@@ -6172,7 +6527,7 @@ msgstr "Typy, které přímo podporují štítky.<br/>POZNÁMKA: V nastaveních 
 msgid "Types with labels"
 msgstr "Typy se štítky"
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6184,6 +6539,7 @@ msgstr "Šablonu nelze načíst"
 msgid "Unassign"
 msgstr "Nepřiřadit"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Nepřiřazeno"
@@ -6216,9 +6572,13 @@ msgstr "Neznámý IBAN země %s"
 msgid "Unlink User"
 msgstr "Odpojit Uživatele"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
 msgstr "Odpojený Uživatel"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6234,13 +6594,17 @@ msgstr "Nerozpoznaný formát souboru ${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr "Nerozpoznaný formát souboru ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "Nepřiřazeno"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Aktualizovat přílohy"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6250,7 +6614,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Nahrajte naskenovaný podpis, který se použije v tištěných zprávách o výsledcích analýz. Ideální velikost je 250 pixelů na šířku a 150 na výšku"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6258,7 +6622,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Použít cenu analýzy profilu"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Jako výchozí vstupní stránku použijte Ovládací panel"
 
@@ -6296,7 +6660,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "Uživatel propojený s tímto kontaktem"
 
@@ -6304,15 +6668,15 @@ msgstr "Uživatel propojený s tímto kontaktem"
 msgid "User name"
 msgstr "Uživatelské jméno"
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Použití příliš malého počtu datových dat nedává statistický smysl. Před přijetím a vynesením statistik QC nastavte přijatelný minimální počet výsledků"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6320,7 +6684,7 @@ msgstr "DPH"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "DPH %"
 
@@ -6567,8 +6931,8 @@ msgstr "Hodnota pro sekundy musí být v rozmezí 0 až 59,9999."
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Zde lze zadat hodnoty, které přepíší výchozí hodnoty zadané v mezipolohách výpočtu."
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Ověřeno"
@@ -6577,11 +6941,19 @@ msgstr "Ověřeno"
 msgid "Verified By"
 msgstr "Ověřeno"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Ověřit"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6596,6 +6968,14 @@ msgstr "Zobrazit"
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
 msgstr "Zobrazit stránky SENAITE"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr ""
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -6630,6 +7010,10 @@ msgstr "Webová stránka"
 msgid "Wednesday"
 msgstr "Středa"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Týdnů do expirace"
@@ -6642,19 +7026,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr "Vítejte v SENAITE"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr "Je-li tato funkce povolena, vzorek se automaticky ověří, jakmile jsou ověřeny všechny výsledky. V opačném případě musí uživatelé s dostatečnými právy vzorek následně ověřit ručně. Výchozí nastavení: povoleno"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6705,10 +7089,18 @@ msgstr "Šablony pracovního listu"
 msgid "Worksheet printing templates order"
 msgstr "Pořadí šablon pro tisk pracovních listů"
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Pracovní listy"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6717,6 +7109,10 @@ msgstr "Chybná délka IBAN o %s: %s"
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Špatná délka IBAN podle %s : %s zkratka po %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6800,6 +7196,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6904,8 +7304,17 @@ msgstr "dní"
 msgid "deactivate"
 msgstr "deaktivovat"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr "description_Labels"
 
@@ -6970,7 +7379,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7139,33 +7548,33 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 #, fuzzy
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr "description_bikasetup_always_cc_responsibles_in_report_emails"
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr "description_bikasetup_categorizesampleanalyses"
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 #, fuzzy
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr "description_bikasetup_email_body_sample_publication"
@@ -7173,14 +7582,14 @@ msgstr "description_bikasetup_email_body_sample_publication"
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 #, fuzzy
 msgid "description_bikasetup_immediateresultsentry"
 msgstr "description_bikasetup_immediateresultsentry"
@@ -7193,19 +7602,19 @@ msgstr "description_bikasetup_immediateresultsentry"
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr "description_bikasetup_sampleanalysesrequired"
 
@@ -7226,16 +7635,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7260,12 +7674,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7275,7 +7689,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7378,6 +7792,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7407,6 +7834,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7553,12 +7987,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7811,7 +8245,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7819,109 +8253,109 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 #, fuzzy
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr "description_senaitesetup_always_cc_responsibles_in_report_emails"
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr "description_senaitesetup_categorizesampleanalyses"
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 #, fuzzy
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr "description_senaitesetup_immediateresultsentry"
@@ -7929,21 +8363,21 @@ msgstr "description_senaitesetup_immediateresultsentry"
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 #, fuzzy
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr "description_senaitesetup_maxnumberofsamplesadd"
@@ -7951,35 +8385,35 @@ msgstr "description_senaitesetup_maxnumberofsamplesadd"
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 #, fuzzy
 msgid "description_senaitesetup_publication_email_text"
 msgstr "description_senaitesetup_publication_email_text"
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7987,47 +8421,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr "description_senaitesetup_sampleanalysesrequired"
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8036,20 +8470,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8057,32 +8491,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8090,21 +8524,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8260,6 +8694,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8573,7 +9011,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr "label_Labels"
 
@@ -8634,7 +9072,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8750,52 +9188,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr "label_bikasetup_always_cc_responsibles_in_report_emails"
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr "label_bikasetup_categorizesampleanalyses"
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr "label_bikasetup_email_body_sample_publication"
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr "label_bikasetup_immediateresultsentry"
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr "label_bikasetup_sampleanalysesrequired"
 
@@ -8865,12 +9303,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8880,7 +9318,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9176,7 +9614,7 @@ msgid "label_powered_by_plone"
 msgstr "label_powered_by_plone"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9301,12 +9739,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9516,7 +9954,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr "label_save"
 
@@ -9526,12 +9964,12 @@ msgid "label_senaite"
 msgstr "label_senaite"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr "label_senaitesetup_maxnumberofsamplesadd"
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9589,6 +10027,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10765,87 +11219,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10898,6 +11352,11 @@ msgstr ""
 msgid "minutes"
 msgstr "minut"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "měsíčně"
@@ -10948,13 +11407,21 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "z "
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "přehled"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11032,6 +11499,11 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
 msgstr "this_sample_has_been_dispatched_by"
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
+msgstr ""
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11265,13 +11737,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11358,6 +11835,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11603,222 +12085,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr "title_senaitesetup_always_cc_responsibles_in_report_emails"
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr "title_senaitesetup_categorizesampleanalyses"
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr "title_senaitesetup_publication_email_text"
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr "title_senaitesetup_sampleanalysesrequired"
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12072,7 +12554,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "čeká (se) na ověření"
 
@@ -12115,7 +12597,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr "{} (zastaralé)"
 

--- a/src/senaite/core/locales/cs/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/cs/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Czech (https://app.transifex.com/senaite/teams/87045/cs/)\n"

--- a/src/senaite/core/locales/da_DK/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/da_DK/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Danish (Denmark) (https://app.transifex.com/senaite/teams/87045/da_DK/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/da_DK/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/da_DK/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Danish (Denmark) (https://app.transifex.com/senaite/teams/87045/da_DK/)\n"

--- a/src/senaite/core/locales/da_DK/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/da_DK/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Danish (Denmark) (https://app.transifex.com/senaite/teams/87045/da_DK/)\n"

--- a/src/senaite/core/locales/da_DK/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/da_DK/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Danish (Denmark) (https://app.transifex.com/senaite/teams/87045/da_DK/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: da_DK\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Kontotype"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Aktiv"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Tilføj"
 
@@ -284,15 +290,19 @@ msgstr "Tilføj Dublet"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Alle tildelte analyser"
 
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
+
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analyser"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr "Alle"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr ""
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Anvend template"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,18 +606,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Tildelt"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Automatisk log-off"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Bearing"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Faktura adresse"
@@ -800,7 +845,7 @@ msgstr "Mærke"
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr "Business Phone"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC emails"
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Annulleret"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Katalognummer"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr ""
 msgid "Classic"
 msgstr "Klassisk"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Kunde"
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Kunde ID"
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Kunde Ordre"
 
@@ -1126,7 +1185,7 @@ msgstr "Kunde Ordre"
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Kunde ref"
 
@@ -1135,7 +1194,7 @@ msgstr "Kunde ref"
 msgid "Client Reference"
 msgstr "Kunde reference"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Kunde SID"
 
@@ -1228,7 +1287,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Bekæft password"
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kontakt"
@@ -1328,7 +1391,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1473,7 +1540,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1481,12 +1548,20 @@ msgstr ""
 msgid "Current"
 msgstr "aktuelle"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Dato Åbnet"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Offentliggjort den"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Modtagedato"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr "Dato mangler"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Dato for sampling"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Normal prøve opbevaring periode"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Default værdi"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Grader"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Afhængige analyser"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Beskrivelse"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "afsendt"
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Placeret"
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Forfald"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Forfaldsdato"
@@ -2010,7 +2110,7 @@ msgstr "Dupliker"
 msgid "Duplicate Analysis"
 msgstr "Kopier Analyser"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr "E.g. SANAS, APLAC, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr "Højde"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Emailadresse"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr "Indtast rabat procentværdi"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr "Indtast procentværdi f.eks. 14,0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Angiv procentværdi fx. 14,0. Denne procentsats anvendes i hele systemet, men kan overskrives på den enkelte vare"
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Udelad fra faktura"
 
@@ -2279,7 +2392,7 @@ msgstr "Udelad fra faktura"
 msgid "Expected Result"
 msgstr "Forventet resultat"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr "Udløbsdato"
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr "Eksporter"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr "Fornavn"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Fulde navn"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr "Farlige - Hazardous"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr "Titel"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr "Nøgle"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Nøgleord"
 
@@ -3012,6 +3153,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Nøgleorderne"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3056,8 +3201,8 @@ msgstr "Lab-produkter"
 msgid "Lab URL"
 msgstr "Lab URL"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr "laboratorie"
 msgid "Laboratory Accredited"
 msgstr "Laboratorium akkrediteret"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Stor mærkat"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Sen"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Sene analyser"
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr "Mand"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr "Manager email"
 msgid "Manager Phone"
 msgstr "Manager telefon"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr "Max tid"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Medlem rabat%"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Medlem rabat gælder"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr "Minimum 5 tegn."
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Navn"
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Intet"
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Åben"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Opsamlingsted"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr "Pris for"
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr "Print prisliste"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Profil"
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Offentliggjort"
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Modtaget"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registrer"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "Request ID"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Request ny analyser"
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Resultat out of range"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr "Restested"
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr "Tiltale"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Prøve"
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "PrøveID"
 
@@ -4937,7 +5199,7 @@ msgstr "Prøvematrix"
 msgid "Sample Partitions"
 msgstr "Prøve Partitions"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Prøvetype"
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Prøver"
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Prøveudtagningensdato"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Sampling Afvigelse"
@@ -5085,7 +5375,7 @@ msgstr "Sampling Afvigelser"
 msgid "Sampling Frequency"
 msgstr "Prøveudtagningen frekvens"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Gem"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Sekunder"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Vælg template"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr "Serial Nr."
 msgid "Service"
 msgstr "Service"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Lille mærkat"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Tilstand"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Status"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Mærket"
@@ -5577,7 +5908,11 @@ msgstr "Mærket"
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr "Indsend"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotal"
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Titel"
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "To Be Preserved"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "To be verified"
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Type"
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Ikke tildelt"
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr "Moms"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "Moms%"
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "verificeret"
@@ -6576,10 +6940,18 @@ msgstr "verificeret"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,10 +7088,18 @@ msgstr "Arbejdsark Templates"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Arbejdsark"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/de/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/de/LC_MESSAGES/plone.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: German (https://app.transifex.com/senaite/teams/87045/de/)\n"
@@ -924,6 +924,11 @@ msgstr "Brauchen Sie einen Account?"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
 msgstr "Keine Datei"
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
+msgstr "Kein Bild"
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82

--- a/src/senaite/core/locales/de/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/de/LC_MESSAGES/plone.po
@@ -144,7 +144,7 @@ msgstr "Server:"
 #: senaite/core/browser/controlpanel/templates/overview.pt:16
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:13
 msgid "Site Setup"
-msgstr "Systemkonfiguration"
+msgstr "Setup"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Site title"

--- a/src/senaite/core/locales/de/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/de/LC_MESSAGES/plone.po
@@ -928,7 +928,7 @@ msgstr "Keine Datei"
 #. Default: "No image"
 #: senaite/core/z3cform/widgets/namedimage/display.pt:17
 msgid "no_image"
-msgstr ""
+msgstr "Kein Bild"
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82

--- a/src/senaite/core/locales/de/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/de/LC_MESSAGES/plone.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: German (https://app.transifex.com/senaite/teams/87045/de/)\n"
@@ -928,7 +928,7 @@ msgstr "Keine Datei"
 #. Default: "No image"
 #: senaite/core/z3cform/widgets/namedimage/display.pt:17
 msgid "no_image"
-msgstr "Kein Bild"
+msgstr ""
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82

--- a/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: German (https://app.transifex.com/senaite/teams/87045/de/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: de\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr "<p>Der ID-Server stellt eindeutige fortlaufende IDs für Objekte wie Proben und Arbeitsblätter usw. bereit, basierend auf einem für jeden Inhaltstyp festgelegten Format.</p><p>Das Format ist ähnlich wie die Syntax des Python-Formats aufgebaut, wobei vordefinierte Variablen verwendet werden pro Inhaltstyp und Erweitern der IDs durch eine Sequenznummer, 'seq' und ihre Auffüllung als eine Anzahl von Ziffern, z.B. '03d' für eine Folge von IDs von 001 bis 999.</p><p>Alphanumerische Präfixe für IDs sind unverändert in den Formaten enthalten, z. WS for Worksheet in WS-{seq:03d} erzeugt fortlaufende Worksheet-ID\\: WS-001, WS-002, WS-003 usw.</p><p>Für die dynamische Generierung von alphanumerischen und sequenziellen IDs ist der Platzhalter {alpha} verwendet werden. Beispiel: WS-{alpha:2a3d} erzeugt WS-AA001, WS-AA002, WS-AB034 usw.</p><p>Zu den verwendbaren Variablen gehören\\:<table><tr><th style=' width\\:150px'>Inhaltstyp</th><th>Variablen</th></tr><tr><td>Client-ID</td><td>{clientId}</td></tr> <tr><td>Jahr</td><td>{Jahr}</td></tr><tr><td>Proben-ID</td><td>{sampleId}</td></tr><tr><td>Probentyp</td><td>{sampleType}</td></tr><tr><td>Probenahmedatum</td><td>{samplingDate}</td>< /tr><tr><td>Datum der Stichprobe</td><td>{dateSampled}</td></tr></table></p><p>Konfigurationseinstellungen\\:<ul><li> format:<ul><li>ein Python-Formatstring, der aus vordefinierten Variablen wie sampleId, clientId, sampleType aufgebaut ist.</li><li>die spezielle Variable „seq“ muss im Formatstring an letzter Stelle stehen</li></ul></li><li>sequence type: [generated|counter]</li><li>context: wenn type counter, liefert Kontext die Zählfunktion</li><li>counter type: [backreference| enthalten]</li><li>counter reference: ein Parameter für die Zählfunktion</li><li>prefix: Standard-Präfix, falls  keiner angegeben in format string</li><li>split length: die Anzahl der Teile, die im Präfix enthalten sein sollen</li></ul></p>"
 
@@ -30,6 +30,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} Anlage(n) mit einer Gesamtgröße von ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -55,6 +56,7 @@ msgid "%s has no '%s' column."
 msgstr "% hat keine '%' Spalte."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Zurück"
@@ -124,6 +126,10 @@ msgstr "*** Dies ist eine automatisch generierte E-Mail. Bitte antworten Sie nic
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr "-- Auswählen --"
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr "... Prüfgerät auswählen ..."
@@ -141,7 +147,7 @@ msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Zur Konfiguration von A
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Willkommen bei SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr "<p>Der ID-Server vergibt eindeutige fortlaufende IDs für Objekte wie Proben, Arbeitsblätter etc. anhand eines pro Inhaltstyp festgelegten Formats. Das Format folgt der Python-Format-Syntax, z.B. erzeugt <code>WS-{seq:03d}</code> die IDs <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> usw.</p><p>Die aktuellen Zählerstände werden in der <a href='ng'>Nummerngenerator-Ansicht</a> verwaltet.</p><details class='id-server-cheatsheet'><summary>Verfügbare Variablen</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Beschreibung</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numerische Sequenznummer, optional mit führenden Nullen.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumerischer Zähler, z.B. liefert <code>{alpha:2a3d}</code> AA001, AA002, …, AB001, …</td></tr><tr><td><code>{year}</code></td><td>Zweistelliges aktuelles Jahr (z.B. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Aktuelles Datum als <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Kunden-ID (nur Proben).</td></tr><tr><td><code>{sampleType}</code></td><td>Präfix des Probentyps.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Probendaten (Python-<code>strftime</code>-Angaben werden unterstützt).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>Für Partitionen/Wiederholungen/Sekundärproben: ID der übergeordneten Probe.</td></tr><tr><td><code>{partition_count}</code></td><td>Zähler je übergeordneter Probe für Partitionen.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Zähler für Wiederholungen, Sekundärproben und Gesamt.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Konfigurationsfelder</summary><ul><li><strong>Format</strong>: die ID-Vorlage.</li><li><strong>Seq-Typ</strong>: <code>generated</code> nutzt den persistenten Zähler; <code>counter</code> nutzt die Anzahl verknüpfter Objekte.</li><li><strong>Kontext</strong>: nur bei Typ <code>counter</code> verwendet; der benannte Kontext, auf den der Zähler zutrifft.</li><li><strong>Zähler-Typ</strong>: <code>backreference</code> (veraltet) oder <code>contained</code>.</li><li><strong>Zähler-Ref</strong>: Beziehungsname (backreference) oder Meta-Typ (contained).</li><li><strong>Präfix</strong>: Standard-Präfix, falls keines im Format definiert ist.</li><li><strong>Split-Länge</strong>: wie viele Segmente des Formats das Speicher-Präfix bilden. Bestimmt, wie der Zähler partitioniert wird (z.B. pro Jahr, pro Probentyp).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 
@@ -204,7 +210,7 @@ msgid "Account Type"
 msgstr "Kontentyp"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr "Buchhaltung"
 
@@ -249,21 +255,21 @@ msgstr "Aktivieren"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Aktiv"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Ausführender User"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr "Vollständiger Name des Ausführenden"
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -291,15 +297,19 @@ msgstr "Wiederholungsmessung hinzufügen"
 msgid "Add Samples"
 msgstr "Proben hinzufügen"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr "Bemerkung hinzufügen..."
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Bemerkungsfeld zu allen Analysen hinzufügen"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "Eigene CSS Regeln für das Logo setzen, z.B. height:15px; width:150px;"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "Standard Etiketten hinzufügen"
 
@@ -312,8 +322,11 @@ msgstr "Neuen Anhang hinzufügen"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Fügen Sie einen oder mehrere Anhänge zu diesem Analysenauftrag hinzu, um Ihre Probe genauer zu beschreiben."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr "Etiketten der ausgewählten Proben hinzufügen oder entfernen"
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Anmerkungen hinzufügen"
 
@@ -377,13 +390,21 @@ msgstr "Hier sind alle akkreditierten Analyseleistungen aufgelistet."
 msgid "All Analyses of Service"
 msgstr "Alle Analysen zur Analysenleistung"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Alle zugeordneten Analysen"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr "Alle Spalten sind ausgeblendet."
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Manuelle Eingabe der Erfassungsgrenze erlauben."
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr "Manuelle Eingabe erlauben"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -401,11 +422,11 @@ msgstr "Erlaube dem gleichen Benutzer mehrfaches verifizieren"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Erlaube dem gleichen Benutzer mehrfaches verifizieren, jedoch nicht aufeinanderfolgend"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Erlaube Selbstverifizierung der Ergebnisse"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr "Ergebniserfassung für nicht zugewiesene Analysen erlauben"
 
@@ -434,15 +455,31 @@ msgstr "Erlaubte Probenzustände: {allowed_states}, "
 msgid "Analysed by"
 msgstr "Analysiert von"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analysen"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr "Analysen, die einem Arbeitsblatt zugewiesen sind und auf Ergebnisse warten"
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr "Analysen, die in einem veröffentlichten Bericht enthalten sind"
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr "Analysen, die noch keinem Arbeitsblatt zugewiesen sind"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Analysen angefragt"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr "Analysen, die verifiziert wurden"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -511,7 +548,7 @@ msgstr "Analysebedingungen"
 msgid "Analysis conditions updated: {}"
 msgstr "Analysebedingungen aktualisiert: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Analysenspezifikationen die direkt auf der Probe editiert werden können."
 
@@ -548,7 +585,7 @@ msgstr "Analytiker muss angegeben werden"
 msgid "Any"
 msgstr "Beliebig"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "Aussehen"
 
@@ -559,6 +596,10 @@ msgstr "Anwenden"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Vorlage anwenden"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr "Diesen Filter anwenden"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -572,19 +613,15 @@ msgstr "Prüfmittelnummer"
 msgid "Assign"
 msgstr "Zuweisen"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Zugewiesen"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Zugewiesen an: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Zuweisung ausstehend"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -598,7 +635,7 @@ msgstr "An die Probe anhängen"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr "Datei '{filename}' dem Arbeitsblatt {worksheet} angehängt"
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr "Angehängte Etiketten"
 
@@ -686,11 +723,15 @@ msgstr "Verhalten für automatische Generierung der ID von Dexterity-Inhalte"
 msgid "Auto-Import Logs"
 msgstr "Auto-Import Logs"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr "Beim Öffnen automatisch anwenden"
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Automatische Partitionierung bei Empfang"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Proben automatisch empfangen"
 
@@ -698,15 +739,15 @@ msgstr "Proben automatisch empfangen"
 msgid "Autofill"
 msgstr "Automatisch ausfüllen"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr "Automatischer Etikettendruck"
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Automatische Abmeldung"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr "Automatisierte Verifikation für Proben"
 
@@ -757,7 +798,7 @@ msgstr "Batch"
 msgid "Batch Book"
 msgstr "Batch Laborbuch"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Batch ID"
 
@@ -787,6 +828,10 @@ msgstr "Beachten Sie, dass die Bereiche, die in der Tabellenkalkulationsdatei au
 msgid "Bearing"
 msgstr "Lager"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr "Halbjährlich"
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Rechnungsadresse"
@@ -807,7 +852,7 @@ msgstr "Marke"
 msgid "Bulk Discount"
 msgstr "Mengenrabatt"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Mengenrabatt anwenden"
@@ -825,19 +870,19 @@ msgstr "Telefon (geschäftlich)"
 msgid "Business address"
 msgstr "Geschäftsadresse"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr "Aufsteigend durch \"Anzeigewert\""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr "Absteigend durch \"Anzeigewert\""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr "Aufsteigend durch \"Ergebniswert\""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr "Absteigend durch \"Ergebniswert\""
 
@@ -845,12 +890,12 @@ msgstr "Absteigend durch \"Ergebniswert\""
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr "Kontakte in Kopie"
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC E-Mails"
 
@@ -906,23 +951,23 @@ msgstr "Kalibrierungen"
 msgid "Calibrator"
 msgstr "Kalibrator"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "kann verifiziert werden, wurde aber vom aktuellen Benutzer eingereicht"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Kann erneut verifiziert werden, wurde bereits durch aktuellen Benutzer verifiziert"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Stornieren"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Storniert"
 
@@ -942,15 +987,15 @@ msgstr "Probe ${sample_id} kann nicht ungültig gesetzt werden: ${error}"
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr "Für ${sample_id} kann keine E-Mail gesendet werden: ${error}"
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "Kann nicht verifiziert werden, es wurde bereits durch den aktuellen Benutzer verifiziert"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "Kann nicht verifiziert werden, es wurde bereits durch den aktuellen Benutzer eingereicht"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "Kann nicht verifiziert werden, es wurde durch den aktuellen Benutzer verifiziert"
 
@@ -976,7 +1021,7 @@ msgstr "Katalogisieren Sie Dexterity-Inhalte in mehreren Katalogen"
 msgid "Catalogue Number"
 msgstr "Katalognummer"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Analyseleistungen kategorisieren"
 
@@ -1008,11 +1053,11 @@ msgid "Changes Saved"
 msgstr "Änderungen gespeichert"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Änderungen gespeichert."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Änderungen werden an die Partitionen durchgereicht"
 
@@ -1049,31 +1094,31 @@ msgstr "Checkbox"
 msgid "Choices"
 msgstr "Auswahlmöglichkeiten"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr "Standardvorlage für 'große' Etiketten auswählen. Hinweis: Probentypspezifische 'große' Etiketten werden anhand des Probentyps konfiguriert."
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr "Standardvorlage für 'große' Etiketten auswählen.<br/><strong>Hinweis:</strong> Probentypspezifische 'große' Etiketten werden anhand des Probentyps konfiguriert."
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr "Standardvorlage für 'kleine' Etiketten auswählen. Hinweis: Probentypspezifische 'kleine' Etiketten werden anhand des Probentyps konfiguriert."
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr "Standardvorlage für 'kleine' Etiketten auswählen.<br/><strong>Hinweis:</strong> Probentypspezifische 'kleine' Etiketten werden anhand des Probentyps konfiguriert."
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Wählen Sie die Methode für mehrfache Verifikation durch den selben Benutzer. Diese Einstellung kann die einfache bzw. mehrfache Verifikation durch den selben Benutzer aktivieren oder deaktivieren."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr "Auswählen, wann Etiketten automatisch gedruckt werden sollen:<br/><ul><li><strong>Registrieren:</strong> Etiketten werden automatisch gedruckt, wenn neue Proben erstellt werden.</li><li><strong>Empfangen:</strong> Etiketten werden automatisch gedruckt, wenn Proben empfangen werden.</li><li><strong>Keine:</strong> Deaktiviert den automatischen Etikettendruck.</li></ul>"
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr "Auswählen, wann Etiketten automatisch gedruckt werden sollen:<br/><ul><li><strong>Registrieren:</strong> Etiketten werden automatisch gedruckt, wenn neue Proben erstellt werden.</li><li><strong>Empfangen:</strong> Etiketten werden automatisch gedruckt, wenn Proben empfangen werden.</li><li><strong>Keine:</strong> Deaktiviert den automatischen Etikettendruck.</li></ul>"
 
@@ -1086,20 +1131,34 @@ msgstr "Stadt"
 msgid "Classic"
 msgstr "Klassisch"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr "Filter zurücksetzen"
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr "Suche zurücksetzen"
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "Auswahl aufheben"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Klicken um diese Kategorie zu erweitern"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr "Klicken, um diesen Filter zu lösen"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "Klicken um die Sichtbarkeit zu wechseln oder Drag&Drop um die Reihenfolge zu ändern"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Kunde"
@@ -1111,7 +1170,7 @@ msgstr "Kunden Batch ID"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Kunden-ID"
 
@@ -1123,7 +1182,7 @@ msgstr "Kunden-Startseite"
 msgid "Client Name"
 msgstr "Kundenname"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Kundenbestellung"
 
@@ -1133,7 +1192,7 @@ msgstr "Kundenbestellung"
 msgid "Client Order Number"
 msgstr "Kundenbestellnummer"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Kundenreferenz"
 
@@ -1142,7 +1201,7 @@ msgstr "Kundenreferenz"
 msgid "Client Reference"
 msgstr "Kundenreferenz"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Kunden-Proben-ID"
 
@@ -1221,7 +1280,7 @@ msgstr "Spalte '{}' fehlt"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
 msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
-msgstr ""
+msgstr "Spalte {} der Kopfzeile hat keinen Namen. Bitte entfernen Sie leere Spalten aus der Tabelle und laden Sie sie erneut hoch."
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
@@ -1235,7 +1294,7 @@ msgstr "Kommentare"
 msgid "Comments or results interpretation"
 msgstr "Kommentare oder Ergebnisinterpretation"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "HRG-Nr"
@@ -1273,9 +1332,13 @@ msgstr "Konfiguration für die Informationen, die im Kopfbereich in der Probe an
 msgid "Configuration restored to default values."
 msgstr "Konfiguration auf Standardwerte zurückgesetzt"
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr "Konfigurieren"
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
-msgstr "Spalten konfigurieren"
+msgstr "Tabellenüberschriften konfigurieren"
 
 #: bika/lims/content/artemplate.py:173
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
@@ -1291,7 +1354,7 @@ msgstr "Passwort bestätigen"
 msgid "Considerations"
 msgstr "Zu beachten"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kontakt"
@@ -1335,7 +1398,7 @@ msgstr "Probenbehälter"
 msgid "Contents of the file {}"
 msgstr "Inhalte der Datei {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr "Kontext"
 
@@ -1368,15 +1431,15 @@ msgstr "Analyseleistungen kopieren"
 msgid "Copy from"
 msgstr "Kopieren von"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr "Den aktuell angezeigten Spaltenwert in die anderen Spalten rechts kopieren"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr "Den Wert der ersten Probe in die anderen Proben kopieren"
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Kopie erzeugen"
 
@@ -1387,6 +1450,10 @@ msgstr "Konnte {} Wert(e) nicht in Ganzzahl umwandeln: {}"
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
 msgstr "Folgende Probe(n) konnten aufgrund von Transaktionskonflikten nicht angelegt werden, bitte erneut versuchen: ${rows}"
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
+msgstr "Benutzer konnte nicht verknüpft werden: ${error}"
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
@@ -1404,11 +1471,11 @@ msgstr "Proben konnten nicht in den Status \"beprobt\" überführt werden"
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr "Zähler <span class=\"sort-indicator\" />"
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr "Zählerreferenz"
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr "Zählertyp"
 
@@ -1421,7 +1488,7 @@ msgstr "Land"
 msgid "Create Invoice PDF"
 msgstr "Erzeuge PDF-Rechnung"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Partitionen erzeugen"
 
@@ -1429,7 +1496,7 @@ msgstr "Partitionen erzeugen"
 msgid "Create SENAITE Site"
 msgstr "SENAITE Seite erstellen"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr "Arbeitsblatt anlegen"
 
@@ -1441,7 +1508,7 @@ msgstr "Neue SENAITE Seite erstellen"
 msgid "Create a new User"
 msgstr "Einen neuen Benutzer anlegen"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr "Neues Arbeitsblatt mit ausgewählten Proben erstellen"
 
@@ -1471,7 +1538,7 @@ msgid "Created {} partitions: {}"
 msgstr "{} Partitionen erzeugt: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Ersteller"
 
@@ -1480,7 +1547,7 @@ msgstr "Ersteller"
 msgid "Criteria"
 msgstr "Kriterium"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Währung"
 
@@ -1488,13 +1555,21 @@ msgstr "Währung"
 msgid "Current"
 msgstr "Aktuell"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr "Aktuelle Ansicht weicht von der gespeicherten ab"
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Standard Dezimaltrenner"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "DL"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr "Täglich"
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1541,23 +1616,23 @@ msgstr "Modifikationsdatum"
 msgid "Date Opened"
 msgstr "Öffnungsdatum"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Konservierungsdatum"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Druckdatum"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Veröffentlichungsdatum"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Empfangsdatum"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Registrierdatum"
 
@@ -1569,11 +1644,11 @@ msgstr "Auftragsdatum"
 msgid "Date Sample Received"
 msgstr "Probenempfangsdatum"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Probenahmedatum"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Verifizierungsdatum"
 
@@ -1615,7 +1690,7 @@ msgstr "Datum an dem das Kalibrierzertifikat freigegeben wurde"
 msgid "Date when the certificate is valid"
 msgstr "Gültigkeitsdatum des Zertifikats"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr "Datum, an dem der Bericht gedruckt wurde"
 
@@ -1638,11 +1713,11 @@ msgstr "Bis zur nächsten Kalibrierung deaktivieren"
 msgid "Deactivate"
 msgstr "Deaktivieren"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Dezimaltrenner zur Verwendung für diesen Kunden"
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr "Standardmäßige Kontakte in Kopie für neue Proben. Wenn gesetzt, werden diese Kontakte beim Anlegen einer Probe automatisch ausgewählt."
 
@@ -1654,7 +1729,7 @@ msgstr "Standardbehälter"
 msgid "Default Department"
 msgstr "Standard-Abteilung"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Standard E-Mail-Adressen in CC für zu veröffentlichende Proben dieses Kunden."
 
@@ -1666,7 +1741,7 @@ msgstr "Standardgerät"
 msgid "Default Method"
 msgstr "Standardmethode"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr "Standardanzahl der Kopien"
 
@@ -1674,20 +1749,20 @@ msgstr "Standardanzahl der Kopien"
 msgid "Default Preservation"
 msgstr "Standardkonservierung"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr "Standard-Etikettenvorlage"
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr "Standardkontakt für neue Proben. Wenn gesetzt, wird dieser Kontakt im Probenerstellungsformular automatisch ausgewählt."
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Standardanzahl an Proben die hinzugefügt werden"
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Standard-Dezimaltrenner"
 
@@ -1699,7 +1774,7 @@ msgstr "Standard Prüfgerät für Analysen dieser Art"
 msgid "Default large sticker"
 msgstr "Standardetikett groß"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Standardlayout in der Arbeitsblattansicht"
 
@@ -1731,15 +1806,15 @@ msgstr "Standardergebnis muss eine der folgenden Optionen sein: {}"
 msgid "Default result to display on result entry"
 msgstr "Standardergebnis, dass bei Ergebniserfassung angezeigt wird"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Standard-Probenaufbewahrungsfrist"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Wissenschaftliche Standard-Schreibweise für Berichte"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Wissenschaftliche Standard-Schreibweise für Ergebnisse"
 
@@ -1751,7 +1826,7 @@ msgstr "Standardetikett klein"
 msgid "Default timezone"
 msgstr "Standard Zeitzone"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Standardbearbeitungszeit für Analysen"
 
@@ -1760,7 +1835,7 @@ msgstr "Standardbearbeitungszeit für Analysen"
 msgid "Default value"
 msgstr "Standardwert"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "Vorgabewert für 'Probenzahl' für das Erzeugen neuer Proben"
 
@@ -1784,7 +1859,7 @@ msgstr "Anzahl der signifikaten Stellen der Exponentialschreibweise. Standard is
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Definieren Sie den Probenehmer für den geplanten Termin"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr "Vorlage für den E-Mail-Text definieren, der automatisch an primäre Kontakte und Laborleiter gesendet wird, wenn eine Probe ungültig gesetzt wird. Die folgenden Platzhalter werden unterstützt: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 
@@ -1796,9 +1871,18 @@ msgstr "Definiert Etiketten für diesen Probentyp"
 msgid "Degrees"
 msgstr "Grad"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
 msgstr "Löschen"
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr "Filter löschen"
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
+msgstr "Diese Bemerkung löschen?"
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
@@ -1826,9 +1910,9 @@ msgstr "Abteilungen"
 msgid "Dependent Analyses"
 msgstr "Abhängige Analysen"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -1875,7 +1959,11 @@ msgstr "Transitionen nicht automatisch laden"
 msgid "Disable multi-verification for the same user"
 msgstr "Deaktiviere mehrfaches Verifizieren durch den gleichen Benutzer"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr "Änderungen verwerfen und Voreinstellung wiederherstellen"
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Rabatt"
@@ -1893,7 +1981,7 @@ msgstr "Ausliefern"
 msgid "Dispatch samples"
 msgstr "Proben ausliefern"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Ausgeliefert"
@@ -1918,15 +2006,23 @@ msgstr "Anzeigewert muss eindeutig sein"
 msgid "Display a Detection Limit selector"
 msgstr "Zeige Auswahl für Erfassungsgrenzen"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr "Zeige Kunden Probenpartitionen"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Entsorgen"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr "Proben entsorgen"
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Entsorgt"
 
@@ -1996,11 +2092,15 @@ msgstr "PDF herunterladen"
 msgid "Download selected reports"
 msgstr "Ausgewählte Berichte herunterladen"
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr "Zum Umsortieren ziehen"
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Fällig"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Fälligkeit"
@@ -2017,7 +2117,7 @@ msgstr "Kopie"
 msgid "Duplicate Analysis"
 msgstr "Doppelbestimmung"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr "Doppeltes ID-Format für Inhaltstyp '${pt}' (Zeilen ${a} und ${b}). Nur die erste Zeile wird verwendet; bitte das Duplikat entfernen oder zusammenführen."
 
@@ -2031,7 +2131,7 @@ msgstr "Doppelte QC-Analyse"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr ""
+msgstr "Probe duplizieren"
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
@@ -2065,6 +2165,7 @@ msgstr "z.B. SANAS, APLAC, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "Jede Importschnittstelle kann einen Ordner definieren, in dem das System nach den Ergebnisdateien sucht wenn Ergebnisse automatisch importiert werden, wenn der Endpunkt <code>auto_import_results</code> aufgerufen wird."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -2079,21 +2180,21 @@ msgstr "Erhöhung"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "E-Mail"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "E-Mail Adresse"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr "E-Mail-Anhänge"
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr "E-Mail-Text"
 
@@ -2101,27 +2202,27 @@ msgstr "E-Mail-Text"
 msgid "Email Log"
 msgstr "E-Mail Log"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr "E-Mail-Empfänger"
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr "E-Mail-Verantwortliche"
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr "E-Mail-Versanddatum"
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr "E-Mail-Betreff"
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "E-Mail-Text zu Annullierungs-Mitteilungen"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr "E-Mail-Benachrichtigungstext bei Probenablehnung"
 
@@ -2134,17 +2235,21 @@ msgstr "E-Mail-Versand abgebrochen"
 msgid "Email notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "E-Mail-Mitteilung bei Ablehnung von Proben"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr "E-Mail-Versandprotokoll"
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
 msgstr "E-Mail gesendet"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr "Leer"
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2154,27 +2259,27 @@ msgstr "Leere Schlagworte nicht möglich"
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Mehrfachverwendung von Geräten in Arbeitsblättern zulassen."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Probenkonservierung aktivieren"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "Probenspezifikationen erlauben"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "Probenahme aktivieren"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "Probenahmeterminplanung aktivieren"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr "Aktivieren Sie das globale Audit Log"
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr "Aktivieren Sie das globale Audit Log"
 
@@ -2182,9 +2287,17 @@ msgstr "Aktivieren Sie das globale Audit Log"
 msgid "Enable sampling workflow for the created sample"
 msgstr "Probennahmeworkflow für die erzeugte Probe aktivieren "
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "Ablauf für Ergebnisberichtsdruck aktivieren"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr "Workflow zur Probenauslieferung aktivieren"
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr "Workflow zur Probenentsorgung aktivieren"
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2207,7 +2320,7 @@ msgstr "Geben Sie eine E-Mail-Adresse ein. Diese wird benötigt, falls das Passw
 msgid "Enter discount percentage value"
 msgstr "Geben Sie den Rabatt in Prozent ein"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr "Individuelle Werte für dieses Feld pro Probe eingeben"
 
@@ -2220,7 +2333,7 @@ msgstr "Geben Sie den Wert in Prozent ein, z.B. 19.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Bitte geben Sie den Prozentsatz ein, z. B. 14.0. Dieser Prozentsatz wird im gesamtem System angewendet, kann aber individuell an den verschiedenen Elementen überschrieben werden"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Bitte geben Sie den Prozentsatz ein, z. B. 14.0. Dieser Prozentsatz wird im gesamtem System angewendet, kann aber individuell an den verschiedenen Elementen überschrieben werden"
 
@@ -2244,7 +2357,7 @@ msgstr "Geben Sie die Details jeder Analyseleistung ein, die Sie kopieren möcht
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Geben Sie an dieser Stelle ihre Akkreditierung an. Folgende Felder sind verfügbar: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr "Geben Sie das Ergebnis entweder in dezimaler oder wissenschaftlicher Schreibweise ein, z. 0,00005 oder 1e-5, 10000 oder 1e5"
 
@@ -2256,15 +2369,15 @@ msgstr "Umweltbedingungen"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr "Fehlerhafte Ergebnisveröffentlichung: ${sample_id}"
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Entwicklung der Analysen"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Entwicklung der Proben"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Entwicklung der Arbeitsblätter"
 
@@ -2276,7 +2389,7 @@ msgstr "Beispiel-Cronjob, um den automatischen Import alle 10 Minuten auszuführ
 msgid "Example content"
 msgstr "Beispielinhalt"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Von der Rechnung ausschließen"
 
@@ -2286,7 +2399,7 @@ msgstr "Von der Rechnung ausschließen"
 msgid "Expected Result"
 msgstr "Voraussichtliches Ergebnis"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "geplantes Probenahmedatum"
 
@@ -2312,7 +2425,7 @@ msgstr "Verfallsdatum"
 msgid "Exponential format precision"
 msgstr "Exponentielle Darstellung der Präzision"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Exponentielle Darstellung des Schwellwerts"
 
@@ -2320,7 +2433,7 @@ msgstr "Exponentielle Darstellung des Schwellwerts"
 msgid "Export"
 msgstr "Export"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "Etikett Ladefehler"
 
@@ -2407,7 +2520,7 @@ msgstr "Dateiname"
 msgid "Filesize"
 msgstr "Dateigröße"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr "Analysen nach Name filtern..."
 
@@ -2423,6 +2536,18 @@ msgstr "Nach Analysenleistungen der Vorlage filtern"
 msgid "Filter keys (regex supported)"
 msgstr "Schlüssel filtern (Regex unterstützt)"
 
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr "Filtername"
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr "Proben nach dieser Analyse filtern"
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
+msgstr "Filtern..."
+
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
 msgstr "Erstes Arbeitsblatt hat keine gültige Spaltenkonfiguration"
@@ -2437,11 +2562,11 @@ msgstr "Vorname"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Gleitkommawert von 0.0 - 1000.0 um die Sortierreihenfolge zu setzen. Doppelte Werte werden alphabetisch sortiert."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr "Format"
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Konfiguration formatieren"
 
@@ -2464,13 +2589,17 @@ msgstr "Freitag"
 msgid "From"
 msgstr "Von"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr "Von ${from} bis ${to} (alle 2 Stunden aktualisiert)"
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Vollständiger Name"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Vollständiger Name"
 
@@ -2478,7 +2607,7 @@ msgstr "Vollständiger Name"
 msgid "Function"
 msgstr "Funktion"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "In der Zukunft datierte Probe"
 
@@ -2511,7 +2640,7 @@ msgstr "Zur SENAITE Seite gehen"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Anrede Titel, z.B. Herr, Frau, Dr"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Gruppiere Analyseleistungen nach Kategorien. Sinnvoll bei langen Listen."
 
@@ -2525,7 +2654,7 @@ msgid "Hazardous"
 msgstr "Gefährlich"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Versteckt"
@@ -2538,9 +2667,21 @@ msgstr "Verstecktes Feld"
 msgid "Hidden from report"
 msgstr "Im Bericht ausgeblendet"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
 msgstr "Zusätzliche Felder ausblenden"
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr "Alle ausblenden"
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr "Verlauf ausblenden"
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
+msgstr "Diese Spalte ausblenden"
 
 #: bika/lims/config.py:140
 msgid "High"
@@ -2563,7 +2704,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr "ID-Server"
 
@@ -2571,7 +2712,7 @@ msgstr "ID-Server"
 msgid "ID Server Settings"
 msgstr "ID-Server-Einstellungen"
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr "ID-Server Werte"
 
@@ -2591,15 +2732,15 @@ msgstr "Wenn ausgewählt, wird eine Liste in der Ergebnisübersicht angezeigt. L
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Wenn ausgewählt, wird das Gerät bis zur nächsten gültigen Kalibrierung nicht mehr verfügbar sein und automatisch deaktiviert."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Wenn ausgewählt, wird ein Freitext neben jeder Analyse in der Ergebnisübersicht angezeigt"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Wenn ausgewählt, darf der Benutzer, der das Ergebnis eingereicht hat, auch dieses verifizieren. Diese Option gilt nur für die Benutzer mit der entsprechenden Rolle (standardmäßig Administratoren, Laboradministratoren und Prüfer) und hat Vorrang vor der Einstellung in der Bika Einrichtung."
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Wenn ausgewählt, darf der Benutzer, der das Ergebnis eingereicht hat, auch dieses verifizieren. Diese Option gilt nur für die Benutzer mit der entsprechenden Rolle (standardmäßig Administratoren, Laboradministratoren und Prüfer) und kann für jede Analyse im Bearbeitungsmodus der Analyseleistung überschrieben werden. Standardeinstellung ist deaktiviert."
 
@@ -2607,7 +2748,7 @@ msgstr "Wenn ausgewählt, darf der Benutzer, der das Ergebnis eingereicht hat, a
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Wenn ausgewählt, wird die Bezeichnung der Analyse in Kursiv dargestellt."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "Wenn ausgewählt, wird die Analyse und ihre Ergebnisse nicht in Berichten angezeigt. Diese Einstellung kann in den Analysenprofilen und Proben überschrieben werden."
 
@@ -2647,7 +2788,7 @@ msgstr "Wenn abgewählt, können Labormanager keine gleichen Geräte mehr als zu
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "Wenn Ihre Formel eine spezielle Funktion aus einer externen Python-Bibliothek benötigt, kann sie hier importiert werden. Z.B. wenn Sie die Funktion 'floor()' aus den Python 'math' Modul brauchen, tragen Sie bitte 'math' in das Modulfeld und 'floor' in das Funktionsfeld ein. In Python wäre die äquivalente Syntax 'from math import floor'. In der Berechnung könnten Sie sie dann z.B. so verwenden: 'floor([Ca] + [Mg]}'"
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr "Sofortige Ergebniseingabe"
 
@@ -2678,11 +2819,11 @@ msgstr "Laborinternes  Kalibrierungsverfahren"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Preisinformationen anzeigen und hinzufügen"
 
@@ -2879,7 +3020,7 @@ msgid "Internal Certificate"
 msgstr "Internes Zertifikat"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "Interne Verwendung"
 
@@ -2900,13 +3041,13 @@ msgstr "Vorlagen Ergebnisinterpretationen"
 msgid "Interval"
 msgstr "Intervall"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Ungültig"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr "Ungültiges ID-Format in Zeile ${i} ('${pt}'): ${err}"
 
@@ -2969,15 +3110,15 @@ msgstr "Rechnung an"
 msgid "Invoice {} created"
 msgstr "Rechnung {} erzeugt"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "Rechnungs Batch hat kein Enddatum"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "RechnungsBatch hat kein Startdatum"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "RechnungsBatch hat keinen Titel"
 
@@ -2989,7 +3130,7 @@ msgstr "Berufsbezeichnung"
 msgid "Job title"
 msgstr "Berufsbezeichnung"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr "Halten Sie die Reihenfolge oben ein"
 
@@ -3001,9 +3142,9 @@ msgstr "Schlüssel"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr "Schlüssel <span class=\"sort-indicator\" />"
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Schlüsselwort"
 
@@ -3020,7 +3161,7 @@ msgstr "Schlüsselwort benötigt"
 msgid "Keywords"
 msgstr "Schlüsselwörter"
 
-#: senaite/core/browser/samples/view.py:239
+#: senaite/core/browser/samples/view.py:249
 msgid "Keywords of the analyses contained in the sample"
 msgstr "Schlüsselwörter der in der Probe enthaltenen Analysen"
 
@@ -3067,8 +3208,8 @@ msgstr "Laborprodukte"
 msgid "Lab URL"
 msgstr "Labor URL"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Etikett"
@@ -3077,7 +3218,7 @@ msgstr "Etikett"
 msgid "Label configuration"
 msgstr "Etikettenkonfiguration"
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr "Etikettennamen müssen eindeutig sein"
 
@@ -3085,13 +3226,13 @@ msgstr "Etikettennamen müssen eindeutig sein"
 msgid "Label schema extender"
 msgstr "Label-Schema-Extender"
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr "Etikettierte Objekte"
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr "Etiketten"
 
@@ -3104,7 +3245,7 @@ msgstr "Labor"
 msgid "Laboratory Accredited"
 msgstr "Akkreditiertes Labor"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Arbeitstage des Labors"
 
@@ -3116,7 +3257,7 @@ msgstr "Sprache"
 msgid "Large Sticker"
 msgstr "Großer Aufkleber"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr "Große Etikettenvorlage"
 
@@ -3128,11 +3269,11 @@ msgstr "Vorherige Auto-Import-Protokolle"
 msgid "Last Login Time"
 msgstr "Letztes Anmeldedatum"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Verspätet"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Verspätete Analysen"
 
@@ -3178,15 +3319,15 @@ msgstr "Benutzer verknüpfen"
 msgid "Link an existing User"
 msgstr "Bestehenden Benutzer verknüpfen"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr "Zeige alle etikettierten Objekte"
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr "Liste möglicher Endergebnisse. Wenn festgelegt, ist bei der Ergebniseingabe kein benutzerdefiniertes Ergebnis zulässig, und der Benutzer muss aus diesen Werten auswählen"
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr "Liste vordefinierter Ablehnungsgründe. Einen Grund pro Zeile eingeben."
 
@@ -3210,7 +3351,7 @@ msgstr "Zertifikat hier hochladen"
 msgid "Loading navigation..."
 msgstr "Navigation wird geladen…"
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr "Wird geladen…"
 
@@ -3238,6 +3379,14 @@ msgstr "Art des Standorts"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Ort an dem das Dokument eingeordnet wurde"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr "Sperren"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr "Gesperrt"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3301,7 +3450,7 @@ msgstr "Männlich"
 msgid "Manage Analyses"
 msgstr "Analysen verwalten"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "Formularfelder verwalten"
 
@@ -3325,7 +3474,7 @@ msgstr "Proben Formularfelder bearbeiten"
 msgid "Manage linked User"
 msgstr "Verknüpfte Benutzer verwalten"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr "Probenfelder verwalten"
 
@@ -3349,7 +3498,7 @@ msgstr "E-Mail des Managers"
 msgid "Manager Phone"
 msgstr "Telefonnummer des Managers"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Manuell"
 
@@ -3378,7 +3527,7 @@ msgstr "Hersteller"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "Kennzeichnen Sie die Probe nur für den internen Gebrauch. Dies bedeutet, dass es nur für Laborpersonal und nicht für Kunden zugänglich ist."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3393,7 +3542,7 @@ msgstr "Max Zeit"
 msgid "Max operator"
 msgstr "Max Operator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3428,15 +3577,15 @@ msgid "Member Discount"
 msgstr "Mitgliederrabatt"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Mitgliederrabatt %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Mitgliederrabatt anwenden"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Benutzer wurde registriert und zu dem aktuellen Kontakt verknüpft."
 
@@ -3444,7 +3593,7 @@ msgstr "Benutzer wurde registriert und zu dem aktuellen Kontakt verknüpft."
 msgid "Message sent to {}, "
 msgstr "Nachricht gesendet an {}, "
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr "Metadaten"
 
@@ -3475,7 +3624,7 @@ msgstr "Initialien Zuname"
 msgid "Middle name"
 msgstr "Zuname"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3486,7 +3635,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr "Min Operator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3504,7 +3653,7 @@ msgstr "Mindestens 5 Zeichen."
 msgid "Minimum Volume"
 msgstr "Mindestvolumen"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Minimale Anzahl an Ergebnissen für QM-Statusberechnungen"
 
@@ -3535,6 +3684,10 @@ msgstr "Modul"
 msgid "Monday"
 msgstr "Montag"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr "Monatlich"
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr "Mehr als eine Analyse für {sid} und Schlüsselwort '{keyword}' gefunden"
@@ -3548,11 +3701,11 @@ msgstr "Multi-Katalog-Verhalten für Dexterity Inhalte"
 msgid "Multi Results"
 msgstr "Multi Ergebnisse"
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "Mehrfach-Verifikations-Typ"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Mehrfache Verifikation erforderlich"
 
@@ -3588,13 +3741,17 @@ msgstr "Meine Organisation"
 msgid "My Profile"
 msgstr "Mein Profil"
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr "Mein Filter"
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Name"
 
@@ -3605,6 +3762,10 @@ msgstr "Neue LIMS-Einrichtung"
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
 msgstr "Neue Bereiche werden weder auf neue noch auf aktuelle Analysen angewendet. Weisen Sie die Spezifikation neu zu, wenn Sie die letzten Änderungen anwenden möchten."
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
+msgstr "Neueste zuerst"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
@@ -3647,6 +3808,10 @@ msgstr "Keine Untergruppe"
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "Keine Aktion definiert."
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr "Keine Aktionen verfügbar. Bitte wenden Sie sich an Ihren Laborleiter, um Berechtigungen zugewiesen zu bekommen."
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3694,6 +3859,10 @@ msgstr "Keine Änderungen vorgenommen"
 msgid "No changes made."
 msgstr "Keine Änderungen vorgenommen."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr "Keine Daten für den gewählten Zeitraum"
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "Kein Datum gesetzt"
@@ -3738,6 +3907,16 @@ msgstr "Nichts ausgewählt"
 msgid "No items selected."
 msgstr "Keine Objekte ausgewählt"
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr "Keine Treffer in ausgeblendeten Spalten."
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr "Keine Treffer in sichtbaren Spalten."
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "Es wurden keine neuen Elemente angelegt"
@@ -3745,6 +3924,10 @@ msgstr "Es wurden keine neuen Elemente angelegt"
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "Keine Partitionen wurden erzeugt"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr "Noch keine Bemerkungen"
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3761,6 +3944,10 @@ msgstr "Keine Proben wurden abgelehnt"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Kein Probenahme Worfkflow"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr "Noch keine gespeicherten Filter."
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3788,7 +3975,7 @@ msgstr "Keine sichtbaren Analysen für diese Probe"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Keine"
 
@@ -3804,11 +3991,11 @@ msgstr "Folgende Bedingungen konnten nicht aktualisiert werden: {}"
 msgid "Not defined"
 msgstr "Nicht definiert"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr "Nicht gedruckt"
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Nicht gesetzt"
@@ -3829,7 +4016,7 @@ msgstr "Hinweis: Die Einstellungen sind global und gelten für alle Probenansich
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "Hinweis: Man kann die Reihenfolge im Bericht mittels Drag and Drop der Anhangsblöcke ändern."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr "Hinweise"
 
@@ -3841,7 +4028,7 @@ msgstr "Spaltenanzahl"
 msgid "Number"
 msgstr "Zahl"
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Anzahl der Analysen"
 
@@ -3857,16 +4044,16 @@ msgstr "Anzahl Kopien"
 msgid "Number of prominent columns"
 msgstr "Anzahl der prominenten Spalten"
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Anzahl der benötigten Verifikationen"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Anzahl der benötigten Verifikationen bevor ein Ergebnis als 'verifiziert' gilt. Diese Einstellung kann pro Analyse einer Analyseleistung überschrieben werden. Der Standardwert ist 1."
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Anzahl der benötigten Verifikaktionen von unterschiedlichen Benutzern mit entsprechender Berechtigung, bis eine Analyse als 'verifiziert' gilt. Diese Einstellung überschreibt den Wert in den Bika Einstellungen."
 
@@ -3877,6 +4064,10 @@ msgstr "Anzahl der standard Spalten"
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
 msgstr "Numerisch"
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
+msgstr "Älteste zuerst"
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -3894,11 +4085,11 @@ msgstr "Nur Bilder können direkt im Bericht eingebettet werden"
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr "Es werden nur Prüfgeräte angezeigt, für die eine Importschnittstelle konfiguriert ist"
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr "Für die Berechnung der Analysendurchlaufzeit werden nur Laborarbeitstage berücksichtigt."
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "Für die Berechnung der Durchlaufzeit der Analyse werden nur Laborarbeitstage berücksichtigt."
 
@@ -3906,13 +4097,13 @@ msgstr "Für die Berechnung der Durchlaufzeit der Analyse werden nur Laborarbeit
 msgid "Only to empty or zero fields"
 msgstr "Nur für leere oder Null-Felder"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Offen"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr "Offen / Zu verifizieren / Verifiziert / Gesamt"
 
@@ -3920,9 +4111,17 @@ msgstr "Offen / Zu verifizieren / Verifiziert / Gesamt"
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Open Source Web-basiertes Labor-Information-Management-System"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr "Offene Arbeitsblätter"
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "E-Mail-Formular öffnen, um die ausgewählten Berichte an die Empfänger zu senden. Dadurch werden auch die enthaltenen Proben der Berichte veröffentlicht, nachdem die E-Mail erfolgreich gesendet wurde."
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr "Offene Arbeitsblätter mit Analysen, die auf Ergebnisse warten"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3949,7 +4148,7 @@ msgstr "Andere Gründe"
 msgid "Other reasons:"
 msgstr "Andere Gründe:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Anderer Status"
 
@@ -3971,11 +4170,11 @@ msgstr "Nicht leere Analyseergebnisse überschreiben"
 msgid "Override non-empty analysis results, also with empty"
 msgstr "Nicht leere Analyseergebnisse überschreiben, auch mit leeren"
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr "PDF"
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr "PDF-Datei des Berichts"
 
@@ -4072,11 +4271,11 @@ msgstr "Bitte einen Kommentar angeben, der den Grund für die Ungültigkeitserkl
 msgid "Please provide the reason for invalidating the sample."
 msgstr "Bitte den Grund für die Ungültigkeitserklärung der Probe angeben."
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Bitte wählen Sie einen Benutzer aus der Liste"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr "Bitte eine Etikettenvorlage auswählen"
 
@@ -4089,6 +4288,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr "Bitte wählen Sie die Anzahl der zu erstellenden Partitionen aus und klicken Sie auf die Vorschau-Schaltfläche"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr "Bitte Grund angeben"
 
@@ -4110,12 +4310,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr "Bitte kommentieren Sie wohin die ausgewählte(n) Probe(n) ausgeliefert werden"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr "Bitte geben Sie einen Kommentar ein, wo die aufgeführten Proben entsorgt werden"
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Zeitpunkt der Aufnahme"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr "Portaltyp"
 
@@ -4154,31 +4358,31 @@ msgstr "Genauigkeit als Anzahl der Dezimalstellen"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Präzision als Zahl der signifikanten Stellen gemäß der Unsicherheit. Die Dezimalstelle ist durch die erste Zahl die nicht Null ist gegeben und entsprechend von dort durch das System gerundet. Zum Beispiel wird ein Ergebnis von 5.243 un einer Unsicherheit von 0.22 auf 5.2+/-0.2 gerundet. Wenn keine Unsicherheit angegeben wurde nutzt das System ein 'fixed precision set'."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr "Vordefinierte Ergebnisse"
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Bevorzugter Dezimaltrenner für Berichte"
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Bevorzugter Dezimaltrenner für Ergebnisse"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "Bevorzugtes Layout für die Ergebnistabelle in der Arbeitsblatt Ansicht. Das klassische Layout zeigt die Proben und die Analysen in Zeilen. Das transponierte Layout zeigt die Proben in Spalten und die Analysen in Zeilen."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Wissenschaftliche Notation in Berichten bevorzugt"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Wissenschaftliche Notation in Ergebnissen bevorzugt"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr "Präfix"
 
@@ -4211,7 +4415,7 @@ msgstr "Konservierung pro Probenart"
 msgid "Preserve"
 msgstr "Konservieren"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Konservierer"
 
@@ -4228,11 +4432,11 @@ msgstr "Präventiv"
 msgid "Preventive maintenance procedure"
 msgstr "Vorbeugende Wartungsprozedur"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "Vorschau"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4260,7 +4464,7 @@ msgstr "Preisliste für"
 msgid "Pricelists"
 msgstr "Preisliste"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr "Primärkontakt"
 
@@ -4269,7 +4473,7 @@ msgstr "Primärkontakt"
 msgid "Primary Sample"
 msgstr "Primäre Probe"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4291,11 +4495,11 @@ msgstr "Datum des Drucks"
 msgid "Print pricelist"
 msgstr "Preisliste drucken"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Drucke Etiketten"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Gedruckt"
 
@@ -4308,7 +4512,7 @@ msgstr "Gedruckt auf"
 msgid "Priority"
 msgstr "Priorität"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Profil"
 
@@ -4332,7 +4536,7 @@ msgstr "Profilname"
 msgid "Profile keyword must be unique"
 msgstr "Profilschlüsselwort muss eindeutig sein"
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Fortschritt"
 
@@ -4341,7 +4545,7 @@ msgstr "Fortschritt"
 msgid "Prominent fields"
 msgstr "Prominente Felder"
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "Protokoll ID"
 
@@ -4349,7 +4553,7 @@ msgstr "Protokoll ID"
 msgid "Province"
 msgstr "Provinz"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr "Veröffentlichungsmodi"
 
@@ -4358,8 +4562,12 @@ msgstr "Veröffentlichungsmodi"
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr "Berichte veröffentlichen"
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Veröffentlicht"
@@ -4375,6 +4583,10 @@ msgstr "Veröffentlichungsdatum"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Veröffentlichte Ergebnisse"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr "Veröffentlichte Proben, deren Berichte noch nicht gedruckt wurden"
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4396,6 +4608,14 @@ msgstr "QC Ergebnisse"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "QC Proben-ID"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr "Vierteljährlich"
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr "Schnellaktionen"
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4421,7 +4641,7 @@ msgstr "Geben Sie das Passwort erneut ein. Stellen Sie sicher, dass die Passwör
 msgid "Reasons for rejection"
 msgstr "Gründe für die Ablehnung"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Wiederzuweisen"
 
@@ -4431,32 +4651,36 @@ msgstr "Wiederzuweisbarer Platz"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr ""
+msgstr "Wieder anhängen"
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr "Neu berechnen"
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Empfangen"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Empfangen"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr "Angenommene Proben mit Analysen, die auf Ergebnisse warten"
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Empfang ausstehend"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr "Empfänger"
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Empfänger"
 
@@ -4507,11 +4731,15 @@ msgstr "Referenzwert"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Referenzprobenwerte sind Null oder 'blind'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registrieren"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr "Proben registrieren"
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4537,9 +4765,9 @@ msgstr "Analyse ablehnen"
 msgid "Reject samples"
 msgstr "Proben ablehnen"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Abgelehnt"
 
@@ -4555,7 +4783,7 @@ msgstr "Abgelehnte Probe"
 msgid "Rejected {} samples: {}"
 msgstr "Abgelehnt {} Proben: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr "Ablehnungsgründe"
 
@@ -4616,9 +4844,17 @@ msgstr "Entfernte IP"
 msgid "Remove"
 msgstr "Entfernen"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr "Diese Analyse aus dem Filter entfernen"
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
 msgstr "{} Schlüssel entfernt: {}"
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
+msgstr "Filter umbenennen"
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
@@ -4653,11 +4889,11 @@ msgstr "Bericht ID"
 msgid "Report identification number"
 msgstr "Bericht Identifikationsnummer"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr "Berichtsmetadaten"
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr "Berichtsempfänger"
 
@@ -4669,7 +4905,7 @@ msgstr "Bericht hochladen"
 msgid "Republish"
 msgstr "Wiederveröffentlichen"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "Neu veröffentlicht nach letztem Druck"
 
@@ -4678,7 +4914,7 @@ msgstr "Neu veröffentlicht nach letztem Druck"
 msgid "Request ID"
 msgstr "Auftrags ID"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Neue Analyse anfordern"
 
@@ -4694,28 +4930,37 @@ msgstr "Gefordertes Volumen"
 msgid "Reset"
 msgstr "Zurücksetzen"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr "Spaltensichtbarkeit und -reihenfolge auf die Standardwerte zurücksetzen"
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr "Spalten zurücksetzen"
 
-# senaite.app.listing: Reset-columns button tooltip
-msgid "Reset column visibility and order to the defaults"
-msgstr "Sichtbarkeit und Reihenfolge der Spalten auf Standard zurücksetzen"
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr "Auf Standardspalten und -reihenfolge zurücksetzen"
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr "Ansicht zurücksetzen"
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
 msgstr "Verantwortliche"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr "Arbeitsblattzugriff auf zugewiesene Analytiker beschränken"
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr "Arbeitsblattverwaltung auf Laborleiter beschränken"
 
@@ -4740,15 +4985,15 @@ msgstr "Anzeigewert muss eine Nummer sein"
 msgid "Result Value must be unique"
 msgstr "Anzeigewert muss eindeutig sein"
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Ergebnis im Randbereich"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Ergebnis außerhalb des Bereichs"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr "Ergebniswert weicht von der Spezifikation ab: {}"
 
@@ -4756,7 +5001,7 @@ msgstr "Ergebniswert weicht von der Spezifikation ab: {}"
 msgid "Result type"
 msgstr "Ergebnistyp"
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Ergebniswerte mit mehr als der genannten Anzahl signifikanter Stellen werden in der Exponentialschreibweise dargestellt. Die Präzision wird in den einzelnen Analysenservices konfiguriert."
 
@@ -4772,16 +5017,20 @@ msgstr "Ergebnisse"
 msgid "Results Interpretation"
 msgstr "Ergebnisinterpretation"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr "Ausstehende Ergebnisse"
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr "Ergebnisbericht"
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr "Ergebnisberichte"
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Ergebnisse wurden zurückgezogen"
 
@@ -4789,7 +5038,7 @@ msgstr "Ergebnisse wurden zurückgezogen"
 msgid "Results interpretation"
 msgstr "Ergebnisinterpretation"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Ausstehende Ergebnisse"
 
@@ -4813,7 +5062,7 @@ msgstr "Erneut geprüft"
 msgid "Retract"
 msgstr "Zurückziehen"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4849,6 +5098,10 @@ msgstr "Zurückrollen"
 msgid "Routine Analyses"
 msgstr "Routineanalysen"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr "Zeile ${num}"
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr "SENAITE CORE"
@@ -4874,6 +5127,7 @@ msgstr "SENAITE LIMS Startseite"
 msgid "SENAITE Registry"
 msgstr "SENAITE-Registrierung"
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4883,7 +5137,7 @@ msgstr "SENAITE Setup"
 msgid "SENAITE front-page"
 msgstr "SENAITE Startseite"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "SMTP Server nicht verbunden. Benutzererstellung wurde abgebrochen."
 
@@ -4897,7 +5151,7 @@ msgstr "Anrede"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Probe"
 
@@ -4934,7 +5188,7 @@ msgid "Sample Header"
 msgstr "Probenkopf"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "Proben ID"
 
@@ -4954,7 +5208,7 @@ msgstr "Probenmatrix"
 msgid "Sample Partitions"
 msgstr "Teilproben"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4981,7 +5235,7 @@ msgid "Sample Templates"
 msgstr "Proben Vorlagen"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Probenart"
@@ -5042,7 +5296,7 @@ msgstr "Probenart"
 msgid "SampleTypes"
 msgstr "Probentypen"
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Probenehmer"
 
@@ -5054,8 +5308,8 @@ msgstr "Probenehmer für die geplante Probennahme"
 msgid "Sampler required for sample %s"
 msgstr "Probennehmer für Probe erforderlich %s"
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Proben"
@@ -5072,6 +5326,18 @@ msgstr "Proben ${sample_ids} wurden erfolgreich ungültig gesetzt, Benachrichtig
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr "Proben ${sample_ids} wurden erfolgreich ungültig gesetzt."
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr "Proben, die auf die Entnahme der Probe warten"
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr "Proben, die auf die Konservierung warten"
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr "Proben, die auf die Annahme im Labor warten"
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5081,7 +5347,23 @@ msgstr "Proben dieses Typs sollten als gefährlich behandelt werden"
 msgid "Samples rejection reporting form"
 msgstr "Mitteilungsformular zur Ablehnung der Proben"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr "Anzunehmende Proben"
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr "Proben, deren Berichte veröffentlicht wurden"
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr "Proben, deren Ergebnisse auf die Verifizierung warten"
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr "Proben mit einem geplanten Probenahmedatum"
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr "Probenahme"
 
@@ -5089,7 +5371,7 @@ msgstr "Probenahme"
 msgid "Sampling Date"
 msgstr "Probenahmedatum"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Probenahme-Abweichung"
@@ -5102,7 +5384,7 @@ msgstr "Probenahme-Abweichungen"
 msgid "Sampling Frequency"
 msgstr "Probenahmehäufigkeit"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "Probennahme geplant"
 
@@ -5110,15 +5392,24 @@ msgstr "Probennahme geplant"
 msgid "Saturday"
 msgstr "Samstag"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Speichern"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
 msgstr "Speichern und Kopieren"
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr "Aktuelle Ansicht speichern"
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr "Gespeicherte Filter"
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5132,7 +5423,7 @@ msgstr "Zeitplan"
 msgid "Schedule sampling"
 msgstr "Plane Probennahme"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Geplante Probennahme"
@@ -5149,6 +5440,10 @@ msgstr "Wissenschaftlicher Name"
 msgid "Search"
 msgstr "Suchen"
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr "Spalten durchsuchen…"
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr "Suchen…"
@@ -5157,7 +5452,7 @@ msgstr "Suchen…"
 msgid "Seconds"
 msgstr "Sekunden"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr "Sicherheit"
 
@@ -5247,11 +5542,11 @@ msgstr "Gründe auswählen"
 msgid "Select template"
 msgstr "Vorlage auswählen"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Land, das die Seite per Voreinstellung anzeigen soll, auswählen"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Wählen Sie die Währung, die zur Anzeige von Preisen benutzt werden soll."
 
@@ -5263,11 +5558,11 @@ msgstr "Wählen Sie den Standardbehälter der für diese Analysen verwendet werd
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Wählen Sie die Standard - Startseite die verwendet werden soll, wenn Kunden sich im System anmelden oder wenn ein Kunden im Menu ausgewählt wird."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr "Die Standard-Etikettenvorlage für den automatischen Druck auswählen."
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr "Die Standard-Etikettenvorlage für den automatischen Druck auswählen.<br/>"
 
@@ -5275,31 +5570,39 @@ msgstr "Die Standard-Etikettenvorlage für den automatischen Druck auswählen.<b
 msgid "Select the types that this ID is used to identify."
 msgstr "Wählen sie die Typen die durch diese ID identifiziert werden."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "Aktivieren Sie diese Option, um E-Mail-Benachrichtigungen an den Kunden zu schicken, wenn eine Probe  abgelehnt wurde."
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "Aktivieren Sie diese Option, um das Dashboard als Standardseite festzulegen."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Wählen Sie diese Option, um den Probenahme-Ablauft zu aktivieren."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Auswählen um dem Probenahme-Koordinator zu erlauben, eine Probe zeitlich einzuplanen. Diese Funktionalität ist nur dann von Bedeutung, wenn der \"Probenahme Ablauf\" aktiviert ist."
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr "Aktivieren Sie diese Option, um das Ausliefern von Proben über den Übergang 'dispatch' zu erlauben und den zusätzlichen Status 'ausgeliefert' zu aktivieren. Die Analysen einer ausgelieferten Probe werden schreibgeschützt und in ihren vorherigen Status zurückversetzt, wenn die Probe wiederhergestellt wird. Standardmäßig deaktiviert."
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr "Aktivieren Sie diese Option, um das Entsorgen von Proben über den Übergang 'dispose' zu erlauben und den zusätzlichen Status 'entsorgt' zu aktivieren. Standardmäßig deaktiviert."
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr "Auswählen, um dem Benutzer zu erlauben, einen zusätzlichen 'Gedruckt'-Status für veröffentlichte Analyseaufträge zu setzen. Standardmäßig deaktiviert."
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "Wählen Sie diese Option, um die Proben automatisch zu erhalten, wenn sie vom Laborpersonal erstellt wurden und der Probenahme-Workflow deaktiviert ist. Von Kundenkontakten erstellte Proben werden nicht automatisch empfangen"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr "Wählen Sie diese Option aus, um Probenpartitionen für Kundenkontakte anzuzeigen. Wenn deaktiviert, werden Partitionen nicht in Listen aufgenommen und Kundenkontakten wird kein Hinweis mit Links zur Primärprobe angezeigt."
 
@@ -5311,7 +5614,7 @@ msgstr "Wählen Sie die Analysen aus, die auf dem Arbeitsblatt enthalten sein so
 msgid "Selection list"
 msgstr "Auswahlliste"
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Selbstverifizierung von Ergebnissen"
 
@@ -5323,11 +5626,11 @@ msgstr "Senden"
 msgid "Send Analysis Reports via Email"
 msgstr "Analysenberichte via E-Mail senden"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr "Versandprotokoll"
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr "Versandprotokolleintrag"
 
@@ -5349,7 +5652,7 @@ msgstr "Gesendet an"
 msgid "Separate Container"
 msgstr "Separater Behälter"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr "Sequenztyp"
 
@@ -5363,7 +5666,7 @@ msgstr "Seriennummer"
 msgid "Service"
 msgstr "Analyseleistung"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "Diese Analyseleistung kann nicht entfernt werden. Bitte klicken Sie auf den Info-Button für weitere Details."
 
@@ -5391,7 +5694,7 @@ msgstr "Proben-Ablehnungsablauf mit Begründungen setzen"
 msgid "Set the maintenance task as closed."
 msgstr "Setze die Wartungsaufgabe auf geschlossen"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr "Legen Sie den Text für den Text der E-Mail fest, die an den Kundenkontakt der Probe gesendet werden soll, wenn die Option „E-Mail-Benachrichtigung bei Ablehnung der Probe“ aktiviert ist. Sie können reservierte Schlüsselwörter verwenden: $sample_id, $sample_link, $reasons, $lab_address"
 
@@ -5439,29 +5742,41 @@ msgstr "Soll die Analyse von der Rechnung ausgeschlossen werden?"
 msgid "Should the default example content be added to the site?"
 msgstr "Soll Beispielinhalt zur Seite hinzugefügt werden?"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr "Zusätzliche Felder anzeigen"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
 msgstr "Alle anzeigen"
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
+msgstr "Verlauf anzeigen"
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr "Zeige letzte Auto-Import-Protokolle"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr "Zeige mehr"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
 msgstr "Zeige Standardfelder"
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr "Diese Spalte anzeigen"
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
+msgstr "Zeitverlauf ein-/ausblenden"
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5483,11 +5798,11 @@ msgstr "Standortcode"
 msgid "Site Description"
 msgstr "Standortbeschreibung"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr "Seiten-Logo"
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr "Seiten-Logo CSS"
 
@@ -5508,7 +5823,7 @@ msgstr "Ergebnis für Analyse '{keyword}' der Probe '{sid}' mit Berechnung '{cal
 msgid "Small Sticker"
 msgstr "Kleiner Aufkleber"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr "Kleine Etikettenvorlage"
 
@@ -5525,6 +5840,14 @@ msgstr "Einige Analysen verwenden veraltete oder unkalibrierte Geräte. Ergebnis
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Sortierschlüssel"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr "Aufsteigend sortieren"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr "Absteigend sortieren"
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5550,7 +5873,7 @@ msgstr "Die Spezifikationsbereiche haben sich seit ihrer Zuweisung geändert"
 msgid "Specifications"
 msgstr "Spezifikationen"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr "Angeben, wie viele Kopien jedes Etiketts standardmäßig gedruckt werden sollen."
 
@@ -5558,7 +5881,7 @@ msgstr "Angeben, wie viele Kopien jedes Etiketts standardmäßig gedruckt werden
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Geben Sie die Größe des Arbeitsblatts an, z.B. entsprechend der Probenhaltergröße eines bestimmten Prüfmittels. Wählen Sie dann die Analysenart pro Arbeitsblattposition aus. Wenn QC-Proben ausgewählt werden, wählen Sie auch aus, welche Referenzprobe verwendet werden soll. Wenn eine Duplikatanalyse ausgewählt wird, geben Sie an, von welcher Probenposition es ein Duplikat sein soll"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr "Teilungslänge"
 
@@ -5575,17 +5898,17 @@ msgstr "Anfangsdatum"
 msgid "Start date must be before End Date"
 msgstr "Anfangsdatum muss vor dem Enddatum sein"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Status"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Status"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Aufkleber"
@@ -5594,7 +5917,11 @@ msgstr "Aufkleber"
 msgid "Stickers preview"
 msgstr "Etikettenvorschau"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr "Automatisches Anwenden beenden"
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Lagerort"
@@ -5634,7 +5961,11 @@ msgstr "Einreichen"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr "Senden Sie eine gültige Open XML-Datei (.XLSX) mit Setup-Datensätzen, um fortzufahren."
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr "Übermittelte Analysen, die auf die Verifizierung warten"
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "Durch denselben Benutzer eingereicht und verifiziert: {}"
 
@@ -5642,7 +5973,7 @@ msgstr "Durch denselben Benutzer eingereicht und verifiziert: {}"
 msgid "Submitter"
 msgstr "Einreicher"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Zwischensumme"
@@ -5684,7 +6015,7 @@ msgstr "Zum Dashboard wechseln"
 msgid "Switch to transposed view"
 msgstr "Zur transponierten Ansicht wechseln"
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "System Standard"
 
@@ -5710,7 +6041,7 @@ msgstr "Steuern"
 msgid "Technical description and instructions intended for analysts"
 msgstr "Technische Beschreibung und Anweisungen für Analytiker"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5792,7 +6123,7 @@ msgstr "Das Datum wann die Probe konserviert wurde"
 msgid "The date when the sample was received"
 msgstr "Das Datum an dem die Probe empfangen wurde"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Dezimalzeichen im LIMS Setup wird verwendet."
 
@@ -5800,7 +6131,7 @@ msgstr "Dezimalzeichen im LIMS Setup wird verwendet."
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr "Die Standardzeitzoneneinstellung des Portals. Benutzer können ihre eigene Zeitzone festlegen, wenn verfügbare Zeitzonen in den Datums- und Zeiteinstellungen definiert sind."
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "Rabatt für Kunden mit Mitgliederstatus. Für gewöhnlich handelt es sich um Kooperationspartner."
 
@@ -5828,7 +6159,11 @@ msgstr "Die folgenden Partitionen wurden für diese Probe erzeugt:"
 msgid "The following sample(s) will be dispatched"
 msgstr "Die folgende(n) Probe(n) werden versendet"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr "Die folgenden Proben werden entsorgt"
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr "Das globale Audit Log zeigt alle Änderungen des Systems. Wenn aktiviert, werden alle Entitäten in einem separaten Katalog indiziert. Dadurch wird die Zeit verlängert, in der Objekte erstellt oder geändert werden."
 
@@ -5836,11 +6171,11 @@ msgstr "Das globale Audit Log zeigt alle Änderungen des Systems. Wenn aktiviert
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Die Höhe oder Tiefe, in der die Probe genommen wurde"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr "Die Haltezeit für diese Probe und Analyse ist abgelaufen. Das Fortsetzen der Analyse kann die Zuverlässigkeit der Ergebnisse beeinträchtigen."
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr "Die Haltezeit für diese Probe und Analyse läuft bald ab. Bitte die Analyse so schnell wie möglich abschließen, um die Datengenauigkeit und -zuverlässigkeit zu gewährleisten."
 
@@ -5877,11 +6212,11 @@ msgstr "Die Mindestmenge, die für die Analyse benötigt wird, z.B. \"10 ml\" od
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr "Der Speicher des Nummerngenerators ist leer. Zähler werden bei der ersten ID-Vergabe je Präfix angelegt."
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Die Anzahl der Tage, bevor eine Probe verfällt und nicht mehr analysiert werden kann. Diese Einstellung kann für jeden Probentyp im Probentypen-Setup überschrieben werden."
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Anzahl der Minuten, bevor ein Benutzer automatisch abgemeldet wird. 0 deaktiviert die automatische Abmeldung"
 
@@ -5921,7 +6256,7 @@ msgstr "Die Referenznummer, die dem Labor von der Akkreditierungsstelle zugewies
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "Das Ergebnis nach dieser Berechnung wurde aufgrund von Testwerten berechnet. Sie müssen die Berechnung speichern,  bevor dieser Wert berechnet werden kann."
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr "Das Ergebnis wurde nach Ablauf der Haltezeitgrenze erfasst."
 
@@ -5945,11 +6280,11 @@ msgstr "Die Probe ist ein Mix aus Unterproben"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Seriennummer zur eindeutigen Identitifizierung des Geräts"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "Protokoll-ID der Analyseleistung"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "Eindeutige Buchhaltungsnummer der Analysenleistung"
 
@@ -6001,11 +6336,11 @@ msgstr "Dies ist eine sekundäre Probe von"
 msgid "This is a detached partition from Sample"
 msgstr "Dies ist eine ausgegliederte Partition der Probe"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "Dies ist die maximal zulässige Standardzeit für die Durchführung von Analysen. Sie wird nur für Analysen verwendet, bei denen die Analysenleistung keine Bearbeitungszeit vorgibt. Es werden nur Laborarbeitstage berücksichtigt."
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "Dies ist die standardmäßige maximale Durchlaufzeit für Analysen. Sie wird nur für Analysen verwendet, bei denen die Analyseleistung keine Durchlaufzeit vorgibt. Es werden nur Laborarbeitstage berücksichtigt."
 
@@ -6029,11 +6364,11 @@ msgstr "Diese Probe wurde von ${actor_fullname} (${actor_id}) am ${date} aus fol
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr "Diese Probe wurde von ${actor_fullname} (${actor_id}) am ${date} ungültig gesetzt."
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr "Diese Analyseleistung kann nicht ausgewählt werden, um zu verhindern, dass die Analyse über die analytische Haltezeit hinaus durchgeführt wird."
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr "Dies zeigt ein benutzerdefiniertes Logo auf Ihrer SENAITE-Seite."
 
@@ -6065,8 +6400,8 @@ msgstr "Zeit"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Angehängte Dokumente werden nicht geladen solange sie nicht verfügbar sind"
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Name"
@@ -6093,34 +6428,42 @@ msgstr "Name der Einrichtung"
 msgid "To"
 msgstr "Bis"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Zu konservieren"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Zu beproben"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr "Zu veröffentlichen"
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr "Zu verifizieren"
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Unterhalb der Analysekategorien im Ergebnisbericht anzuzeigen"
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Zu konservieren"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "Zu drucken"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Zu beproben"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Zu verifizieren"
@@ -6133,7 +6476,7 @@ msgstr "Geben Sie hier die Werte für alle Berechnungsparameter ein, um diese Be
 msgid "Toggle visibility of standard sample header fields"
 msgstr "Schalten Sie die Sichtbarkeit der Standard-Felder im Kopfbereich der Probe um"
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Gesamt"
 
@@ -6155,7 +6498,7 @@ msgid "Tuesday"
 msgstr "Dienstag"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Typ"
@@ -6180,6 +6523,10 @@ msgstr "Art des Behälters"
 msgid "Type to filter ..."
 msgstr "Tippen um zu filtern ..."
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr "Zum Filtern tippen..."
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr "Typen, die Etiketten direkt unterstützen. <br/>HINWEIS: In Cluster-Setups müssen andere Instanzen manuell neu gestartet werden, damit die Änderungen wirksam werden!"
@@ -6188,7 +6535,7 @@ msgstr "Typen, die Etiketten direkt unterstützen. <br/>HINWEIS: In Cluster-Setu
 msgid "Types with labels"
 msgstr "Typen mit Etiketten"
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr "UID"
 
@@ -6200,6 +6547,7 @@ msgstr "Laden des Templates fehlgeschlagen"
 msgid "Unassign"
 msgstr "Zuweisung aufheben"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Nicht zugeordnet"
@@ -6232,9 +6580,13 @@ msgstr "Unbekanntes IBAN Land %s"
 msgid "Unlink User"
 msgstr "Benutzerverknüpfung aufheben"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
 msgstr "Benutzerverknüpfung aufgehoben"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr "Entsperren"
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6250,13 +6602,17 @@ msgstr "Unbekanntes Dateiformat ${file_format}"
 msgid "Unrecognized file format ${format}"
 msgstr "Unbekanntes Dateiformat ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "Nicht zugewiesen"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Anhänge Aktualisieren"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr "Voreinstellung mit aktueller Ansicht aktualisieren"
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6266,7 +6622,7 @@ msgstr "{} Schlüssel aktualisiert: {}"
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Hier können Sie ihre gescannte Unterschrift zur Verwendung auf Ergebnisberichten hochladen. Die ideale Größe beträgt 250 Pixel breit x 150 Pixel hoch"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr "Dateien und Bilder für diesen Kunden hochladen. Dateien werden im Kundenordner gespeichert und können später heruntergeladen werden."
 
@@ -6274,7 +6630,7 @@ msgstr "Dateien und Bilder für diesen Kunden hochladen. Dateien werden im Kunde
 msgid "Use Analysis Profile Price"
 msgstr "Verwende Preis des Analysenprofils"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Dashboard als Standardansicht für angemeldete Benutzer wählen"
 
@@ -6312,7 +6668,7 @@ msgstr "Benutzer ist mit dem Kontakt '${fullname}' verknüpft"
 msgid "User is linked to the global contact '${fullname}'"
 msgstr "Benutzer ist mit dem globalen Kontakt '${fullname}' verknüpft"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "Benutzer wurde zu diesem Kontakt verknüpft"
 
@@ -6320,15 +6676,15 @@ msgstr "Benutzer wurde zu diesem Kontakt verknüpft"
 msgid "User name"
 msgstr "Benutzername"
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr "Benutzername"
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Derart wenige Messwerte ergeben statistischen gesehen keinen Sinn. Erfassen Sie weitere Daten für eine zuverlässige QC Auswertung."
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6336,7 +6692,7 @@ msgstr "MwSt."
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "MwSt. %"
 
@@ -6583,8 +6939,8 @@ msgstr "Wert für Sekunden muss zwischen 0 und 59,9999 liegen"
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Die hier eingetragenen Werte ersetzen die vorläufigen Standardwerte der Berechnungsfelder."
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verifiziert"
@@ -6593,11 +6949,19 @@ msgstr "Verifiziert"
 msgid "Verified By"
 msgstr "Verifiziert von"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr "Verifizierte Proben, die zur Veröffentlichung bereit sind"
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Verifizieren"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr "Ergebnisse verifizieren"
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6612,6 +6976,14 @@ msgstr "Anzeigen"
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
 msgstr "SENAITE Seite ansehen"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr "Sichtbar"
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr "Sichtbare / gesamte Spalten"
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -6646,6 +7018,10 @@ msgstr "Webseite"
 msgid "Wednesday"
 msgstr "Mittwoch"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr "Wöchentlich"
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Wochen bis zum Verfall"
@@ -6658,19 +7034,19 @@ msgstr "Willkommen"
 msgid "Welcome to SENAITE"
 msgstr "Willkommen bei SENAITE"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr "Wenn aktiviert, können Analytiker nur auf Arbeitsblätter zugreifen, denen sie zugewiesen sind. Wenn deaktiviert, haben Analytiker Zugriff auf alle Arbeitsblätter."
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr "Wenn aktiviert, können nur Laborleiter Arbeitsblätter erstellen und verwalten. Wenn deaktiviert, können auch Analytiker und Labormitarbeiter Arbeitsblätter verwalten. Hinweis: Diese Einstellung wird automatisch aktiviert und gesperrt, wenn der Arbeitsblattzugriff auf zugewiesene Analytiker beschränkt ist."
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr "Wenn aktiviert, wird die Probe automatisch verifiziert, sobald alle Ergebnisse verifiziert sind. Andernfalls müssen Benutzer mit ausreichenden Berechtigungen die Probe anschließend manuell verifizieren. Standard: aktiviert"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr "Wenn aktiviert, können Benutzer Ergebnisse für Analysen einreichen, die nicht ihnen zugewiesen sind oder für nicht zugewiesene Analysen. Wenn deaktiviert, können Benutzer nur Ergebnisse für ihnen zugewiesene Analysen einreichen. Diese Einstellung gilt nicht für Benutzer mit der Rolle Laborleiter."
 
@@ -6721,10 +7097,18 @@ msgstr "Arbeitsblattvorlagen"
 msgid "Worksheet printing templates order"
 msgstr "Reihenfolge der Druckvorlagen für Arbeitsblätter"
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Arbeitsblätter"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr "Arbeitsblätter, die verifiziert wurden"
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr "Arbeitsblätter, deren Ergebnisse auf die Verifizierung warten"
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6733,6 +7117,10 @@ msgstr "Falsche IBAN-Länge bei %s: %s"
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Falsche IBAN Länge von %s: %s ist %i zu kurz"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr "Jährlich"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6817,6 +7205,10 @@ msgstr "Duplikat"
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
 msgstr "Analytiker muss angegeben werden."
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
+msgstr "auto"
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
@@ -6911,7 +7303,7 @@ msgstr "${d}.${m}.${y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
+#. Default: "yy-mm-dd"
 #, fuzzy
 msgid "date_format_short_datepicker"
 msgstr "tt.mm.jj"
@@ -6924,8 +7316,17 @@ msgstr "Tage"
 msgid "deactivate"
 msgstr "deaktivieren"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr "Probe nach Ablauf der Aufbewahrungsfrist entsorgt."
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr "gelöscht von {user} am {time}"
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr "Angehängte Etiketten"
 
@@ -6993,7 +7394,7 @@ msgstr "Diese Analyseleistung wird im Probenregistrierungsformular nicht zur Aus
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 #, fuzzy
 msgid "description_analysis_results_options_sorting"
 msgstr "Zu verwendende Kriterien, wenn Ergebnisoptionen in Ergebniseintragslisten zur Auswahl angezeigt werden. Beachten Sie, dass dies nur für die in der Auswahlliste angezeigten Optionen gilt. Es hat keinen Einfluss auf die Reihenfolge, in der die Ergebnisse nach der Übermittlung angezeigt werden"
@@ -7169,27 +7570,27 @@ msgstr "Wählen Sie den Kunden dieses Batches aus"
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 #, fuzzy
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr "Wenn diese Option aktiviert ist, kann das Ergebniserfassungsdatum für Analysen manuell eingegeben werden"
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 #, fuzzy
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr "Bei Auswahl erhalten die Verantwortlichen aller beteiligten Laborabteilungen Veröffentlichungs-E-Mails"
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr "Analysen in Proben nach Kategorie gruppieren"
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 #, fuzzy
 msgid "description_bikasetup_date_sampled_required"
 msgstr "Auswählen, um das Feld 'Datum der Entnahme' bei der Probenerstellung als Pflichtfeld festzulegen. Diese Funktion hat nur Auswirkung, wenn der 'Probenahme-Workflow' nicht aktiv ist"
@@ -7197,7 +7598,7 @@ msgstr "Auswählen, um das Feld 'Datum der Entnahme' bei der Probenerstellung al
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 #, fuzzy
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr "Legen Sie den E-Mail-Text fest, der standardmäßig verwendet werden soll, wenn Ergebnisberichte an die ausgewählten Empfänger gesendet werden. Sie können reservierte Schlüsselwörter verwenden: $client_name, $recipients, $lab_name, $lab_address"
@@ -7205,7 +7606,7 @@ msgstr "Legen Sie den E-Mail-Text fest, der standardmäßig verwendet werden sol
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 #, fuzzy
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr "E-Mail-Adresse, die als Absenderadresse für ausgehende E-Mails beim Veröffentlichen von Ergebnisberichten verwendet wird. Diese Adresse überschreibt den in den 'Mail-Einstellungen' des Portals festgelegten Wert."
@@ -7213,7 +7614,7 @@ msgstr "E-Mail-Adresse, die als Absenderadresse für ausgehende E-Mails beim Ver
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 #, fuzzy
 msgid "description_bikasetup_immediateresultsentry"
 msgstr "Ermöglichen Sie dem Benutzer die direkte Eingabe von Ergebnissen nach der Probenerstellung, z.B. zur sofortigen Eingabe von Feldergebnissen oder Laborergebnissen, wenn der automatische Probenempfang aktiviert ist."
@@ -7226,7 +7627,7 @@ msgstr "Ermöglichen Sie dem Benutzer die direkte Eingabe von Ergebnissen nach d
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 #, fuzzy
 msgid "description_bikasetup_invalidation_email_body"
 msgstr "Vorlage für den E-Mail-Text definieren, der automatisch an primäre Kontakte und Laborleiter gesendet wird, wenn eine Probe ungültig gesetzt wird. Folgende Platzhalter werden unterstützt: <code title='Die ID der Probe'>$sample_id</code>, <code title='Die ID der Wiederholungsprobe'>$retest_id</code>, <code title='Der Link zur Wiederholungsprobe'>$retest_link</code>, <code title='Der/die Grund/Gründe für die Ungültigkeitserklärung'>$reason</code>, <code title='Die Adresse des Labors'>$lab_address</code>."
@@ -7234,13 +7635,13 @@ msgstr "Vorlage für den E-Mail-Text definieren, der automatisch an primäre Kon
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 #, fuzzy
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr "Angeben, ob die Angabe eines Grundes bei der Ungültigkeitserklärung einer Probe verpflichtend ist. Wenn aktiviert, wird der Platzhalter '$reason' im E-Mail-Text der Benachrichtigung über die Probenungültigkeitserklärung durch den eingegebenen Grund ersetzt."
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr "Für die Probenregistrierung sind Analysen erforderlich"
 
@@ -7262,21 +7663,27 @@ msgstr "Abhängige Analyesleistungen dieser Berechnung"
 msgid "description_calculation_formula"
 msgstr "<p>Die hier eingegebene Formel wird dynamisch berechnet, sobald eine Analyse mit dieser Berechnung angezeigt wird.</p><p>Für die Berechnung können die Standard-Rechenoperatoren + - * / ( ) sowie alle verfügbaren Schlüsselwörter — sowohl aus anderen Analyseverfahren als auch aus den hier definierten Interim-Feldern — als Variablen verwendet werden. Diese in eckige Klammern [ ] setzen.</p><p>Beispiel: die Berechnung der Gesamthärte als Summe von Calcium (ppm) und Magnesium (ppm) wird als [Ca] + [Mg] eingegeben, wobei Ca und Mg die Schlüsselwörter der beiden Analyseverfahren sind.</p>"
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 #, fuzzy
 msgid "description_calculation_imports"
 msgstr "Interim-Felder wie Gefäßmasse, Verdünnungsfaktoren etc. festlegen, sofern für die Berechnung erforderlich. Der hier angegebene Feldtitel wird als Spaltenkopf und Feldbezeichnung verwendet, wo die Interim-Felder angezeigt werden. Ist 'Übergreifend anwenden' aktiviert, wird das Feld in einer Auswahlbox oben auf dem Arbeitsblatt angezeigt, mit der ein einzelner Wert auf alle entsprechenden Felder des Blatts angewendet werden kann."
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
+#, fuzzy
 msgid "description_calculation_interims"
-msgstr ""
+msgstr "Definieren Sie Zwischenfelder wie Gefäßmasse oder Verdünnungsfaktoren, falls Ihre Berechnung diese benötigt. Der hier angegebene Feldtitel wird als Spaltenüberschrift und Feldbeschreibung verwendet, wo die Zwischenfelder angezeigt werden. Wenn 'Breit anwenden' aktiviert ist, wird das Feld in einem Auswahlfeld oben im Arbeitsblatt angezeigt, sodass ein bestimmter Wert auf alle entsprechenden Felder des Blattes angewendet werden kann."
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
@@ -7299,12 +7706,12 @@ msgid "description_category_department"
 msgstr "Wählen Sie die zuständige Abteilung aus"
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr "Erweitern Sie immer die ausgewählten Kategorien"
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr "Nur ausgewählte Kategorien anzeigen"
 
@@ -7314,7 +7721,7 @@ msgid "description_confidence_level"
 msgstr "Dieser Wert wird unten auf allen veröffentlichten Berichten ausgegeben"
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr "Kontakte in Kopie für neue Proben"
 
@@ -7421,6 +7828,21 @@ msgstr "Wählen Sie aus einer der ausgewählten Abteilungen eine Standardabteilu
 msgid "description_labcontact_departments"
 msgstr "Zugeordnete Laborabteilungen"
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+#, fuzzy
+msgid "description_label_color"
+msgstr "Hex-Farbcode für den Chip (z. B. #0d6efd). Leer lassen für den Standardstil."
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+#, fuzzy
+msgid "description_label_title"
+msgstr "Das Umbenennen dieses Etiketts überschreibt den gespeicherten Namen bei allen aktuell etikettierten Inhalten. Der Kaskadenvorgang läuft in derselben Transaktion wie das Speichern und kann bei großen Datenmengen einen Moment dauern."
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7452,6 +7874,14 @@ msgstr "Bitte den Preis ohne Mehrwertsteuer angeben"
 #, fuzzy
 msgid "description_labproduct_vat"
 msgstr "Bitte den Mehrwertsteuersatz in Prozent angeben, der zum Laborproduktpreis addiert wird"
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+#, fuzzy
+msgid "description_manage_viewlets"
+msgstr "Die Viewlet-Manager und ihre Viewlets werden an Ort und Stelle angezeigt, verschachtelt und so positioniert, wie sie auf der Website erscheinen. Verwenden Sie die Steuerelemente, um jedes Viewlet auszublenden, anzuzeigen oder neu anzuordnen."
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
@@ -7610,12 +8040,12 @@ msgid "description_registry_worksheet_settings"
 msgstr "Konfiguration der Arbeitsblattansicht"
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr "Im PDF enthaltene Proben"
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr "Die primäre Probe des PDFs"
 
@@ -7880,7 +8310,7 @@ msgstr "Wählen Sie die Probenmatrix für diese Probenart aus"
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 #, fuzzy
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr "Wenn diese Option aktiviert ist, kann das Ergebniserfassungsdatum für Analysen manuell eingegeben werden"
@@ -7889,21 +8319,21 @@ msgstr "Wenn diese Option aktiviert ist, kann das Ergebniserfassungsdatum für A
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 #, fuzzy
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr "Wenn aktiviert, können Benutzer Ergebnisse für Analysen einreichen, die nicht ihnen zugewiesen sind oder für nicht zugewiesene Analysen. Wenn deaktiviert, können Benutzer nur Ergebnisse für ihnen zugewiesene Analysen einreichen. Diese Einstellung gilt nicht für Benutzer mit der Rolle Laborleiter."
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 #, fuzzy
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr "Bei Auswahl erhalten die Verantwortlichen aller beteiligten Laborabteilungen Veröffentlichungs-E-Mails."
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 #, fuzzy
 msgid "description_senaitesetup_auto_log_off"
 msgstr "Die Anzahl der Minuten, nach der ein Benutzer automatisch abgemeldet wird. 0 deaktiviert die automatische Abmeldung"
@@ -7911,54 +8341,54 @@ msgstr "Die Anzahl der Minuten, nach der ein Benutzer automatisch abgemeldet wir
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 #, fuzzy
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr "Wenn aktiviert, wird die Probe automatisch verifiziert, sobald alle Ergebnisse verifiziert sind. Andernfalls müssen Benutzer mit ausreichenden Rechten die Probe anschließend manuell verifizieren. Standard: aktiviert"
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 #, fuzzy
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr "Analyseleistungen in LIMS-Tabellen nach Kategorie gruppieren, hilfreich bei langen Listen"
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr "Analysen in Proben nach Kategorie gruppieren"
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr "Währung auswählen, die die Website für die Preisanzeige verwenden soll."
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr "Auswählen, um das Dashboard als Standard-Startseite zu aktivieren."
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 #, fuzzy
 msgid "description_senaitesetup_date_sampled_required"
 msgstr "Auswählen, um das Feld 'Datum der Entnahme' bei der Probenerstellung als Pflichtfeld festzulegen. Diese Funktion hat nur Auswirkung, wenn der 'Probenahme-Workflow' nicht aktiv ist"
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr "Bevorzugtes Dezimaltrennzeichen für Berichte."
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr "Das Land auswählen, das die Website standardmäßig anzeigen soll"
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 #, fuzzy
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr "Standardwert für 'Probenanzahl', wenn Benutzer auf 'HINZUFÜGEN' klicken, um neue Proben zu erstellen"
@@ -7966,26 +8396,26 @@ msgstr "Standardwert für 'Probenanzahl', wenn Benutzer auf 'HINZUFÜGEN' klicke
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 #, fuzzy
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr "E-Mail-Adresse, die als Absenderadresse für ausgehende E-Mails beim Veröffentlichen von Ergebnisberichten verwendet wird. Diese Adresse überschreibt den in den 'Mail-Einstellungen' des Portals festgelegten Wert."
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 #, fuzzy
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr "Wenn aktiviert, wird in der Ergebniserfassungsansicht neben jeder Analyse ein Freitextfeld angezeigt"
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr "Analysenspezifikationen, die direkt auf der Probe bearbeitet werden."
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 #, fuzzy
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr "Auswählen, um den Ablehnungs-Workflow für Proben zu aktivieren. Im Aktionsmenü wird eine Option 'Ablehnen' angezeigt."
@@ -7993,7 +8423,7 @@ msgstr "Auswählen, um den Ablehnungs-Workflow für Proben zu aktivieren. Im Akt
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 #, fuzzy
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr "Ergebniswerte mit mindestens dieser Anzahl signifikanter Stellen werden in wissenschaftlicher Notation mit dem Buchstaben 'e' zur Kennzeichnung des Exponenten angezeigt. Die Genauigkeit kann in einzelnen Analyseleistungen konfiguriert werden."
@@ -8001,7 +8431,7 @@ msgstr "Ergebniswerte mit mindestens dieser Anzahl signifikanter Stellen werden 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 #, fuzzy
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr "Ermöglichen Sie dem Benutzer die direkte Eingabe von Ergebnissen nach der Probenerstellung, z.B. zur sofortigen Eingabe von Feldergebnissen oder Laborergebnissen, wenn der automatische Probenempfang aktiviert ist."
@@ -8009,7 +8439,7 @@ msgstr "Ermöglichen Sie dem Benutzer die direkte Eingabe von Ergebnissen nach d
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 #, fuzzy
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr "Angeben, ob die Angabe eines Grundes bei der Ungültigkeitserklärung einer Probe verpflichtend ist. Wenn aktiviert, wird der Platzhalter '$reason' im E-Mail-Text der Benachrichtigung durch den eingegebenen Grund ersetzt."
@@ -8017,7 +8447,7 @@ msgstr "Angeben, ob die Angabe eines Grundes bei der Ungültigkeitserklärung ei
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 #, fuzzy
 msgid "description_senaitesetup_landing_page"
 msgstr "Die Startseite wird nicht authentifizierten Benutzern angezeigt, wenn das Dashboard nicht als Standard-Startseite ausgewählt ist. Wenn keine Startseite ausgewählt ist, wird die Standard-Startseite angezeigt."
@@ -8025,7 +8455,7 @@ msgstr "Die Startseite wird nicht authentifizierten Benutzern angezeigt, wenn da
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 #, fuzzy
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr "Maximale Anzahl an Proben, die gemäß dem im Probenregistrierungsformular für das Feld „Anzahl der Proben“ festgelegten Wert erstellt werden können"
@@ -8033,7 +8463,7 @@ msgstr "Maximale Anzahl an Proben, die gemäß dem im Probenregistrierungsformul
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 #, fuzzy
 msgid "description_senaitesetup_member_discount"
 msgstr "Der hier eingegebene Rabattprozentsatz wird auf die Preise für Kunden angewendet, die als 'Mitglieder' gekennzeichnet sind, in der Regel Genossenschaftsmitglieder oder Gesellschafter, die diesen Rabatt erhalten"
@@ -8041,7 +8471,7 @@ msgstr "Der hier eingegebene Rabattprozentsatz wird auf die Preise für Kunden a
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 #, fuzzy
 msgid "description_senaitesetup_minimum_results"
 msgstr "Zu wenige Datenpunkte ergeben statistisch keinen Sinn. Eine akzeptable Mindestanzahl von Ergebnissen festlegen, bevor QC-Statistiken berechnet und dargestellt werden"
@@ -8049,7 +8479,7 @@ msgstr "Zu wenige Datenpunkte ergeben statistisch keinen Sinn. Eine akzeptable M
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 #, fuzzy
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr "Anzahl der erforderlichen Verifizierungen, bevor ein Ergebnis als 'verifiziert' gilt. Diese Einstellung kann für jede Analyse in der Bearbeitungsansicht der Analyseleistung überschrieben werden. Standard: 1"
@@ -8057,14 +8487,14 @@ msgstr "Anzahl der erforderlichen Verifizierungen, bevor ein Ergebnis als 'verif
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 #, fuzzy
 msgid "description_senaitesetup_publication_email_text"
 msgstr "Legen Sie den E-Mail-Text fest, der standardmäßig verwendet werden soll, wenn Ergebnisberichte an die ausgewählten Empfänger gesendet werden. Sie können reservierte Schlüsselwörter verwenden: $client_name, $recipients, $lab_name, $lab_address"
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 #, fuzzy
 msgid "description_senaitesetup_rejection_reasons"
 msgstr "Die vordefinierten Ablehnungsgründe eingeben, die Benutzer beim Ablehnen einer Probe auswählen können."
@@ -8073,51 +8503,51 @@ msgstr "Die vordefinierten Ablehnungsgründe eingeben, die Benutzer beim Ablehne
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 #, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr "Wenn aktiviert, können nur Laborleiter Arbeitsblätter erstellen und verwalten. Wenn deaktiviert, können auch Analytiker und Labormitarbeiter Arbeitsblätter verwalten. Hinweis: Diese Einstellung wird automatisch aktiviert und gesperrt, wenn der Arbeitsblattzugriff auf zugewiesene Analytiker beschränkt ist."
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 #, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr "Wenn aktiviert, können Analytiker nur auf Arbeitsblätter zugreifen, denen sie zugewiesen sind. Wenn deaktiviert, haben Analytiker Zugriff auf alle Arbeitsblätter."
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr "Bevorzugtes Dezimaltrennzeichen für Ergebnisse"
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 #, fuzzy
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr "Wenn aktiviert, können Benutzer mit ausreichender Berechtigung über die Aktion 'Probe duplizieren' in der Probenliste direkt eine Geschwisterprobe aus einer bestehenden Probe erzeugen. Standardmäßig aktiviert."
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr "Für die Probenregistrierung sind Analysen erforderlich"
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 #, fuzzy
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr "Auswählen, welche Spalten in den Probenanalyse-Listen angezeigt werden sollen. Die Reihenfolge der Auswahl bestimmt die Anzeigereihenfolge. Nicht ausgewählte Spalten werden ausgeblendet. Leer lassen, um alle Spalten in der Standardreihenfolge anzuzeigen."
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr "Bevorzugtes Format der wissenschaftlichen Notation für Berichte"
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr "Bevorzugtes Format der wissenschaftlichen Notation für Ergebnisse"
 
@@ -8126,14 +8556,14 @@ msgstr "Bevorzugtes Format der wissenschaftlichen Notation für Ergebnisse"
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 #, fuzzy
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr "Wenn aktiviert, kann ein Benutzer, der ein Ergebnis eingereicht hat, es auch verifizieren. Diese Einstellung gilt nur für Benutzer mit einer Rolle, die ihnen die Verifizierung von Ergebnissen erlaubt (standardmäßig Manager, Laborleiter und Verifizierer). Diese Einstellung kann für eine bestimmte Analyse in der Bearbeitungsansicht der Analyseleistung überschrieben werden. Standard: deaktiviert."
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 #, fuzzy
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr "Wenn ausgewählt, wird der Laborname auf der Anmeldeseite oberhalb der Zugangsdaten angezeigt."
@@ -8141,7 +8571,7 @@ msgstr "Wenn ausgewählt, wird der Laborname auf der Anmeldeseite oberhalb der Z
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 #, fuzzy
 msgid "description_senaitesetup_show_partitions"
 msgstr "Auswählen, um Probenpartitionen für Kundenkontakte anzuzeigen. Wenn deaktiviert, werden Partitionen nicht in Listen aufgeführt und Kundenkontakten werden keine Informationsmeldungen mit Links zur primären Probe angezeigt."
@@ -8150,21 +8580,21 @@ msgstr "Auswählen, um Probenpartitionen für Kundenkontakte anzuzeigen. Wenn de
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 #, fuzzy
 msgid "description_senaitesetup_sidebar_folders"
 msgstr "Auswählen, welche übergeordneten Ordner in der Seitenleistennavigation angezeigt werden sollen. Die Reihenfolge der Auswahl bestimmt die Anzeigereihenfolge. Wenn keine ausgewählt sind, werden alle Ordner in der Standardreihenfolge angezeigt."
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 #, fuzzy
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr "Maximale Tiefe der Seitenleisten-Navigationsstruktur. Ebene 1 zeigt nur übergeordnete Ordner, Ebene 2 enthält deren Unterordner usw."
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 #, fuzzy
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr "Auswählen, welche Inhaltstypen aus der Seitenleistennavigation ausgeschlossen werden sollen. Wenn keine ausgewählt sind, werden alle Inhaltstypen angezeigt."
@@ -8172,14 +8602,14 @@ msgstr "Auswählen, welche Inhaltstypen aus der Seitenleistennavigation ausgesch
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 #, fuzzy
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr "Methode für mehrfache Verifikation durch denselben Benutzer auswählen. Diese Einstellung kann die einfache bzw. mehrfache Verifikation durch denselben Benutzer aktivieren oder deaktivieren."
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 #, fuzzy
 msgid "description_senaitesetup_vat"
 msgstr "Prozentwert eingeben, z.B. 14,0. Dieser Prozentsatz wird systemweit angewendet, kann aber für einzelne Elemente überschrieben werden"
@@ -8188,7 +8618,7 @@ msgstr "Prozentwert eingeben, z.B. 14,0. Dieser Prozentsatz wird systemweit ange
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 #, fuzzy
 msgid "description_senaitesetup_worksheet_layout"
 msgstr "Bevorzugtes Layout der Ergebniserfassungstabelle in der Arbeitsblattansicht. Klassisches Layout zeigt Proben in Zeilen und Analysen in Spalten. Transponiertes Layout zeigt Proben in Spalten und Analysen in Zeilen."
@@ -8196,7 +8626,7 @@ msgstr "Bevorzugtes Layout der Ergebniserfassungstabelle in der Arbeitsblattansi
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 #, fuzzy
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr "Auswählen, welche Spalten in den Arbeitsblatt-Analyselisten angezeigt werden sollen. Die Reihenfolge der Auswahl bestimmt die Anzeigereihenfolge. Nicht ausgewählte Spalten werden ausgeblendet. Leer lassen, um alle Spalten in der Standardreihenfolge anzuzeigen."
@@ -8204,7 +8634,7 @@ msgstr "Auswählen, welche Spalten in den Arbeitsblatt-Analyselisten angezeigt w
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 #, fuzzy
 msgid "description_setup_landingpage"
 msgstr "Die Startseite wird nicht authentifizierten Benutzern angezeigt, wenn das Dashboard nicht als Standard-Startseite ausgewählt ist. Wenn keine Startseite ausgewählt ist, wird die Standard-Startseite angezeigt"
@@ -8367,6 +8797,10 @@ msgstr "${seconds} Sekunden"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
 msgstr "Inhalt der Datei"
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
+msgstr "bearbeitet"
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8679,7 +9113,7 @@ msgid "invalid_wildcards_check_error"
 msgstr "Ungültige Platzhalter gefunden: ${wildcards}"
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr "Etiketten"
 
@@ -8742,7 +9176,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr "Maximale Haltezeit"
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr "Sortierkriterien"
 
@@ -8860,52 +9294,52 @@ msgid "label_batch_client"
 msgstr "Kunde"
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr "Manuelle Eingabe des Ergebniserfassungsdatums erlauben"
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr "Veröffentlichungs-E-Mails immer an die Verantwortlichen versenden"
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr "Analysen in Proben kategorisieren"
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr "Entnahmedatum erforderlich"
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr "E-Mail-Text für Benachrichtigungen bei Probenveröffentlichung"
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr "Absenderadresse für Veröffentlichungen"
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr "Sofortige Ergebniseingabe"
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr "E-Mail-Text für Benachrichtigungen bei Probenungültigkeitserklärung"
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr "Ungültigkeitsgrund erforderlich"
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr "Analysen in Proben erforderlich"
 
@@ -8975,12 +9409,12 @@ msgid "label_category_department"
 msgstr "Abteilung"
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr "Standardkategorien"
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr "Kategorien einschränken"
 
@@ -8990,7 +9424,7 @@ msgid "label_confirm_password"
 msgstr "Passwort bestätigen"
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr "Kontakte in CC"
 
@@ -9287,7 +9721,7 @@ msgid "label_powered_by_plone"
 msgstr "Plone & Python"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr "Veröffentlichungspräferenz"
 
@@ -9412,12 +9846,12 @@ msgid "label_registry_worksheet_settings"
 msgstr "Arbeitsblatt"
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr "Enthaltene Proben"
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr "Primäre Probe"
 
@@ -9627,7 +10061,7 @@ msgid "label_sampletype_title"
 msgstr "Name"
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr "Speichern"
 
@@ -9637,12 +10071,12 @@ msgid "label_senaite"
 msgstr "SENAITE LIMS"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr "Maximalwert für das Feld „Anzahl der Proben“ bei der Registrierung"
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr "Startseite"
 
@@ -9701,6 +10135,23 @@ msgstr "Bevorzugtes Prüfgerät"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
 msgstr "Auf Methode beschränken"
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr "${count} Etikett(en) zu ${affected} Probe(n) hinzugefügt"
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+#, fuzzy
+msgid "labels_changed"
+msgstr "${added} hinzugefügt und ${removed} entfernt bei ${affected} Probe(n) angewendet"
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
+msgstr "${count} Etikett(en) von ${affected} Probe(n) entfernt"
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
@@ -10876,87 +11327,87 @@ msgid "listing_suppliers_title"
 msgstr "Lieferanten"
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr "Hinzufügen"
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr "Analytiker"
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr "Erstellt"
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr "Routineanalysen"
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr "QC-Analysen"
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr "Proben"
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr "Fortschritt"
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr "Status"
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr "Vorlage"
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr "Arbeitsblatt"
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr "Aktiv"
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr "Alle"
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr "Meine"
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr "Offen"
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr "Zu verifizieren"
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr "Verifiziert"
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr "Arbeitsblätter"
 
@@ -11009,6 +11460,11 @@ msgstr "Arbeitsblattvorlagen"
 msgid "minutes"
 msgstr "Minuten"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr "geändert"
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "monatlich"
@@ -11060,13 +11516,21 @@ msgstr "Layout-Ansicht '${view}' nicht gefunden. '${default}' als Layout-Ansicht
 msgid "num_of_positions_button_title"
 msgstr "Festlegen"
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "von"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr "Original"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "Übersicht"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr "pro Liste"
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11144,6 +11608,11 @@ msgstr "Schnittstellencode"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
 msgstr "Diese Probe wurde von ${actor} am ${date} versandt."
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
+msgstr "Diese Probe wurde von ${actor} am ${date} entsorgt"
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11377,13 +11846,18 @@ msgstr "Laborant"
 msgid "title_lab_manager_role"
 msgstr "Laborleiter"
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr "Farbe"
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr "Beschreibung"
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr "Name"
 
@@ -11471,6 +11945,11 @@ msgstr "Referenz"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
 msgstr "Analysentyp"
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
+msgstr "Viewlets verwalten"
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
@@ -11715,222 +12194,222 @@ msgid "title_samplingdeviation_title"
 msgstr "Name"
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr "Manuelle Eingabe des Ergebniserfassungsdatums erlauben"
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr "Ergebniserfassung für nicht zugewiesene Analysen erlauben"
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr "Senden Sie Veröffentlichungs-E-Mails immer an die Verantwortlichen"
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr "Automatische Abmeldung"
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr "Automatische Verifizierung von Proben"
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr "Analyseleistungen kategorisieren"
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr "Analysen in Proben kategorisieren"
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr "Währung"
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr "Dashboard als Standard-Startseite verwenden"
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr "Entnahmedatum erforderlich"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr "Standard-Dezimaltrennzeichen"
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr "Land"
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr "Standard-Probenanzahl beim Hinzufügen"
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr "Absenderadresse für Veröffentlichungen"
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr "Bemerkungsfeld zu allen Analysen hinzufügen"
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr "Probenspezifikationen aktivieren"
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr "Ablehnungs-Workflow aktivieren"
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr "Schwellenwert für Exponentialformat"
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr "Ungültigkeitsgrund erforderlich"
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr "Startseite"
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr "Mitgliederrabatt %"
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr "Mindestanzahl der Ergebnisse für QC-Statistiken"
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr "Anzahl der erforderlichen Verifizierungen"
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr "E-Mail Text bei Probenveröffentlichung"
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr "Ablehnungsgründe"
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr "Arbeitsblattverwaltung auf Laborleiter beschränken"
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr "Arbeitsblattzugriff auf zugewiesene Analytiker beschränken"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr "Standard-Dezimaltrennzeichen"
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr "Probenduplikation erlauben"
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr "Analysen in Probe erforderlich"
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr "Analysespalten in der Probenansicht"
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr "Standard-Wissenschaftsnotationsformat für Berichte"
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr "Standard-Wissenschaftsnotationsformat für Ergebnisse"
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr "Selbstverifizierung von Ergebnissen erlauben"
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr "Laborname auf der Anmeldeseite anzeigen"
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr "Probenpartitionen für Kunden anzeigen"
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr "Preisinformationen einbeziehen und anzeigen"
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr "Seitenleisten-Navigationsordner"
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr "Seitenleisten-Navigationstiefe"
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr "Übersprungene Portaltypen in der Seitenleiste"
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr "Typ der Mehrfachverifizierung"
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr "MwSt. %"
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr "Standard-Layout in der Arbeitsblattansicht"
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr "Analysespalten in der Arbeitsblattansicht"
 
@@ -12189,7 +12668,7 @@ msgstr "Die Referenzproben-ID ist ungültig. Sicherstellen, dass sie nur Buchsta
 msgid "validator_uloq_above_ulod"
 msgstr "Die Obere Bestimmungsgrenze (ULOQ) darf nicht größer sein als die Obere Nachweisgrenze (ULOD)."
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "Verifikation(en) ausstehend"
 
@@ -12232,276 +12711,10 @@ msgstr "{sid}: Ergebnis für '{analysis_keyword}:{interim_keyword}': '{value}'"
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr "{sid}: Ergebnis für '{keyword}': '{result}'"
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr "{} (veraltet)"
 
 #: bika/lims/controlpanel/bika_instruments.py:173
 msgid "{} weeks and {} day(s)"
 msgstr "{} Woche(n) und {} Tag(e)"
-
-# senaite.app.listing: Saved filter presets — toggle title + menu header
-msgid "Saved filters"
-msgstr "Gespeicherte Filter"
-
-# senaite.app.listing: Saved filter presets — menu subtitle
-msgid "per listing"
-msgstr "pro Listenansicht"
-
-# senaite.app.listing: Saved filter presets — empty state
-msgid "No saved filters yet."
-msgstr "Noch keine gespeicherten Filter."
-
-# senaite.app.listing: Saved filter presets — footer button to save the current view
-msgid "Save current view"
-msgstr "Aktuelle Ansicht speichern"
-
-# senaite.app.listing: Saved filter presets — inline editor placeholder
-msgid "Filter name"
-msgstr "Filtername"
-
-# senaite.app.listing: Saved filter presets — default name when saving
-msgid "My filter"
-msgstr "Mein Filter"
-
-# senaite.app.listing: Saved filter presets — row action tooltip
-msgid "Rename filter"
-msgstr "Filter umbenennen"
-
-# senaite.app.listing: Saved filter presets — row action tooltip
-msgid "Delete filter"
-msgstr "Filter löschen"
-
-# senaite.app.listing: Saved filter presets — star action tooltip
-msgid "Auto-apply on open"
-msgstr "Beim Öffnen automatisch anwenden"
-
-# senaite.app.listing: Saved filter presets — star action tooltip when active
-msgid "Stop auto-applying"
-msgstr "Automatisches Anwenden beenden"
-
-# senaite.app.listing: Saved filter presets — micro-tag on the default preset
-msgid "auto"
-msgstr "auto"
-
-# senaite.app.listing: Saved filter presets — dirty indicator on the applied preset
-msgid "modified"
-msgstr "geändert"
-
-# senaite.app.listing: Saved filter presets — apply button tooltip
-msgid "Apply this filter"
-msgstr "Diesen Filter anwenden"
-
-# senaite.app.listing: Saved filter presets — release button tooltip on the applied preset
-msgid "Click to release this filter"
-msgstr "Klicken, um den Filter zu lösen"
-
-# senaite.app.listing: Saved filter presets — Update preset action tooltip
-msgid "Update preset with current view"
-msgstr "Filter mit aktueller Ansicht aktualisieren"
-
-# senaite.app.listing: Saved filter presets — Revert action tooltip
-msgid "Discard edits and restore preset"
-msgstr "Änderungen verwerfen und Filter wiederherstellen"
-
-# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
-msgid "Current view differs from saved"
-msgstr "Aktuelle Ansicht weicht vom gespeicherten Filter ab"
-
-# senaite.app.listing: Column header — sort arrow tooltip / aria-label
-msgid "Sort ascending"
-msgstr "Aufsteigend sortieren"
-
-# senaite.app.listing: Column header — sort arrow tooltip / aria-label
-msgid "Sort descending"
-msgstr "Absteigend sortieren"
-
-# senaite.app.listing: Search box — undo / reset-view button tooltip
-msgid "Reset view"
-msgstr "Ansicht zurücksetzen"
-
-# senaite.app.listing: Search box — undo button tooltip when only clearing search
-msgid "Clear search"
-msgstr "Suche leeren"
-
-# senaite.app.listing: Column-filter row — searchable-select placeholder
-msgid "Type to filter..."
-msgstr "Zum Filtern tippen…"
-
-# senaite.app.listing: Column-filter row — text-input placeholder
-msgid "Filter..."
-msgstr "Filtern…"
-
-# senaite.app.listing: Column-filter row — boolean select placeholder
-msgid "-- Select --"
-msgstr "-- Auswählen --"
-
-# senaite.app.listing: Column-filter row — clear button tooltip
-msgid "Clear filter"
-msgstr "Filter leeren"
-
-# senaite.app.listing: Column config — trigger button label
-msgid "Configure"
-msgstr "Konfigurieren"
-
-# senaite.app.listing: Column config — search input placeholder
-msgid "Search columns…"
-msgstr "Spalten suchen…"
-
-# senaite.app.listing: Column config — visible-section header
-msgid "Visible"
-msgstr "Sichtbar"
-
-# senaite.app.listing: Column config — bulk action button
-msgid "Hide all"
-msgstr "Alle ausblenden"
-
-# senaite.app.listing: Column config — counter title attribute
-msgid "Visible / total columns"
-msgstr "Sichtbare / gesamte Spalten"
-
-# senaite.app.listing: Column config — drag handle tooltip / aria-label
-msgid "Drag to reorder"
-msgstr "Ziehen, um die Reihenfolge zu ändern"
-
-# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
-msgid "Hide this column"
-msgstr "Diese Spalte ausblenden"
-
-# senaite.app.listing: Column config — plus button tooltip / aria-label
-msgid "Show this column"
-msgstr "Diese Spalte einblenden"
-
-# senaite.app.listing: Column config — reset link tooltip
-msgid "Reset to default columns and order"
-msgstr "Auf Standardspalten und -reihenfolge zurücksetzen"
-
-# senaite.app.listing: Column config — empty state for visible section with search
-msgid "No matches in visible columns."
-msgstr "Keine Treffer in sichtbaren Spalten."
-
-# senaite.app.listing: Column config — empty state when no columns are visible
-msgid "All columns are hidden."
-msgstr "Alle Spalten sind ausgeblendet."
-
-# senaite.app.listing: Column config — empty state for hidden section with search
-msgid "No matches in hidden columns."
-msgstr "Keine Treffer in ausgeblendeten Spalten."
-
-#: senaite/core/browser/samples/view.py:507
-msgid "Filter samples by this analysis"
-msgstr "Proben nach dieser Analyse filtern"
-
-#: senaite/core/browser/samples/view.py:537
-msgid "Remove this analysis from the filter"
-msgstr "Diese Analyse aus dem Filter entfernen"
-
-#: senaite/core/browser/samples/view.py:518
-msgid "Showing samples that contain:"
-msgstr "Angezeigt werden Proben, die Folgendes enthalten:"
-#: senaite/core/browser/dashboard/dashboard.py:368
-msgid "Samples awaiting collection of the sample"
-msgstr "Proben, die auf die Probenahme warten"
-
-#: senaite/core/browser/dashboard/dashboard.py:372
-msgid "Samples awaiting preservation"
-msgstr "Proben, die auf die Konservierung warten"
-
-#: senaite/core/browser/dashboard/dashboard.py:377
-msgid "Samples with a scheduled sampling date"
-msgstr "Proben mit geplantem Probenahmedatum"
-
-#: senaite/core/browser/dashboard/dashboard.py:384
-msgid "Samples awaiting reception at the laboratory"
-msgstr "Proben, die auf den Eingang im Labor warten"
-
-#: senaite/core/browser/dashboard/dashboard.py:388
-msgid "Received samples with analyses awaiting results"
-msgstr "Eingegangene Proben mit Analysen, die auf Ergebnisse warten"
-
-#: senaite/core/browser/dashboard/dashboard.py:392
-msgid "Samples whose results are awaiting verification"
-msgstr "Proben, deren Ergebnisse auf Verifizierung warten"
-
-#: senaite/core/browser/dashboard/dashboard.py:396
-msgid "Verified samples ready to be published"
-msgstr "Verifizierte Proben, bereit zur Veröffentlichung"
-
-#: senaite/core/browser/dashboard/dashboard.py:400
-msgid "Samples whose reports have been published"
-msgstr "Proben, deren Berichte veröffentlicht wurden"
-
-#: senaite/core/browser/dashboard/dashboard.py:416
-msgid "Published samples whose reports have not been printed yet"
-msgstr "Veröffentlichte Proben, deren Berichte noch nicht gedruckt wurden"
-
-#: senaite/core/browser/dashboard/dashboard.py:448
-msgid "Analyses not yet assigned to a worksheet"
-msgstr "Analysen, die noch keinem Arbeitsblatt zugewiesen sind"
-
-#: senaite/core/browser/dashboard/dashboard.py:453
-msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr "Analysen, die einem Arbeitsblatt zugewiesen sind und auf Ergebnisse warten"
-
-#: senaite/core/browser/dashboard/dashboard.py:458
-msgid "Submitted analyses awaiting verification"
-msgstr "Eingereichte Analysen, die auf Verifizierung warten"
-
-#: senaite/core/browser/dashboard/dashboard.py:462
-msgid "Analyses that have been verified"
-msgstr "Analysen, die verifiziert wurden"
-
-#: senaite/core/browser/dashboard/dashboard.py:486
-msgid "Open worksheets with analyses awaiting results"
-msgstr "Offene Arbeitsblätter mit Analysen, die auf Ergebnisse warten"
-
-#: senaite/core/browser/dashboard/dashboard.py:490
-msgid "Worksheets whose results are awaiting verification"
-msgstr "Arbeitsblätter, deren Ergebnisse auf Verifizierung warten"
-
-#: senaite/core/browser/dashboard/dashboard.py:495
-msgid "Worksheets that have been verified"
-msgstr "Arbeitsblätter, die verifiziert wurden"
-
-#: senaite/core/browser/dashboard/dashboard.py:466
-msgid "Analyses included in a published report"
-msgstr "Analysen, die in einem veröffentlichten Bericht enthalten sind"
-#: senaite/core/api/remarks.py
-msgid "Add a remark..."
-msgstr "Bemerkung hinzufügen..."
-
-#: senaite/core/api/remarks.py
-msgid "Hide history"
-msgstr "Verlauf ausblenden"
-
-#: senaite/core/api/remarks.py
-msgid "No remarks yet"
-msgstr "Noch keine Bemerkungen"
-
-#: senaite/core/api/remarks.py
-msgid "Show history"
-msgstr "Verlauf anzeigen"
-
-#: senaite/core/api/remarks.py
-msgid "edited"
-msgstr "bearbeitet"
-
-#: senaite/core/api/remarks.py
-msgid "original"
-msgstr "Original"
-
-#: senaite/core/api/remarks.py
-msgid "Delete this remark?"
-msgstr "Diese Bemerkung löschen?"
-
-#: senaite/core/api/remarks.py
-msgid "deleted by {user} at {time}"
-msgstr "gelöscht von {user} um {time}"
-
-#: senaite/core/api/remarks.py
-msgid "Newest first"
-msgstr "Neueste zuerst"
-
-#: senaite/core/api/remarks.py
-msgid "Oldest first"
-msgstr "Älteste zuerst"

--- a/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: German (https://app.transifex.com/senaite/teams/87045/de/)\n"
@@ -128,7 +128,7 @@ msgstr "±"
 
 # senaite.app.listing: Column-filter row — boolean select placeholder
 msgid "-- Select --"
-msgstr "-- Auswählen --"
+msgstr ""
 
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
@@ -299,7 +299,7 @@ msgstr "Proben hinzufügen"
 
 #: senaite/core/api/remarks.py:492
 msgid "Add a remark..."
-msgstr "Bemerkung hinzufügen..."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
@@ -324,7 +324,7 @@ msgstr "Fügen Sie einen oder mehrere Anhänge zu diesem Analysenauftrag hinzu, 
 
 #: senaite/core/browser/samples/view.py:879
 msgid "Add or remove labels on the selected samples"
-msgstr "Etiketten der ausgewählten Proben hinzufügen oder entfernen"
+msgstr ""
 
 #: senaite/core/api/remarks.py:477
 msgid "Add remarks"
@@ -396,7 +396,7 @@ msgstr "Alle zugeordneten Analysen"
 
 # senaite.app.listing: Column config — empty state when no columns are visible
 msgid "All columns are hidden."
-msgstr "Alle Spalten sind ausgeblendet."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
@@ -404,7 +404,7 @@ msgstr "Manuelle Eingabe der Erfassungsgrenze erlauben."
 
 #: bika/lims/content/abstractbaseanalysis.py:728
 msgid "Allow Manual Entry"
-msgstr "Manuelle Eingabe erlauben"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -463,15 +463,15 @@ msgstr "Analysen"
 
 #: senaite/core/browser/dashboard/dashboard.py:485
 msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr "Analysen, die einem Arbeitsblatt zugewiesen sind und auf Ergebnisse warten"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:498
 msgid "Analyses included in a published report"
-msgstr "Analysen, die in einem veröffentlichten Bericht enthalten sind"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:480
 msgid "Analyses not yet assigned to a worksheet"
-msgstr "Analysen, die noch keinem Arbeitsblatt zugewiesen sind"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
@@ -479,7 +479,7 @@ msgstr "Analysen angefragt"
 
 #: senaite/core/browser/dashboard/dashboard.py:494
 msgid "Analyses that have been verified"
-msgstr "Analysen, die verifiziert wurden"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -599,7 +599,7 @@ msgstr "Vorlage anwenden"
 
 # senaite.app.listing: Saved filter presets — apply button tooltip
 msgid "Apply this filter"
-msgstr "Diesen Filter anwenden"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -725,7 +725,7 @@ msgstr "Auto-Import Logs"
 
 # senaite.app.listing: Saved filter presets — star action tooltip
 msgid "Auto-apply on open"
-msgstr "Beim Öffnen automatisch anwenden"
+msgstr ""
 
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
@@ -830,7 +830,7 @@ msgstr "Lager"
 
 #: senaite/core/browser/dashboard/dashboard.py:139
 msgid "Biannual"
-msgstr "Halbjährlich"
+msgstr ""
 
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
@@ -1133,12 +1133,12 @@ msgstr "Klassisch"
 
 # senaite.app.listing: Column-filter row — clear button tooltip
 msgid "Clear filter"
-msgstr "Filter zurücksetzen"
+msgstr ""
 
 # senaite.app.listing: Search box — undo button tooltip when only clearing
 # search
 msgid "Clear search"
-msgstr "Suche zurücksetzen"
+msgstr ""
 
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
@@ -1151,7 +1151,7 @@ msgstr "Klicken um diese Kategorie zu erweitern"
 # senaite.app.listing: Saved filter presets — release button tooltip on the
 # applied preset
 msgid "Click to release this filter"
-msgstr "Klicken, um diesen Filter zu lösen"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
@@ -1280,7 +1280,7 @@ msgstr "Spalte '{}' fehlt"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
 msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
-msgstr "Spalte {} der Kopfzeile hat keinen Namen. Bitte entfernen Sie leere Spalten aus der Tabelle und laden Sie sie erneut hoch."
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
@@ -1334,7 +1334,7 @@ msgstr "Konfiguration auf Standardwerte zurückgesetzt"
 
 # senaite.app.listing: Column config — trigger button label
 msgid "Configure"
-msgstr "Konfigurieren"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
@@ -1453,7 +1453,7 @@ msgstr "Folgende Probe(n) konnten aufgrund von Transaktionskonflikten nicht ange
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:228
 msgid "Could not link User: ${error}"
-msgstr "Benutzer konnte nicht verknüpft werden: ${error}"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
@@ -1557,7 +1557,7 @@ msgstr "Aktuell"
 
 # senaite.app.listing: Saved filter presets — dirty tag hover tooltip
 msgid "Current view differs from saved"
-msgstr "Aktuelle Ansicht weicht von der gespeicherten ab"
+msgstr ""
 
 #: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
@@ -1569,7 +1569,7 @@ msgstr "DL"
 
 #: senaite/core/browser/dashboard/dashboard.py:135
 msgid "Daily"
-msgstr "Täglich"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1878,11 +1878,11 @@ msgstr "Löschen"
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Delete filter"
-msgstr "Filter löschen"
+msgstr ""
 
 #: senaite/core/api/remarks.py:484
 msgid "Delete this remark?"
-msgstr "Diese Bemerkung löschen?"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
@@ -1961,7 +1961,7 @@ msgstr "Deaktiviere mehrfaches Verifizieren durch den gleichen Benutzer"
 
 # senaite.app.listing: Saved filter presets — Revert action tooltip
 msgid "Discard edits and restore preset"
-msgstr "Änderungen verwerfen und Voreinstellung wiederherstellen"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
@@ -2018,7 +2018,7 @@ msgstr "Entsorgen"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:15
 msgid "Dispose samples"
-msgstr "Proben entsorgen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
@@ -2094,7 +2094,7 @@ msgstr "Ausgewählte Berichte herunterladen"
 
 # senaite.app.listing: Column config — drag handle tooltip / aria-label
 msgid "Drag to reorder"
-msgstr "Zum Umsortieren ziehen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:327
 msgid "Due"
@@ -2131,7 +2131,7 @@ msgstr "Doppelte QC-Analyse"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr "Probe duplizieren"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
@@ -2249,7 +2249,7 @@ msgstr "E-Mail gesendet"
 
 #: bika/lims/api/snapshot.py:585
 msgid "Empty"
-msgstr "Leer"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2293,11 +2293,11 @@ msgstr "Ablauf für Ergebnisberichtsdruck aktivieren"
 
 #: senaite/core/content/senaitesetup.py:1000
 msgid "Enable the Sample Dispatch workflow"
-msgstr "Workflow zur Probenauslieferung aktivieren"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:990
 msgid "Enable the Sample Dispose workflow"
-msgstr "Workflow zur Probenentsorgung aktivieren"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2538,15 +2538,15 @@ msgstr "Schlüssel filtern (Regex unterstützt)"
 
 # senaite.app.listing: Saved filter presets — inline editor placeholder
 msgid "Filter name"
-msgstr "Filtername"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:601
 msgid "Filter samples by this analysis"
-msgstr "Proben nach dieser Analyse filtern"
+msgstr ""
 
 # senaite.app.listing: Column-filter row — text-input placeholder
 msgid "Filter..."
-msgstr "Filtern..."
+msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
@@ -2591,7 +2591,7 @@ msgstr "Von"
 
 #: senaite/core/browser/dashboard/dashboard.py:134
 msgid "From ${from} to ${to} (updated every 2 hours)"
-msgstr "Von ${from} bis ${to} (alle 2 Stunden aktualisiert)"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
@@ -2673,15 +2673,15 @@ msgstr "Zusätzliche Felder ausblenden"
 
 # senaite.app.listing: Column config — bulk action button
 msgid "Hide all"
-msgstr "Alle ausblenden"
+msgstr ""
 
 #: senaite/core/api/remarks.py:487
 msgid "Hide history"
-msgstr "Verlauf ausblenden"
+msgstr ""
 
 # senaite.app.listing: Column config — eye-slash button tooltip / aria-label
 msgid "Hide this column"
-msgstr "Diese Spalte ausblenden"
+msgstr ""
 
 #: bika/lims/config.py:140
 msgid "High"
@@ -3163,7 +3163,7 @@ msgstr "Schlüsselwörter"
 
 #: senaite/core/browser/samples/view.py:249
 msgid "Keywords of the analyses contained in the sample"
-msgstr "Schlüsselwörter der in der Probe enthaltenen Analysen"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3382,11 +3382,11 @@ msgstr "Ort an dem das Dokument eingeordnet wurde"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Lock"
-msgstr "Sperren"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Locked"
-msgstr "Gesperrt"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3686,7 +3686,7 @@ msgstr "Montag"
 
 #: senaite/core/browser/dashboard/dashboard.py:137
 msgid "Monthly"
-msgstr "Monatlich"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
@@ -3743,7 +3743,7 @@ msgstr "Mein Profil"
 
 # senaite.app.listing: Saved filter presets — default name when saving
 msgid "My filter"
-msgstr "Mein Filter"
+msgstr ""
 
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
@@ -3765,7 +3765,7 @@ msgstr "Neue Bereiche werden weder auf neue noch auf aktuelle Analysen angewende
 
 #: senaite/core/api/remarks.py:490
 msgid "Newest first"
-msgstr "Neueste zuerst"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
@@ -3811,7 +3811,7 @@ msgstr "Keine Aktion definiert."
 
 #: senaite/core/browser/dashboard/dashboard.py:131
 msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
-msgstr "Keine Aktionen verfügbar. Bitte wenden Sie sich an Ihren Laborleiter, um Berechtigungen zugewiesen zu bekommen."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3861,7 +3861,7 @@ msgstr "Keine Änderungen vorgenommen."
 
 #: senaite/core/browser/dashboard/dashboard.py:130
 msgid "No data for the selected period"
-msgstr "Keine Daten für den gewählten Zeitraum"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
@@ -3910,12 +3910,12 @@ msgstr "Keine Objekte ausgewählt"
 # senaite.app.listing: Column config — empty state for hidden section with
 # search
 msgid "No matches in hidden columns."
-msgstr "Keine Treffer in ausgeblendeten Spalten."
+msgstr ""
 
 # senaite.app.listing: Column config — empty state for visible section with
 # search
 msgid "No matches in visible columns."
-msgstr "Keine Treffer in sichtbaren Spalten."
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
@@ -3927,7 +3927,7 @@ msgstr "Keine Partitionen wurden erzeugt"
 
 #: senaite/core/api/remarks.py:493
 msgid "No remarks yet"
-msgstr "Noch keine Bemerkungen"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3947,7 +3947,7 @@ msgstr "Kein Probenahme Worfkflow"
 
 # senaite.app.listing: Saved filter presets — empty state
 msgid "No saved filters yet."
-msgstr "Noch keine gespeicherten Filter."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -4067,7 +4067,7 @@ msgstr "Numerisch"
 
 #: senaite/core/api/remarks.py:491
 msgid "Oldest first"
-msgstr "Älteste zuerst"
+msgstr ""
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -4113,7 +4113,7 @@ msgstr "Open Source Web-basiertes Labor-Information-Management-System"
 
 #: senaite/core/browser/dashboard/dashboard.py:97
 msgid "Open Worksheets"
-msgstr "Offene Arbeitsblätter"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
@@ -4121,7 +4121,7 @@ msgstr "E-Mail-Formular öffnen, um die ausgewählten Berichte an die Empfänger
 
 #: senaite/core/browser/dashboard/dashboard.py:522
 msgid "Open worksheets with analyses awaiting results"
-msgstr "Offene Arbeitsblätter mit Analysen, die auf Ergebnisse warten"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -4312,7 +4312,7 @@ msgstr "Bitte kommentieren Sie wohin die ausgewählte(n) Probe(n) ausgeliefert w
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:73
 msgid "Please write a comment where the listed sample(s) are disposed"
-msgstr "Bitte geben Sie einen Kommentar ein, wo die aufgeführten Proben entsorgt werden"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
@@ -4564,7 +4564,7 @@ msgstr "Veröffentlichen"
 
 #: senaite/core/browser/dashboard/dashboard.py:112
 msgid "Publish Reports"
-msgstr "Berichte veröffentlichen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:150
 #: senaite/core/browser/samples/view.py:369
@@ -4586,7 +4586,7 @@ msgstr "Veröffentlichte Ergebnisse"
 
 #: senaite/core/browser/dashboard/dashboard.py:448
 msgid "Published samples whose reports have not been printed yet"
-msgstr "Veröffentlichte Proben, deren Berichte noch nicht gedruckt wurden"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4611,11 +4611,11 @@ msgstr "QC Proben-ID"
 
 #: senaite/core/browser/dashboard/dashboard.py:138
 msgid "Quarterly"
-msgstr "Vierteljährlich"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:128
 msgid "Quick Actions"
-msgstr "Schnellaktionen"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4651,7 +4651,7 @@ msgstr "Wiederzuweisbarer Platz"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr "Wieder anhängen"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
@@ -4670,7 +4670,7 @@ msgstr "Empfangen"
 
 #: senaite/core/browser/dashboard/dashboard.py:420
 msgid "Received samples with analyses awaiting results"
-msgstr "Angenommene Proben mit Analysen, die auf Ergebnisse warten"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
@@ -4737,7 +4737,7 @@ msgstr "Registrieren"
 
 #: senaite/core/browser/dashboard/dashboard.py:105
 msgid "Register Samples"
-msgstr "Proben registrieren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
@@ -4846,7 +4846,7 @@ msgstr "Entfernen"
 
 #: senaite/core/browser/samples/view.py:597
 msgid "Remove this analysis from the filter"
-msgstr "Diese Analyse aus dem Filter entfernen"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
@@ -4854,7 +4854,7 @@ msgstr "{} Schlüssel entfernt: {}"
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Rename filter"
-msgstr "Filter umbenennen"
+msgstr ""
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
@@ -4932,7 +4932,7 @@ msgstr "Zurücksetzen"
 
 # senaite.app.listing: Reset-columns button tooltip
 msgid "Reset column visibility and order to the defaults"
-msgstr "Spaltensichtbarkeit und -reihenfolge auf die Standardwerte zurücksetzen"
+msgstr ""
 
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
@@ -4940,11 +4940,11 @@ msgstr "Spalten zurücksetzen"
 
 # senaite.app.listing: Column config — reset link tooltip
 msgid "Reset to default columns and order"
-msgstr "Auf Standardspalten und -reihenfolge zurücksetzen"
+msgstr ""
 
 # senaite.app.listing: Search box — undo / reset-view button tooltip
 msgid "Reset view"
-msgstr "Ansicht zurücksetzen"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
@@ -5019,7 +5019,7 @@ msgstr "Ergebnisinterpretation"
 
 #: senaite/core/browser/dashboard/dashboard.py:85
 msgid "Results Pending"
-msgstr "Ausstehende Ergebnisse"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
@@ -5100,7 +5100,7 @@ msgstr "Routineanalysen"
 
 #: bika/lims/api/snapshot.py:555
 msgid "Row ${num}"
-msgstr "Zeile ${num}"
+msgstr ""
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
@@ -5328,15 +5328,15 @@ msgstr "Proben ${sample_ids} wurden erfolgreich ungültig gesetzt."
 
 #: senaite/core/browser/dashboard/dashboard.py:400
 msgid "Samples awaiting collection of the sample"
-msgstr "Proben, die auf die Entnahme der Probe warten"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:404
 msgid "Samples awaiting preservation"
-msgstr "Proben, die auf die Konservierung warten"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:416
 msgid "Samples awaiting reception at the laboratory"
-msgstr "Proben, die auf die Annahme im Labor warten"
+msgstr ""
 
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
@@ -5349,19 +5349,19 @@ msgstr "Mitteilungsformular zur Ablehnung der Proben"
 
 #: senaite/core/browser/dashboard/dashboard.py:81
 msgid "Samples to Receive"
-msgstr "Anzunehmende Proben"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:432
 msgid "Samples whose reports have been published"
-msgstr "Proben, deren Berichte veröffentlicht wurden"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:424
 msgid "Samples whose results are awaiting verification"
-msgstr "Proben, deren Ergebnisse auf die Verifizierung warten"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:409
 msgid "Samples with a scheduled sampling date"
-msgstr "Proben mit einem geplanten Probenahmedatum"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
@@ -5405,11 +5405,11 @@ msgstr "Speichern und Kopieren"
 # senaite.app.listing: Saved filter presets — footer button to save the
 # current view
 msgid "Save current view"
-msgstr "Aktuelle Ansicht speichern"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — toggle title + menu header
 msgid "Saved filters"
-msgstr "Gespeicherte Filter"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5442,7 +5442,7 @@ msgstr "Suchen"
 
 # senaite.app.listing: Column config — search input placeholder
 msgid "Search columns…"
-msgstr "Spalten durchsuchen…"
+msgstr ""
 
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
@@ -5588,11 +5588,11 @@ msgstr "Auswählen um dem Probenahme-Koordinator zu erlauben, eine Probe zeitlic
 
 #: senaite/core/content/senaitesetup.py:1001
 msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
-msgstr "Aktivieren Sie diese Option, um das Ausliefern von Proben über den Übergang 'dispatch' zu erlauben und den zusätzlichen Status 'ausgeliefert' zu aktivieren. Die Analysen einer ausgelieferten Probe werden schreibgeschützt und in ihren vorherigen Status zurückversetzt, wenn die Probe wiederhergestellt wird. Standardmäßig deaktiviert."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:991
 msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
-msgstr "Aktivieren Sie diese Option, um das Entsorgen von Proben über den Übergang 'dispose' zu erlauben und den zusätzlichen Status 'entsorgt' zu aktivieren. Standardmäßig deaktiviert."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
@@ -5752,7 +5752,7 @@ msgstr "Alle anzeigen"
 
 #: senaite/core/api/remarks.py:486
 msgid "Show history"
-msgstr "Verlauf anzeigen"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
@@ -5772,11 +5772,11 @@ msgstr "Zeige Standardfelder"
 
 # senaite.app.listing: Column config — plus button tooltip / aria-label
 msgid "Show this column"
-msgstr "Diese Spalte anzeigen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:129
 msgid "Show/hide timeline"
-msgstr "Zeitverlauf ein-/ausblenden"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5843,11 +5843,11 @@ msgstr "Sortierschlüssel"
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort ascending"
-msgstr "Aufsteigend sortieren"
+msgstr ""
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort descending"
-msgstr "Absteigend sortieren"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5919,7 +5919,7 @@ msgstr "Etikettenvorschau"
 
 # senaite.app.listing: Saved filter presets — star action tooltip when active
 msgid "Stop auto-applying"
-msgstr "Automatisches Anwenden beenden"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
@@ -5963,7 +5963,7 @@ msgstr "Senden Sie eine gültige Open XML-Datei (.XLSX) mit Setup-Datensätzen, 
 
 #: senaite/core/browser/dashboard/dashboard.py:490
 msgid "Submitted analyses awaiting verification"
-msgstr "Übermittelte Analysen, die auf die Verifizierung warten"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
@@ -6161,7 +6161,7 @@ msgstr "Die folgende(n) Probe(n) werden versendet"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:47
 msgid "The following sample(s) will be disposed"
-msgstr "Die folgenden Proben werden entsorgt"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
@@ -6438,11 +6438,11 @@ msgstr "Zu beproben"
 
 #: senaite/core/browser/dashboard/dashboard.py:93
 msgid "To be Published"
-msgstr "Zu veröffentlichen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:89
 msgid "To be Verified"
-msgstr "Zu verifizieren"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
@@ -6525,7 +6525,7 @@ msgstr "Tippen um zu filtern ..."
 
 # senaite.app.listing: Column-filter row — searchable-select placeholder
 msgid "Type to filter..."
-msgstr "Zum Filtern tippen..."
+msgstr ""
 
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
@@ -6586,7 +6586,7 @@ msgstr "Benutzerverknüpfung aufgehoben"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unlock"
-msgstr "Entsperren"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6612,7 +6612,7 @@ msgstr "Anhänge Aktualisieren"
 
 # senaite.app.listing: Saved filter presets — Update preset action tooltip
 msgid "Update preset with current view"
-msgstr "Voreinstellung mit aktueller Ansicht aktualisieren"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6951,7 +6951,7 @@ msgstr "Verifiziert von"
 
 #: senaite/core/browser/dashboard/dashboard.py:428
 msgid "Verified samples ready to be published"
-msgstr "Verifizierte Proben, die zur Veröffentlichung bereit sind"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
@@ -6961,7 +6961,7 @@ msgstr "Verifizieren"
 
 #: senaite/core/browser/dashboard/dashboard.py:109
 msgid "Verify Results"
-msgstr "Ergebnisse verifizieren"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6979,11 +6979,11 @@ msgstr "SENAITE Seite ansehen"
 
 # senaite.app.listing: Column config — visible-section header
 msgid "Visible"
-msgstr "Sichtbar"
+msgstr ""
 
 # senaite.app.listing: Column config — counter title attribute
 msgid "Visible / total columns"
-msgstr "Sichtbare / gesamte Spalten"
+msgstr ""
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -7020,7 +7020,7 @@ msgstr "Mittwoch"
 
 #: senaite/core/browser/dashboard/dashboard.py:136
 msgid "Weekly"
-msgstr "Wöchentlich"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
@@ -7104,11 +7104,11 @@ msgstr "Arbeitsblätter"
 
 #: senaite/core/browser/dashboard/dashboard.py:531
 msgid "Worksheets that have been verified"
-msgstr "Arbeitsblätter, die verifiziert wurden"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:526
 msgid "Worksheets whose results are awaiting verification"
-msgstr "Arbeitsblätter, deren Ergebnisse auf die Verifizierung warten"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -7120,7 +7120,7 @@ msgstr "Falsche IBAN Länge von %s: %s ist %i zu kurz"
 
 #: senaite/core/browser/dashboard/dashboard.py:140
 msgid "Yearly"
-msgstr "Jährlich"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -7208,7 +7208,7 @@ msgstr "Analytiker muss angegeben werden."
 
 # senaite.app.listing: Saved filter presets — micro-tag on the default preset
 msgid "auto"
-msgstr "auto"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
@@ -7303,7 +7303,7 @@ msgstr "${d}.${m}.${y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "yy-mm-dd"
+#. Default: "mm/dd/yy"
 #, fuzzy
 msgid "date_format_short_datepicker"
 msgstr "tt.mm.jj"
@@ -7319,11 +7319,11 @@ msgstr "deaktivieren"
 #. Default: "Sample disposed after the retention period."
 #: senaite/core/browser/samples/templates/dispose_samples.pt:66
 msgid "default_dispose_reason"
-msgstr "Probe nach Ablauf der Aufbewahrungsfrist entsorgt."
+msgstr ""
 
 #: senaite/core/api/remarks.py:485
 msgid "deleted by {user} at {time}"
-msgstr "gelöscht von {user} am {time}"
+msgstr ""
 
 #. Default: "Attached labels"
 #: senaite/core/behaviors/label.py:126
@@ -7681,9 +7681,8 @@ msgstr "Interim-Felder wie Gefäßmasse, Verdünnungsfaktoren etc. festlegen, so
 #. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
-#, fuzzy
 msgid "description_calculation_interims"
-msgstr "Definieren Sie Zwischenfelder wie Gefäßmasse oder Verdünnungsfaktoren, falls Ihre Berechnung diese benötigt. Der hier angegebene Feldtitel wird als Spaltenüberschrift und Feldbeschreibung verwendet, wo die Zwischenfelder angezeigt werden. Wenn 'Breit anwenden' aktiviert ist, wird das Feld in einem Auswahlfeld oben im Arbeitsblatt angezeigt, sodass ein bestimmter Wert auf alle entsprechenden Felder des Blattes angewendet werden kann."
+msgstr ""
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
@@ -7831,17 +7830,15 @@ msgstr "Zugeordnete Laborabteilungen"
 #. the default style."
 #. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
 #: senaite/core/content/label.py:72
-#, fuzzy
 msgid "description_label_color"
-msgstr "Hex-Farbcode für den Chip (z. B. #0d6efd). Leer lassen für den Standardstil."
+msgstr ""
 
 #. labeled content. The cascade runs in the same transaction as the save and
 #. may take a moment on large datasets."
 #. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
 #: senaite/core/content/label.py:45
-#, fuzzy
 msgid "description_label_title"
-msgstr "Das Umbenennen dieses Etiketts überschreibt den gespeicherten Namen bei allen aktuell etikettierten Inhalten. Der Kaskadenvorgang läuft in derselben Transaktion wie das Speichern und kann bei großen Datenmengen einen Moment dauern."
+msgstr ""
 
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
@@ -7879,9 +7876,8 @@ msgstr "Bitte den Mehrwertsteuersatz in Prozent angeben, der zum Laborproduktpre
 #. show or reorder each viewlet."
 #. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
-#, fuzzy
 msgid "description_manage_viewlets"
-msgstr "Die Viewlet-Manager und ihre Viewlets werden an Ort und Stelle angezeigt, verschachtelt und so positioniert, wie sie auf der Website erscheinen. Verwenden Sie die Steuerelemente, um jedes Viewlet auszublenden, anzuzeigen oder neu anzuordnen."
+msgstr ""
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
@@ -8756,42 +8752,42 @@ msgstr "Doppelbestimmung in Position ${dup} referenziert diese, daher muss es si
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr "${days} Tage"
+msgstr ""
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr "${hours} Stunden"
+msgstr ""
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr "Tage"
+msgstr ""
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr "Stunden"
+msgstr ""
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr "Minuten"
+msgstr ""
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr "Sekunden"
+msgstr ""
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr "${minutes} Minuten"
+msgstr ""
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr "${seconds} Sekunden"
+msgstr ""
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
@@ -8800,7 +8796,7 @@ msgstr "Inhalt der Datei"
 
 #: senaite/core/api/remarks.py:481
 msgid "edited"
-msgstr "bearbeitet"
+msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -10139,19 +10135,18 @@ msgstr "Auf Methode beschränken"
 #. Default: "Added ${count} label(s) to ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:185
 msgid "labels_added"
-msgstr "${count} Etikett(en) zu ${affected} Probe(n) hinzugefügt"
+msgstr ""
 
 #. sample(s)"
 #. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:174
-#, fuzzy
 msgid "labels_changed"
-msgstr "${added} hinzugefügt und ${removed} entfernt bei ${affected} Probe(n) angewendet"
+msgstr ""
 
 #. Default: "Removed ${count} label(s) from ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:194
 msgid "labels_removed"
-msgstr "${count} Etikett(en) von ${affected} Probe(n) entfernt"
+msgstr ""
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
@@ -11463,7 +11458,7 @@ msgstr "Minuten"
 # senaite.app.listing: Saved filter presets — dirty indicator on the applied
 # preset
 msgid "modified"
-msgstr "geändert"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
@@ -11522,7 +11517,7 @@ msgstr "von"
 
 #: senaite/core/api/remarks.py:494
 msgid "original"
-msgstr "Original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
@@ -11530,7 +11525,7 @@ msgstr "Übersicht"
 
 # senaite.app.listing: Saved filter presets — menu subtitle
 msgid "per listing"
-msgstr "pro Liste"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11612,7 +11607,7 @@ msgstr "Diese Probe wurde von ${actor} am ${date} versandt."
 #. Default: "This sample has been disposed by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
 msgid "this_sample_has_been_disposed_by"
-msgstr "Diese Probe wurde von ${actor} am ${date} entsorgt"
+msgstr ""
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11849,7 +11844,7 @@ msgstr "Laborleiter"
 #. Default: "Color"
 #: senaite/core/content/label.py:68
 msgid "title_label_color"
-msgstr "Farbe"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/label.py:56
@@ -11949,7 +11944,7 @@ msgstr "Analysentyp"
 #. Default: "Manage Viewlets"
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
 msgid "title_manage_viewlets"
-msgstr "Viewlets verwalten"
+msgstr ""
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86

--- a/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
@@ -128,7 +128,7 @@ msgstr "±"
 
 # senaite.app.listing: Column-filter row — boolean select placeholder
 msgid "-- Select --"
-msgstr ""
+msgstr "-- Auswählen --"
 
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
@@ -299,7 +299,7 @@ msgstr "Proben hinzufügen"
 
 #: senaite/core/api/remarks.py:492
 msgid "Add a remark..."
-msgstr ""
+msgstr "Bemerkung hinzufügen..."
 
 #: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
@@ -324,7 +324,7 @@ msgstr "Fügen Sie einen oder mehrere Anhänge zu diesem Analysenauftrag hinzu, 
 
 #: senaite/core/browser/samples/view.py:879
 msgid "Add or remove labels on the selected samples"
-msgstr ""
+msgstr "Etiketten der ausgewählten Proben hinzufügen oder entfernen"
 
 #: senaite/core/api/remarks.py:477
 msgid "Add remarks"
@@ -396,7 +396,7 @@ msgstr "Alle zugeordneten Analysen"
 
 # senaite.app.listing: Column config — empty state when no columns are visible
 msgid "All columns are hidden."
-msgstr ""
+msgstr "Alle Spalten sind ausgeblendet."
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
@@ -404,7 +404,7 @@ msgstr "Manuelle Eingabe der Erfassungsgrenze erlauben."
 
 #: bika/lims/content/abstractbaseanalysis.py:728
 msgid "Allow Manual Entry"
-msgstr ""
+msgstr "Manuelle Eingabe erlauben"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -463,15 +463,15 @@ msgstr "Analysen"
 
 #: senaite/core/browser/dashboard/dashboard.py:485
 msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr ""
+msgstr "Analysen, die einem Arbeitsblatt zugewiesen sind und auf Ergebnisse warten"
 
 #: senaite/core/browser/dashboard/dashboard.py:498
 msgid "Analyses included in a published report"
-msgstr ""
+msgstr "Analysen, die in einem veröffentlichten Bericht enthalten sind"
 
 #: senaite/core/browser/dashboard/dashboard.py:480
 msgid "Analyses not yet assigned to a worksheet"
-msgstr ""
+msgstr "Analysen, die noch keinem Arbeitsblatt zugewiesen sind"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
@@ -479,7 +479,7 @@ msgstr "Analysen angefragt"
 
 #: senaite/core/browser/dashboard/dashboard.py:494
 msgid "Analyses that have been verified"
-msgstr ""
+msgstr "Analysen, die verifiziert wurden"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -599,7 +599,7 @@ msgstr "Vorlage anwenden"
 
 # senaite.app.listing: Saved filter presets — apply button tooltip
 msgid "Apply this filter"
-msgstr ""
+msgstr "Diesen Filter anwenden"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -725,7 +725,7 @@ msgstr "Auto-Import Logs"
 
 # senaite.app.listing: Saved filter presets — star action tooltip
 msgid "Auto-apply on open"
-msgstr ""
+msgstr "Beim Öffnen automatisch anwenden"
 
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
@@ -830,7 +830,7 @@ msgstr "Lager"
 
 #: senaite/core/browser/dashboard/dashboard.py:139
 msgid "Biannual"
-msgstr ""
+msgstr "Halbjährlich"
 
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
@@ -1133,12 +1133,12 @@ msgstr "Klassisch"
 
 # senaite.app.listing: Column-filter row — clear button tooltip
 msgid "Clear filter"
-msgstr ""
+msgstr "Filter zurücksetzen"
 
 # senaite.app.listing: Search box — undo button tooltip when only clearing
 # search
 msgid "Clear search"
-msgstr ""
+msgstr "Suche zurücksetzen"
 
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
@@ -1151,7 +1151,7 @@ msgstr "Klicken um diese Kategorie zu erweitern"
 # senaite.app.listing: Saved filter presets — release button tooltip on the
 # applied preset
 msgid "Click to release this filter"
-msgstr ""
+msgstr "Klicken, um diesen Filter zu lösen"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
@@ -1280,7 +1280,7 @@ msgstr "Spalte '{}' fehlt"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
 msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
-msgstr ""
+msgstr "Spalte {} der Kopfzeile hat keinen Namen. Bitte entfernen Sie leere Spalten aus der Tabelle und laden Sie sie erneut hoch."
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
@@ -1334,7 +1334,7 @@ msgstr "Konfiguration auf Standardwerte zurückgesetzt"
 
 # senaite.app.listing: Column config — trigger button label
 msgid "Configure"
-msgstr ""
+msgstr "Konfigurieren"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
@@ -1453,7 +1453,7 @@ msgstr "Folgende Probe(n) konnten aufgrund von Transaktionskonflikten nicht ange
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:228
 msgid "Could not link User: ${error}"
-msgstr ""
+msgstr "Benutzer konnte nicht verknüpft werden: ${error}"
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
@@ -1557,7 +1557,7 @@ msgstr "Aktuell"
 
 # senaite.app.listing: Saved filter presets — dirty tag hover tooltip
 msgid "Current view differs from saved"
-msgstr ""
+msgstr "Aktuelle Ansicht weicht von der gespeicherten ab"
 
 #: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
@@ -1569,7 +1569,7 @@ msgstr "DL"
 
 #: senaite/core/browser/dashboard/dashboard.py:135
 msgid "Daily"
-msgstr ""
+msgstr "Täglich"
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1878,11 +1878,11 @@ msgstr "Löschen"
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Delete filter"
-msgstr ""
+msgstr "Filter löschen"
 
 #: senaite/core/api/remarks.py:484
 msgid "Delete this remark?"
-msgstr ""
+msgstr "Diese Bemerkung löschen?"
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
@@ -1961,7 +1961,7 @@ msgstr "Deaktiviere mehrfaches Verifizieren durch den gleichen Benutzer"
 
 # senaite.app.listing: Saved filter presets — Revert action tooltip
 msgid "Discard edits and restore preset"
-msgstr ""
+msgstr "Änderungen verwerfen und Voreinstellung wiederherstellen"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
@@ -2018,7 +2018,7 @@ msgstr "Entsorgen"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:15
 msgid "Dispose samples"
-msgstr ""
+msgstr "Proben entsorgen"
 
 #: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
@@ -2094,7 +2094,7 @@ msgstr "Ausgewählte Berichte herunterladen"
 
 # senaite.app.listing: Column config — drag handle tooltip / aria-label
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Zum Umsortieren ziehen"
 
 #: senaite/core/browser/samples/view.py:327
 msgid "Due"
@@ -2131,7 +2131,7 @@ msgstr "Doppelte QC-Analyse"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr ""
+msgstr "Probe duplizieren"
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
@@ -2249,7 +2249,7 @@ msgstr "E-Mail gesendet"
 
 #: bika/lims/api/snapshot.py:585
 msgid "Empty"
-msgstr ""
+msgstr "Leer"
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2293,11 +2293,11 @@ msgstr "Ablauf für Ergebnisberichtsdruck aktivieren"
 
 #: senaite/core/content/senaitesetup.py:1000
 msgid "Enable the Sample Dispatch workflow"
-msgstr ""
+msgstr "Workflow zur Probenauslieferung aktivieren"
 
 #: senaite/core/content/senaitesetup.py:990
 msgid "Enable the Sample Dispose workflow"
-msgstr ""
+msgstr "Workflow zur Probenentsorgung aktivieren"
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2538,15 +2538,15 @@ msgstr "Schlüssel filtern (Regex unterstützt)"
 
 # senaite.app.listing: Saved filter presets — inline editor placeholder
 msgid "Filter name"
-msgstr ""
+msgstr "Filtername"
 
 #: senaite/core/browser/samples/view.py:601
 msgid "Filter samples by this analysis"
-msgstr ""
+msgstr "Proben nach dieser Analyse filtern"
 
 # senaite.app.listing: Column-filter row — text-input placeholder
 msgid "Filter..."
-msgstr ""
+msgstr "Filtern..."
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
@@ -2591,7 +2591,7 @@ msgstr "Von"
 
 #: senaite/core/browser/dashboard/dashboard.py:134
 msgid "From ${from} to ${to} (updated every 2 hours)"
-msgstr ""
+msgstr "Von ${from} bis ${to} (alle 2 Stunden aktualisiert)"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
@@ -2673,15 +2673,15 @@ msgstr "Zusätzliche Felder ausblenden"
 
 # senaite.app.listing: Column config — bulk action button
 msgid "Hide all"
-msgstr ""
+msgstr "Alle ausblenden"
 
 #: senaite/core/api/remarks.py:487
 msgid "Hide history"
-msgstr ""
+msgstr "Verlauf ausblenden"
 
 # senaite.app.listing: Column config — eye-slash button tooltip / aria-label
 msgid "Hide this column"
-msgstr ""
+msgstr "Diese Spalte ausblenden"
 
 #: bika/lims/config.py:140
 msgid "High"
@@ -3163,7 +3163,7 @@ msgstr "Schlüsselwörter"
 
 #: senaite/core/browser/samples/view.py:249
 msgid "Keywords of the analyses contained in the sample"
-msgstr ""
+msgstr "Schlüsselwörter der in der Probe enthaltenen Analysen"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3382,11 +3382,11 @@ msgstr "Ort an dem das Dokument eingeordnet wurde"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Lock"
-msgstr ""
+msgstr "Sperren"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Locked"
-msgstr ""
+msgstr "Gesperrt"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3686,7 +3686,7 @@ msgstr "Montag"
 
 #: senaite/core/browser/dashboard/dashboard.py:137
 msgid "Monthly"
-msgstr ""
+msgstr "Monatlich"
 
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
@@ -3743,7 +3743,7 @@ msgstr "Mein Profil"
 
 # senaite.app.listing: Saved filter presets — default name when saving
 msgid "My filter"
-msgstr ""
+msgstr "Mein Filter"
 
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
@@ -3765,7 +3765,7 @@ msgstr "Neue Bereiche werden weder auf neue noch auf aktuelle Analysen angewende
 
 #: senaite/core/api/remarks.py:490
 msgid "Newest first"
-msgstr ""
+msgstr "Neueste zuerst"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
@@ -3811,7 +3811,7 @@ msgstr "Keine Aktion definiert."
 
 #: senaite/core/browser/dashboard/dashboard.py:131
 msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
-msgstr ""
+msgstr "Keine Aktionen verfügbar. Bitte wenden Sie sich an Ihren Laborleiter, um Berechtigungen zugewiesen zu bekommen."
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3861,7 +3861,7 @@ msgstr "Keine Änderungen vorgenommen."
 
 #: senaite/core/browser/dashboard/dashboard.py:130
 msgid "No data for the selected period"
-msgstr ""
+msgstr "Keine Daten für den gewählten Zeitraum"
 
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
@@ -3910,12 +3910,12 @@ msgstr "Keine Objekte ausgewählt"
 # senaite.app.listing: Column config — empty state for hidden section with
 # search
 msgid "No matches in hidden columns."
-msgstr ""
+msgstr "Keine Treffer in ausgeblendeten Spalten."
 
 # senaite.app.listing: Column config — empty state for visible section with
 # search
 msgid "No matches in visible columns."
-msgstr ""
+msgstr "Keine Treffer in sichtbaren Spalten."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
@@ -3927,7 +3927,7 @@ msgstr "Keine Partitionen wurden erzeugt"
 
 #: senaite/core/api/remarks.py:493
 msgid "No remarks yet"
-msgstr ""
+msgstr "Noch keine Bemerkungen"
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3947,7 +3947,7 @@ msgstr "Kein Probenahme Worfkflow"
 
 # senaite.app.listing: Saved filter presets — empty state
 msgid "No saved filters yet."
-msgstr ""
+msgstr "Noch keine gespeicherten Filter."
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -4067,7 +4067,7 @@ msgstr "Numerisch"
 
 #: senaite/core/api/remarks.py:491
 msgid "Oldest first"
-msgstr ""
+msgstr "Älteste zuerst"
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -4113,7 +4113,7 @@ msgstr "Open Source Web-basiertes Labor-Information-Management-System"
 
 #: senaite/core/browser/dashboard/dashboard.py:97
 msgid "Open Worksheets"
-msgstr ""
+msgstr "Offene Arbeitsblätter"
 
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
@@ -4121,7 +4121,7 @@ msgstr "E-Mail-Formular öffnen, um die ausgewählten Berichte an die Empfänger
 
 #: senaite/core/browser/dashboard/dashboard.py:522
 msgid "Open worksheets with analyses awaiting results"
-msgstr ""
+msgstr "Offene Arbeitsblätter mit Analysen, die auf Ergebnisse warten"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -4312,7 +4312,7 @@ msgstr "Bitte kommentieren Sie wohin die ausgewählte(n) Probe(n) ausgeliefert w
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:73
 msgid "Please write a comment where the listed sample(s) are disposed"
-msgstr ""
+msgstr "Bitte geben Sie einen Kommentar ein, wo die aufgeführten Proben entsorgt werden"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
@@ -4564,7 +4564,7 @@ msgstr "Veröffentlichen"
 
 #: senaite/core/browser/dashboard/dashboard.py:112
 msgid "Publish Reports"
-msgstr ""
+msgstr "Berichte veröffentlichen"
 
 #: senaite/core/browser/dashboard/dashboard.py:150
 #: senaite/core/browser/samples/view.py:369
@@ -4586,7 +4586,7 @@ msgstr "Veröffentlichte Ergebnisse"
 
 #: senaite/core/browser/dashboard/dashboard.py:448
 msgid "Published samples whose reports have not been printed yet"
-msgstr ""
+msgstr "Veröffentlichte Proben, deren Berichte noch nicht gedruckt wurden"
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4611,11 +4611,11 @@ msgstr "QC Proben-ID"
 
 #: senaite/core/browser/dashboard/dashboard.py:138
 msgid "Quarterly"
-msgstr ""
+msgstr "Vierteljährlich"
 
 #: senaite/core/browser/dashboard/dashboard.py:128
 msgid "Quick Actions"
-msgstr ""
+msgstr "Schnellaktionen"
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4651,7 +4651,7 @@ msgstr "Wiederzuweisbarer Platz"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr ""
+msgstr "Wieder anhängen"
 
 #: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
@@ -4670,7 +4670,7 @@ msgstr "Empfangen"
 
 #: senaite/core/browser/dashboard/dashboard.py:420
 msgid "Received samples with analyses awaiting results"
-msgstr ""
+msgstr "Angenommene Proben mit Analysen, die auf Ergebnisse warten"
 
 #: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
@@ -4737,7 +4737,7 @@ msgstr "Registrieren"
 
 #: senaite/core/browser/dashboard/dashboard.py:105
 msgid "Register Samples"
-msgstr ""
+msgstr "Proben registrieren"
 
 #: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
@@ -4846,7 +4846,7 @@ msgstr "Entfernen"
 
 #: senaite/core/browser/samples/view.py:597
 msgid "Remove this analysis from the filter"
-msgstr ""
+msgstr "Diese Analyse aus dem Filter entfernen"
 
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
@@ -4854,7 +4854,7 @@ msgstr "{} Schlüssel entfernt: {}"
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Rename filter"
-msgstr ""
+msgstr "Filter umbenennen"
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
@@ -4932,7 +4932,7 @@ msgstr "Zurücksetzen"
 
 # senaite.app.listing: Reset-columns button tooltip
 msgid "Reset column visibility and order to the defaults"
-msgstr ""
+msgstr "Spaltensichtbarkeit und -reihenfolge auf die Standardwerte zurücksetzen"
 
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
@@ -4940,11 +4940,11 @@ msgstr "Spalten zurücksetzen"
 
 # senaite.app.listing: Column config — reset link tooltip
 msgid "Reset to default columns and order"
-msgstr ""
+msgstr "Auf Standardspalten und -reihenfolge zurücksetzen"
 
 # senaite.app.listing: Search box — undo / reset-view button tooltip
 msgid "Reset view"
-msgstr ""
+msgstr "Ansicht zurücksetzen"
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
@@ -5019,7 +5019,7 @@ msgstr "Ergebnisinterpretation"
 
 #: senaite/core/browser/dashboard/dashboard.py:85
 msgid "Results Pending"
-msgstr ""
+msgstr "Ausstehende Ergebnisse"
 
 #: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
@@ -5100,7 +5100,7 @@ msgstr "Routineanalysen"
 
 #: bika/lims/api/snapshot.py:555
 msgid "Row ${num}"
-msgstr ""
+msgstr "Zeile ${num}"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
@@ -5328,15 +5328,15 @@ msgstr "Proben ${sample_ids} wurden erfolgreich ungültig gesetzt."
 
 #: senaite/core/browser/dashboard/dashboard.py:400
 msgid "Samples awaiting collection of the sample"
-msgstr ""
+msgstr "Proben, die auf die Entnahme der Probe warten"
 
 #: senaite/core/browser/dashboard/dashboard.py:404
 msgid "Samples awaiting preservation"
-msgstr ""
+msgstr "Proben, die auf die Konservierung warten"
 
 #: senaite/core/browser/dashboard/dashboard.py:416
 msgid "Samples awaiting reception at the laboratory"
-msgstr ""
+msgstr "Proben, die auf die Annahme im Labor warten"
 
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
@@ -5349,19 +5349,19 @@ msgstr "Mitteilungsformular zur Ablehnung der Proben"
 
 #: senaite/core/browser/dashboard/dashboard.py:81
 msgid "Samples to Receive"
-msgstr ""
+msgstr "Anzunehmende Proben"
 
 #: senaite/core/browser/dashboard/dashboard.py:432
 msgid "Samples whose reports have been published"
-msgstr ""
+msgstr "Proben, deren Berichte veröffentlicht wurden"
 
 #: senaite/core/browser/dashboard/dashboard.py:424
 msgid "Samples whose results are awaiting verification"
-msgstr ""
+msgstr "Proben, deren Ergebnisse auf die Verifizierung warten"
 
 #: senaite/core/browser/dashboard/dashboard.py:409
 msgid "Samples with a scheduled sampling date"
-msgstr ""
+msgstr "Proben mit einem geplanten Probenahmedatum"
 
 #: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
@@ -5405,11 +5405,11 @@ msgstr "Speichern und Kopieren"
 # senaite.app.listing: Saved filter presets — footer button to save the
 # current view
 msgid "Save current view"
-msgstr ""
+msgstr "Aktuelle Ansicht speichern"
 
 # senaite.app.listing: Saved filter presets — toggle title + menu header
 msgid "Saved filters"
-msgstr ""
+msgstr "Gespeicherte Filter"
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5442,7 +5442,7 @@ msgstr "Suchen"
 
 # senaite.app.listing: Column config — search input placeholder
 msgid "Search columns…"
-msgstr ""
+msgstr "Spalten durchsuchen…"
 
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
@@ -5588,11 +5588,11 @@ msgstr "Auswählen um dem Probenahme-Koordinator zu erlauben, eine Probe zeitlic
 
 #: senaite/core/content/senaitesetup.py:1001
 msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
-msgstr ""
+msgstr "Aktivieren Sie diese Option, um das Ausliefern von Proben über den Übergang 'dispatch' zu erlauben und den zusätzlichen Status 'ausgeliefert' zu aktivieren. Die Analysen einer ausgelieferten Probe werden schreibgeschützt und in ihren vorherigen Status zurückversetzt, wenn die Probe wiederhergestellt wird. Standardmäßig deaktiviert."
 
 #: senaite/core/content/senaitesetup.py:991
 msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
-msgstr ""
+msgstr "Aktivieren Sie diese Option, um das Entsorgen von Proben über den Übergang 'dispose' zu erlauben und den zusätzlichen Status 'entsorgt' zu aktivieren. Standardmäßig deaktiviert."
 
 #: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
@@ -5752,7 +5752,7 @@ msgstr "Alle anzeigen"
 
 #: senaite/core/api/remarks.py:486
 msgid "Show history"
-msgstr ""
+msgstr "Verlauf anzeigen"
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
@@ -5772,11 +5772,11 @@ msgstr "Zeige Standardfelder"
 
 # senaite.app.listing: Column config — plus button tooltip / aria-label
 msgid "Show this column"
-msgstr ""
+msgstr "Diese Spalte anzeigen"
 
 #: senaite/core/browser/dashboard/dashboard.py:129
 msgid "Show/hide timeline"
-msgstr ""
+msgstr "Zeitverlauf ein-/ausblenden"
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5843,11 +5843,11 @@ msgstr "Sortierschlüssel"
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort ascending"
-msgstr ""
+msgstr "Aufsteigend sortieren"
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort descending"
-msgstr ""
+msgstr "Absteigend sortieren"
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5919,7 +5919,7 @@ msgstr "Etikettenvorschau"
 
 # senaite.app.listing: Saved filter presets — star action tooltip when active
 msgid "Stop auto-applying"
-msgstr ""
+msgstr "Automatisches Anwenden beenden"
 
 #: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
@@ -5963,7 +5963,7 @@ msgstr "Senden Sie eine gültige Open XML-Datei (.XLSX) mit Setup-Datensätzen, 
 
 #: senaite/core/browser/dashboard/dashboard.py:490
 msgid "Submitted analyses awaiting verification"
-msgstr ""
+msgstr "Übermittelte Analysen, die auf die Verifizierung warten"
 
 #: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
@@ -6161,7 +6161,7 @@ msgstr "Die folgende(n) Probe(n) werden versendet"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:47
 msgid "The following sample(s) will be disposed"
-msgstr ""
+msgstr "Die folgenden Proben werden entsorgt"
 
 #: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
@@ -6438,11 +6438,11 @@ msgstr "Zu beproben"
 
 #: senaite/core/browser/dashboard/dashboard.py:93
 msgid "To be Published"
-msgstr ""
+msgstr "Zu veröffentlichen"
 
 #: senaite/core/browser/dashboard/dashboard.py:89
 msgid "To be Verified"
-msgstr ""
+msgstr "Zu verifizieren"
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
@@ -6525,7 +6525,7 @@ msgstr "Tippen um zu filtern ..."
 
 # senaite.app.listing: Column-filter row — searchable-select placeholder
 msgid "Type to filter..."
-msgstr ""
+msgstr "Zum Filtern tippen..."
 
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
@@ -6586,7 +6586,7 @@ msgstr "Benutzerverknüpfung aufgehoben"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unlock"
-msgstr ""
+msgstr "Entsperren"
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6612,7 +6612,7 @@ msgstr "Anhänge Aktualisieren"
 
 # senaite.app.listing: Saved filter presets — Update preset action tooltip
 msgid "Update preset with current view"
-msgstr ""
+msgstr "Voreinstellung mit aktueller Ansicht aktualisieren"
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6951,7 +6951,7 @@ msgstr "Verifiziert von"
 
 #: senaite/core/browser/dashboard/dashboard.py:428
 msgid "Verified samples ready to be published"
-msgstr ""
+msgstr "Verifizierte Proben, die zur Veröffentlichung bereit sind"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
@@ -6961,7 +6961,7 @@ msgstr "Verifizieren"
 
 #: senaite/core/browser/dashboard/dashboard.py:109
 msgid "Verify Results"
-msgstr ""
+msgstr "Ergebnisse verifizieren"
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6979,11 +6979,11 @@ msgstr "SENAITE Seite ansehen"
 
 # senaite.app.listing: Column config — visible-section header
 msgid "Visible"
-msgstr ""
+msgstr "Sichtbar"
 
 # senaite.app.listing: Column config — counter title attribute
 msgid "Visible / total columns"
-msgstr ""
+msgstr "Sichtbare / gesamte Spalten"
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -7020,7 +7020,7 @@ msgstr "Mittwoch"
 
 #: senaite/core/browser/dashboard/dashboard.py:136
 msgid "Weekly"
-msgstr ""
+msgstr "Wöchentlich"
 
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
@@ -7104,11 +7104,11 @@ msgstr "Arbeitsblätter"
 
 #: senaite/core/browser/dashboard/dashboard.py:531
 msgid "Worksheets that have been verified"
-msgstr ""
+msgstr "Arbeitsblätter, die verifiziert wurden"
 
 #: senaite/core/browser/dashboard/dashboard.py:526
 msgid "Worksheets whose results are awaiting verification"
-msgstr ""
+msgstr "Arbeitsblätter, deren Ergebnisse auf die Verifizierung warten"
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -7120,7 +7120,7 @@ msgstr "Falsche IBAN Länge von %s: %s ist %i zu kurz"
 
 #: senaite/core/browser/dashboard/dashboard.py:140
 msgid "Yearly"
-msgstr ""
+msgstr "Jährlich"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -7208,7 +7208,7 @@ msgstr "Analytiker muss angegeben werden."
 
 # senaite.app.listing: Saved filter presets — micro-tag on the default preset
 msgid "auto"
-msgstr ""
+msgstr "auto"
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
@@ -7303,7 +7303,7 @@ msgstr "${d}.${m}.${y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
+#. Default: "yy-mm-dd"
 #, fuzzy
 msgid "date_format_short_datepicker"
 msgstr "tt.mm.jj"
@@ -7319,11 +7319,11 @@ msgstr "deaktivieren"
 #. Default: "Sample disposed after the retention period."
 #: senaite/core/browser/samples/templates/dispose_samples.pt:66
 msgid "default_dispose_reason"
-msgstr ""
+msgstr "Probe nach Ablauf der Aufbewahrungsfrist entsorgt."
 
 #: senaite/core/api/remarks.py:485
 msgid "deleted by {user} at {time}"
-msgstr ""
+msgstr "gelöscht von {user} am {time}"
 
 #. Default: "Attached labels"
 #: senaite/core/behaviors/label.py:126
@@ -7681,8 +7681,9 @@ msgstr "Interim-Felder wie Gefäßmasse, Verdünnungsfaktoren etc. festlegen, so
 #. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
+#, fuzzy
 msgid "description_calculation_interims"
-msgstr ""
+msgstr "Definieren Sie Zwischenfelder wie Gefäßmasse oder Verdünnungsfaktoren, falls Ihre Berechnung diese benötigt. Der hier angegebene Feldtitel wird als Spaltenüberschrift und Feldbeschreibung verwendet, wo die Zwischenfelder angezeigt werden. Wenn 'Breit anwenden' aktiviert ist, wird das Feld in einem Auswahlfeld oben im Arbeitsblatt angezeigt, sodass ein bestimmter Wert auf alle entsprechenden Felder des Blattes angewendet werden kann."
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
@@ -7830,15 +7831,17 @@ msgstr "Zugeordnete Laborabteilungen"
 #. the default style."
 #. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
 #: senaite/core/content/label.py:72
+#, fuzzy
 msgid "description_label_color"
-msgstr ""
+msgstr "Hex-Farbcode für den Chip (z. B. #0d6efd). Leer lassen für den Standardstil."
 
 #. labeled content. The cascade runs in the same transaction as the save and
 #. may take a moment on large datasets."
 #. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
 #: senaite/core/content/label.py:45
+#, fuzzy
 msgid "description_label_title"
-msgstr ""
+msgstr "Das Umbenennen dieses Etiketts überschreibt den gespeicherten Namen bei allen aktuell etikettierten Inhalten. Der Kaskadenvorgang läuft in derselben Transaktion wie das Speichern und kann bei großen Datenmengen einen Moment dauern."
 
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
@@ -7876,8 +7879,9 @@ msgstr "Bitte den Mehrwertsteuersatz in Prozent angeben, der zum Laborproduktpre
 #. show or reorder each viewlet."
 #. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+#, fuzzy
 msgid "description_manage_viewlets"
-msgstr ""
+msgstr "Die Viewlet-Manager und ihre Viewlets werden an Ort und Stelle angezeigt, verschachtelt und so positioniert, wie sie auf der Website erscheinen. Verwenden Sie die Steuerelemente, um jedes Viewlet auszublenden, anzuzeigen oder neu anzuordnen."
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
@@ -8752,42 +8756,42 @@ msgstr "Doppelbestimmung in Position ${dup} referenziert diese, daher muss es si
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr ""
+msgstr "${days} Tage"
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr ""
+msgstr "${hours} Stunden"
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr ""
+msgstr "Tage"
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr ""
+msgstr "Stunden"
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr ""
+msgstr "Minuten"
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr ""
+msgstr "Sekunden"
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr ""
+msgstr "${minutes} Minuten"
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr ""
+msgstr "${seconds} Sekunden"
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
@@ -8796,7 +8800,7 @@ msgstr "Inhalt der Datei"
 
 #: senaite/core/api/remarks.py:481
 msgid "edited"
-msgstr ""
+msgstr "bearbeitet"
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -10135,18 +10139,19 @@ msgstr "Auf Methode beschränken"
 #. Default: "Added ${count} label(s) to ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:185
 msgid "labels_added"
-msgstr ""
+msgstr "${count} Etikett(en) zu ${affected} Probe(n) hinzugefügt"
 
 #. sample(s)"
 #. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:174
+#, fuzzy
 msgid "labels_changed"
-msgstr ""
+msgstr "${added} hinzugefügt und ${removed} entfernt bei ${affected} Probe(n) angewendet"
 
 #. Default: "Removed ${count} label(s) from ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:194
 msgid "labels_removed"
-msgstr ""
+msgstr "${count} Etikett(en) von ${affected} Probe(n) entfernt"
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
@@ -11458,7 +11463,7 @@ msgstr "Minuten"
 # senaite.app.listing: Saved filter presets — dirty indicator on the applied
 # preset
 msgid "modified"
-msgstr ""
+msgstr "geändert"
 
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
@@ -11517,7 +11522,7 @@ msgstr "von"
 
 #: senaite/core/api/remarks.py:494
 msgid "original"
-msgstr ""
+msgstr "Original"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
@@ -11525,7 +11530,7 @@ msgstr "Übersicht"
 
 # senaite.app.listing: Saved filter presets — menu subtitle
 msgid "per listing"
-msgstr ""
+msgstr "pro Liste"
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11607,7 +11612,7 @@ msgstr "Diese Probe wurde von ${actor} am ${date} versandt."
 #. Default: "This sample has been disposed by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
 msgid "this_sample_has_been_disposed_by"
-msgstr ""
+msgstr "Diese Probe wurde von ${actor} am ${date} entsorgt"
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11844,7 +11849,7 @@ msgstr "Laborleiter"
 #. Default: "Color"
 #: senaite/core/content/label.py:68
 msgid "title_label_color"
-msgstr ""
+msgstr "Farbe"
 
 #. Default: "Description"
 #: senaite/core/content/label.py:56
@@ -11944,7 +11949,7 @@ msgstr "Analysentyp"
 #. Default: "Manage Viewlets"
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
 msgid "title_manage_viewlets"
-msgstr ""
+msgstr "Viewlets verwalten"
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86

--- a/src/senaite/core/locales/el/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/el/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Greek (https://app.transifex.com/senaite/teams/87045/el/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/el/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/el/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Greek (https://app.transifex.com/senaite/teams/87045/el/)\n"

--- a/src/senaite/core/locales/el/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/el/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Greek (https://app.transifex.com/senaite/teams/87045/el/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: el\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Είδος  Λογαριασμού"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Προσθήκη"
 
@@ -284,15 +290,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Αναλύσεις"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -551,6 +588,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -565,18 +606,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Αυτόματη αποσύνδεση"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -800,7 +845,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr "Τηλέφωνο Εργασίας"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC Emails"
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Ακυρώθηκε"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Αριθμός Καταλόγου"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr "Πόλη"
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Πελάτης"
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Παραγγελία Πελάτη"
 
@@ -1126,7 +1185,7 @@ msgstr "Παραγγελία Πελάτη"
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1135,7 +1194,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1228,7 +1287,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Επιβεβαίωση κωδικού πρόσβασης"
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Επαφή"
@@ -1328,7 +1391,7 @@ msgstr "Δοχεία"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr "Αντιγραφή από"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "Χώρα"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1473,7 +1540,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Νόμισμα"
 
@@ -1481,12 +1548,20 @@ msgstr "Νόμισμα"
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Ημερομηνία Ανοίγματος"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Ημερομηνία Δημοσίευσης"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Ημερομηνία Παραλαβής"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr "Ημερομηνία Αίτησης"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Ημερομηνία Δειγματοληψίας"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr "Προεπιλεγμένο Δοχείο"
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Προεπιλεγμένη τιμή"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Περιγραφή"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Προθεσμία"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Προθεσμία"
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr "Π.χ. SANAS, APLAC, κλπ."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr "Υψόμετρο"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Διεύθυνση Email"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr "Ημερομηνία Λήξης"
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr "Εξαγωγή"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr "Από"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr "Κλειδί"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Λέξη Κλειδί"
 
@@ -3012,6 +3153,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Λέξεις Κλειδιά"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3056,8 +3201,8 @@ msgstr "Προϊόντα Εργαστηρίου"
 msgid "Lab URL"
 msgstr "URL Εργαστηρίου"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Ετικέτα"
@@ -3066,7 +3211,7 @@ msgstr "Ετικέτα"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr "Εργαστήριο"
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Μεγάλο Αυτοκόλλητο"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Καθυστερημένες Αναλύσεις"
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr "Άρρεν"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr "Email Διευθυντή"
 msgid "Manager Phone"
 msgstr "Τηλέφωνο Διευθυντή"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr "Μέγιστος Χρόνος"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr "Ελάχιστο"
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr "Τουλάχιστον 5 χαρακτήρες."
 msgid "Minimum Volume"
 msgstr "Ελάχιστος Όγκος"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Όνομα"
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Άνοιγμα"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr "Τιμοκατάλογος για"
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr "Εκτύπωση τιμοκαταλόγου"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Προφίλ"
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Αίτηση νέων αναλύσεων"
 
@@ -4681,8 +4921,20 @@ msgstr "Απαιτούμενος Όγκος"
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Αποτέλεσμα εκτός εύρους"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Δείγμα"
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Είδος Δείγματος"
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Δειγματολήπτης"
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Δείγματα"
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Ημερομηνία Δειγματοληψίας"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr "Συχνότητα Δειγματοληψίας"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Δευτερόλεπτα"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr "Επιλέξτε ποιες Αναλύσεις πρέπει να περ�
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Ξεχωριστό Δοχείο"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr "Σειριακός Αριθμός"
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Μικρό Αυτοκόλλητο"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Κατάσταση"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Αυτοκόλλητο"
@@ -5577,7 +5908,11 @@ msgstr "Αυτοκόλλητο"
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr "Υποβολή"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Υποσύνολο"
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Το ύψος ή βάθος στο οποίο πρέπει να ληφθεί το δείγμα"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Σύνολο"
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Είδος"
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr "ΦΠΑ"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "ΦΠΑ %"
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6576,10 +6940,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,10 +7088,18 @@ msgstr "Πρότυπα Φύλλου Εργασίας"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Φύλλα Εργασίας"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "απενεργοποίηση"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/el/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/el/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Greek (https://app.transifex.com/senaite/teams/87045/el/)\n"

--- a/src/senaite/core/locales/en/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/en/LC_MESSAGES/plone.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/src/senaite/core/locales/en/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/en/LC_MESSAGES/plone.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -854,6 +854,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/en/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/en/LC_MESSAGES/senaite.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -23,6 +23,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -48,6 +49,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -117,6 +119,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -134,7 +140,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -192,7 +198,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -237,21 +243,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -279,15 +285,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -300,8 +310,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -365,12 +378,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -389,11 +410,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -422,14 +443,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -499,7 +536,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -536,7 +573,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -546,6 +583,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -560,18 +601,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -586,7 +623,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -674,11 +711,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -686,15 +727,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -745,7 +786,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -775,6 +816,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -795,7 +840,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -813,19 +858,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -833,12 +878,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -894,23 +939,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -930,15 +975,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -964,7 +1009,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -996,11 +1041,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1037,31 +1082,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1074,12 +1119,24 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1087,7 +1144,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1099,7 +1156,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1111,7 +1168,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1121,7 +1178,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1130,7 +1187,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1223,7 +1280,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1261,6 +1318,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1279,7 +1340,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1323,7 +1384,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1356,15 +1417,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1374,6 +1435,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1392,11 +1457,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1409,7 +1474,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1417,7 +1482,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1429,7 +1494,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1459,7 +1524,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1468,7 +1533,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1476,12 +1541,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1529,23 +1602,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1557,11 +1630,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1603,7 +1676,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1626,11 +1699,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1642,7 +1715,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1654,7 +1727,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1662,20 +1735,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1687,7 +1760,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1719,15 +1792,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1739,7 +1812,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1748,7 +1821,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1772,7 +1845,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1784,8 +1857,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1814,9 +1896,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1863,7 +1945,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1881,7 +1967,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1906,15 +1992,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1984,11 +2078,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2005,7 +2103,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2053,6 +2151,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2067,21 +2166,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2089,27 +2188,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2122,16 +2221,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2142,27 +2245,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2170,8 +2273,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2195,7 +2306,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2208,7 +2319,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2232,7 +2343,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2244,15 +2355,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2264,7 +2375,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2274,7 +2385,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2300,7 +2411,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2308,7 +2419,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2395,7 +2506,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2409,6 +2520,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2425,11 +2548,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2452,13 +2575,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2466,7 +2593,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2499,7 +2626,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2513,7 +2640,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2526,8 +2653,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2551,7 +2690,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2559,7 +2698,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2579,15 +2718,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2595,7 +2734,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2635,7 +2774,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2666,11 +2805,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2867,7 +3006,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2888,13 +3027,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2957,15 +3096,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2977,7 +3116,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2989,9 +3128,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3006,6 +3145,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3051,8 +3194,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3061,7 +3204,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3069,13 +3212,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3088,7 +3231,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3100,7 +3243,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3112,11 +3255,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3162,15 +3305,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3194,7 +3337,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3221,6 +3364,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3285,7 +3436,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3309,7 +3460,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3333,7 +3484,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3362,7 +3513,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3377,7 +3528,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3412,15 +3563,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3428,7 +3579,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3459,7 +3610,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3470,7 +3621,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3488,7 +3639,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3519,6 +3670,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3532,11 +3687,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3572,13 +3727,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3588,6 +3747,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3630,6 +3793,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3678,6 +3845,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3722,12 +3893,24 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3744,6 +3927,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3772,7 +3959,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3788,11 +3975,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3813,7 +4000,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3825,7 +4012,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3841,16 +4028,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3860,6 +4047,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3878,11 +4069,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3890,13 +4081,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3904,8 +4095,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3933,7 +4132,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3955,11 +4154,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4056,11 +4255,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4073,6 +4272,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4092,12 +4292,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4136,31 +4340,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4193,7 +4397,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4210,11 +4414,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4242,7 +4446,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4251,7 +4455,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4273,11 +4477,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4290,7 +4494,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4314,7 +4518,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4323,7 +4527,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4331,7 +4535,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4340,8 +4544,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4356,6 +4564,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4377,6 +4589,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4403,7 +4623,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4415,30 +4635,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4489,11 +4713,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4519,9 +4747,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4537,7 +4765,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4598,8 +4826,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4635,11 +4871,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4651,7 +4887,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4660,7 +4896,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4676,8 +4912,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4685,15 +4933,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4718,15 +4967,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4734,7 +4983,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4750,16 +4999,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4767,7 +5020,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4791,7 +5044,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4827,6 +5080,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4852,6 +5109,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4861,7 +5119,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4875,7 +5133,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4912,7 +5170,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4932,7 +5190,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4959,7 +5217,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5020,7 +5278,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5032,8 +5290,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5050,6 +5308,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5059,7 +5329,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5067,7 +5353,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5080,7 +5366,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5088,14 +5374,22 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5110,7 +5404,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5127,6 +5421,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5135,7 +5433,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5225,11 +5523,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5241,11 +5539,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5253,31 +5551,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5289,7 +5595,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5301,11 +5607,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5327,7 +5633,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5341,7 +5647,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5369,7 +5675,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5417,28 +5723,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5461,11 +5779,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5486,7 +5804,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5502,6 +5820,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5528,7 +5854,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5536,7 +5862,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5553,17 +5879,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5572,7 +5898,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5612,7 +5942,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5620,7 +5954,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5662,7 +5996,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5688,7 +6022,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5770,7 +6104,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5778,7 +6112,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5806,7 +6140,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5814,11 +6152,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5855,11 +6193,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5899,7 +6237,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5923,11 +6261,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5979,11 +6317,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6007,11 +6345,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6043,8 +6381,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6071,34 +6409,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6111,7 +6457,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6133,7 +6479,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6158,6 +6504,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6166,7 +6516,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6178,6 +6528,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6210,8 +6561,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6228,12 +6583,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6244,7 +6603,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6252,7 +6611,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6290,7 +6649,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6298,15 +6657,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6314,7 +6673,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6561,8 +6920,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6571,10 +6930,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6589,6 +6956,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6624,6 +6999,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6636,19 +7015,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6699,9 +7078,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6710,6 +7097,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6794,6 +7185,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6895,8 +7290,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6946,7 +7350,7 @@ msgid "description_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7086,52 +7490,52 @@ msgid "description_batch_client"
 msgstr ""
 
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7171,12 +7575,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7186,7 +7590,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7280,6 +7684,16 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7308,6 +7722,11 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7426,12 +7845,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7661,232 +8080,232 @@ msgid "description_sampletype_samplematrix"
 msgstr ""
 
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -7993,46 +8412,50 @@ msgstr ""
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr "${days} days"
+msgstr ""
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr "${hours} hours"
+msgstr ""
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr "Days"
+msgstr ""
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr "Hours"
+msgstr ""
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr "Minutes"
+msgstr ""
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr "Seconds"
+msgstr ""
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr "${minutes} minutes"
+msgstr ""
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr "${seconds} seconds"
+msgstr ""
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8344,7 +8767,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8394,7 +8817,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8499,52 +8922,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8614,12 +9037,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8629,7 +9052,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -8924,7 +9347,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9049,12 +9472,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9264,7 +9687,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9274,12 +9697,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9337,6 +9760,21 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10513,87 +10951,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10646,6 +11084,10 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10695,12 +11137,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -10778,6 +11228,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11012,13 +11467,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11105,6 +11565,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11350,222 +11815,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -11813,7 +12278,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -11856,7 +12321,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/en/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/en/LC_MESSAGES/senaite.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/src/senaite/core/locales/en_ES/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/en_ES/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (Spain) (https://www.transifex.com/senaite/teams/87045/en_ES/)\n"

--- a/src/senaite/core/locales/en_ES/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/en_ES/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (Spain) (https://www.transifex.com/senaite/teams/87045/en_ES/)\n"
@@ -856,6 +856,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/en_ES/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/en_ES/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (Spain) (https://www.transifex.com/senaite/teams/87045/en_ES/)\n"
@@ -7281,7 +7281,7 @@ msgstr ""
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
+#. Default: "yy-mm-dd"
 msgid "date_format_short_datepicker"
 msgstr ""
 

--- a/src/senaite/core/locales/en_ES/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/en_ES/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (Spain) (https://www.transifex.com/senaite/teams/87045/en_ES/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: en_ES\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,24 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1146,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1158,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1170,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1180,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1189,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1282,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1320,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1342,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1386,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1419,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1437,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1459,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1476,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1484,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1496,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1526,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1535,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1543,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1604,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1632,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1678,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1701,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1717,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1729,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1737,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1762,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1794,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1814,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1823,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1847,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1859,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1898,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1947,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1969,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1994,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2080,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2105,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2153,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2168,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2190,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2223,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2247,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2275,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2308,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2321,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2345,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2357,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2377,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2387,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2413,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2421,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2508,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2522,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2550,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2577,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2595,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2628,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2642,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2655,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2692,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2700,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2720,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2736,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2776,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2807,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3008,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3029,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3098,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3118,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3130,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3147,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3196,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3206,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3214,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3233,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3245,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3257,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3307,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3339,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3366,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3438,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3462,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3486,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3515,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3530,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3565,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3581,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3612,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3623,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3641,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3672,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3689,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3729,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3749,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3795,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3847,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3895,24 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3929,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3961,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3977,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4002,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4014,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4030,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4049,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4071,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4083,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4097,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4134,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4156,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4257,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4274,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4294,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4342,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4399,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4416,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4448,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4457,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4479,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4496,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4520,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4529,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4537,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4546,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4566,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4591,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4625,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4637,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4715,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4749,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4767,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4828,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4873,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4889,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4898,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4914,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4935,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4969,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4985,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5001,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5022,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5046,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5082,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5111,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5121,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5135,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5172,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5192,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5219,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5280,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5292,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5310,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5331,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5355,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5368,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5376,22 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5406,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5423,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5435,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5525,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5541,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5553,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5597,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5609,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5635,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5649,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5677,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,29 +5725,41 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
 # senaite.app.listing: Show more
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5464,11 +5782,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5489,7 +5807,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5505,6 +5823,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5531,7 +5857,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5539,7 +5865,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5556,17 +5882,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5575,7 +5901,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5615,7 +5945,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5623,7 +5957,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5665,7 +5999,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5691,7 +6025,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5773,7 +6107,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5781,7 +6115,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5809,7 +6143,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5817,11 +6155,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5858,11 +6196,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5902,7 +6240,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5926,11 +6264,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5982,11 +6320,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6010,11 +6348,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6046,8 +6384,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6074,34 +6412,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6114,7 +6460,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6136,7 +6482,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6161,6 +6507,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6169,7 +6519,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6181,6 +6531,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6213,8 +6564,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6231,12 +6586,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6247,7 +6606,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6255,7 +6614,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6293,7 +6652,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6301,15 +6660,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6317,7 +6676,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6564,8 +6923,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6574,10 +6933,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6592,6 +6959,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6627,6 +7002,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6639,19 +7018,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6702,9 +7081,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6713,6 +7100,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6797,6 +7188,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6886,7 +7281,7 @@ msgstr ""
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "yy-mm-dd"
+#. Default: "mm/dd/yy"
 msgid "date_format_short_datepicker"
 msgstr ""
 
@@ -6898,8 +7293,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6949,7 +7353,7 @@ msgid "description_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7089,52 +7493,52 @@ msgid "description_batch_client"
 msgstr ""
 
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7174,12 +7578,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7189,7 +7593,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7283,6 +7687,16 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7311,6 +7725,11 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7429,12 +7848,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7664,232 +8083,232 @@ msgid "description_sampletype_samplematrix"
 msgstr ""
 
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8036,6 +8455,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8347,7 +8770,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8397,7 +8820,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8502,52 +8925,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8617,12 +9040,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8632,7 +9055,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -8927,7 +9350,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9052,12 +9475,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9267,7 +9690,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9277,12 +9700,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9340,6 +9763,21 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10516,87 +10954,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10649,6 +11087,10 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10698,12 +11140,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -10781,6 +11231,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11015,13 +11470,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11108,6 +11568,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11353,222 +11818,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -11816,7 +12281,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -11859,7 +12324,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/en_US/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/en_US/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (United States) (https://app.transifex.com/senaite/teams/87045/en_US/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/en_US/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/en_US/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (United States) (https://app.transifex.com/senaite/teams/87045/en_US/)\n"

--- a/src/senaite/core/locales/en_US/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/en_US/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: English (United States) (https://app.transifex.com/senaite/teams/87045/en_US/)\n"

--- a/src/senaite/core/locales/en_US/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/en_US/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: English (United States) (https://app.transifex.com/senaite/teams/87045/en_US/)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: en_US\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -27,6 +27,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -52,6 +53,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -121,6 +123,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -138,7 +144,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -196,7 +202,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -241,21 +247,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -283,15 +289,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -304,8 +314,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -369,12 +382,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -393,11 +414,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -426,14 +447,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -503,7 +540,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -540,7 +577,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -550,6 +587,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -564,18 +605,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -590,7 +627,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -678,11 +715,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -690,15 +731,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -749,7 +790,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -779,6 +820,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -799,7 +844,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -817,19 +862,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -837,12 +882,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -898,23 +943,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -934,15 +979,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -968,7 +1013,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1000,11 +1045,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1041,31 +1086,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1078,12 +1123,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1091,7 +1150,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1103,7 +1162,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1115,7 +1174,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1125,7 +1184,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1134,7 +1193,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1227,7 +1286,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1265,6 +1324,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1283,7 +1346,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1327,7 +1390,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1360,15 +1423,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1378,6 +1441,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1396,11 +1463,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1413,7 +1480,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1421,7 +1488,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1433,7 +1500,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1463,7 +1530,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1472,7 +1539,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1480,12 +1547,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1533,23 +1608,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1561,11 +1636,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1607,7 +1682,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1630,11 +1705,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1646,7 +1721,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1658,7 +1733,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1666,20 +1741,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1691,7 +1766,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1723,15 +1798,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1743,7 +1818,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1752,7 +1827,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1776,7 +1851,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1788,8 +1863,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1818,9 +1902,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1867,7 +1951,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1885,7 +1973,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1910,15 +1998,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1988,11 +2084,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2009,7 +2109,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2057,6 +2157,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2071,21 +2172,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2093,27 +2194,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2126,16 +2227,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2146,27 +2251,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2174,8 +2279,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2199,7 +2312,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2212,7 +2325,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2236,7 +2349,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2248,15 +2361,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2268,7 +2381,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2278,7 +2391,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2304,7 +2417,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2312,7 +2425,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2399,7 +2512,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2413,6 +2526,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2429,11 +2554,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2456,13 +2581,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2470,7 +2599,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2503,7 +2632,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2517,7 +2646,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2530,8 +2659,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2555,7 +2696,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2563,7 +2704,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2583,15 +2724,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2599,7 +2740,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2639,7 +2780,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2670,11 +2811,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2871,7 +3012,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2892,13 +3033,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2961,15 +3102,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2981,7 +3122,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2993,9 +3134,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3010,6 +3151,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3055,8 +3200,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3065,7 +3210,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3073,13 +3218,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3092,7 +3237,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3104,7 +3249,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3116,11 +3261,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3166,15 +3311,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3198,7 +3343,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3225,6 +3370,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3289,7 +3442,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3313,7 +3466,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3337,7 +3490,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3366,7 +3519,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3381,7 +3534,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3416,15 +3569,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3432,7 +3585,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3463,7 +3616,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3474,7 +3627,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3492,7 +3645,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3523,6 +3676,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3536,11 +3693,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3576,13 +3733,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3592,6 +3753,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3634,6 +3799,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3682,6 +3851,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3726,12 +3899,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3748,6 +3935,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3776,7 +3967,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3792,11 +3983,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3817,7 +4008,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3829,7 +4020,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3845,16 +4036,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3864,6 +4055,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3882,11 +4077,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3894,13 +4089,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3908,8 +4103,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3937,7 +4140,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3959,11 +4162,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4060,11 +4263,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4077,6 +4280,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4096,12 +4300,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4140,31 +4348,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4197,7 +4405,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4214,11 +4422,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4246,7 +4454,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4255,7 +4463,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4277,11 +4485,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4294,7 +4502,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4318,7 +4526,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4327,7 +4535,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4335,7 +4543,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4344,8 +4552,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4360,6 +4572,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4381,6 +4597,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4407,7 +4631,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4419,30 +4643,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4493,11 +4721,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4523,9 +4755,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4541,7 +4773,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4602,8 +4834,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4639,11 +4879,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4655,7 +4895,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4664,7 +4904,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4680,8 +4920,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4689,15 +4941,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4722,15 +4975,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4738,7 +4991,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4754,16 +5007,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4771,7 +5028,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4795,7 +5052,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4831,6 +5088,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4856,6 +5117,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4865,7 +5127,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4879,7 +5141,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4916,7 +5178,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4936,7 +5198,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4963,7 +5225,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5024,7 +5286,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5036,8 +5298,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5054,6 +5316,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5063,7 +5337,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5071,7 +5361,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5084,7 +5374,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5092,14 +5382,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5114,7 +5413,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5131,6 +5430,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5139,7 +5442,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5229,11 +5532,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5245,11 +5548,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5257,31 +5560,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5293,7 +5604,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5305,11 +5616,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5331,7 +5642,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5345,7 +5656,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5373,7 +5684,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5421,28 +5732,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5465,11 +5788,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5490,7 +5813,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5506,6 +5829,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5532,7 +5863,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5540,7 +5871,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5557,17 +5888,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5576,7 +5907,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5616,7 +5951,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5624,7 +5963,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5666,7 +6005,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5692,7 +6031,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5774,7 +6113,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5782,7 +6121,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5810,7 +6149,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5818,11 +6161,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5859,11 +6202,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5903,7 +6246,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5927,11 +6270,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5983,11 +6326,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6011,11 +6354,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6047,8 +6390,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6075,34 +6418,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6115,7 +6466,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6137,7 +6488,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6162,6 +6513,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6170,7 +6525,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6182,6 +6537,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6214,8 +6570,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6232,12 +6592,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6248,7 +6612,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6256,7 +6620,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6294,7 +6658,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6302,15 +6666,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6318,7 +6682,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6565,8 +6929,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6575,10 +6939,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6593,6 +6965,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6628,6 +7008,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6640,19 +7024,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6703,9 +7087,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6714,6 +7106,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6798,6 +7194,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6902,8 +7302,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6968,7 +7377,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7135,46 +7544,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7186,19 +7595,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7219,16 +7628,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7253,12 +7667,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7268,7 +7682,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7371,6 +7785,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7400,6 +7827,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7546,12 +7980,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7804,7 +8238,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7812,163 +8246,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7976,47 +8410,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8025,20 +8459,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8046,32 +8480,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8079,21 +8513,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8249,6 +8683,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8561,7 +8999,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8622,7 +9060,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8738,52 +9176,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8853,12 +9291,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8868,7 +9306,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9164,7 +9602,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9289,12 +9727,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9504,7 +9942,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9514,12 +9952,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9577,6 +10015,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10753,87 +11207,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10886,6 +11340,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10936,12 +11395,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11019,6 +11486,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11253,13 +11725,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11346,6 +11823,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11591,222 +12073,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12060,7 +12542,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12103,7 +12585,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/eo/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/eo/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Esperanto (https://app.transifex.com/senaite/teams/87045/eo/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/eo/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/eo/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Esperanto (https://app.transifex.com/senaite/teams/87045/eo/)\n"

--- a/src/senaite/core/locales/eo/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/eo/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Esperanto (https://app.transifex.com/senaite/teams/87045/eo/)\n"

--- a/src/senaite/core/locales/eo/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/eo/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Esperanto (https://app.transifex.com/senaite/teams/87045/eo/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: eo\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/es/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es/LC_MESSAGES/plone.po
@@ -21,7 +21,7 @@ msgstr ""
 
 #: senaite/core/browser/user/templates/account-panel.pt:16
 msgid "${action/title}"
-msgstr ""
+msgstr "${action/title}"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:167
 msgid "Activated add-ons"
@@ -98,7 +98,7 @@ msgstr "Salir"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt:275
 msgid "More"
-msgstr ""
+msgstr "Más"
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:79
 msgid "Move down"
@@ -241,12 +241,12 @@ msgstr "Se han definido aquí portlets antiguos. Haga clic en el botón para con
 #. Default: "Next ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:85
 msgid "batch_next_x_items"
-msgstr ""
+msgstr "Siguientes ${number} elementos"
 
 #. Default: "Previous ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:19
 msgid "batch_previous_x_items"
-msgstr ""
+msgstr "Anteriores ${number} elementos"
 
 #. Default: "Add action"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:183
@@ -445,7 +445,7 @@ msgstr "Las cookies no han sido habilitadas. Debe habilitar las cookies antes de
 #. Default: "File already uploaded:"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_input.pt:19
 msgid "file_already_uploaded"
-msgstr ""
+msgstr "Archivo ya subido:"
 
 #. Default: "Get help"
 #: senaite/core/browser/login/templates/login.pt:105
@@ -928,7 +928,7 @@ msgstr "Archivo no encontrado"
 #. Default: "No image"
 #: senaite/core/z3cform/widgets/namedimage/display.pt:17
 msgid "no_image"
-msgstr ""
+msgstr "Sin imagen"
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82

--- a/src/senaite/core/locales/es/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es/LC_MESSAGES/plone.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: David Molins, 2024\n"
 "Language-Team: Spanish (https://app.transifex.com/senaite/teams/87045/es/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 
 #: senaite/core/browser/user/templates/account-panel.pt:16
 msgid "${action/title}"
-msgstr "${action/title}"
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:167
 msgid "Activated add-ons"
@@ -98,7 +98,7 @@ msgstr "Salir"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt:275
 msgid "More"
-msgstr "Más"
+msgstr ""
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:79
 msgid "Move down"
@@ -241,12 +241,12 @@ msgstr "Se han definido aquí portlets antiguos. Haga clic en el botón para con
 #. Default: "Next ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:85
 msgid "batch_next_x_items"
-msgstr "Siguientes ${number} elementos"
+msgstr ""
 
 #. Default: "Previous ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:19
 msgid "batch_previous_x_items"
-msgstr "Anteriores ${number} elementos"
+msgstr ""
 
 #. Default: "Add action"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:183
@@ -445,7 +445,7 @@ msgstr "Las cookies no han sido habilitadas. Debe habilitar las cookies antes de
 #. Default: "File already uploaded:"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_input.pt:19
 msgid "file_already_uploaded"
-msgstr "Archivo ya subido:"
+msgstr ""
 
 #. Default: "Get help"
 #: senaite/core/browser/login/templates/login.pt:105
@@ -928,7 +928,7 @@ msgstr "Archivo no encontrado"
 #. Default: "No image"
 #: senaite/core/z3cform/widgets/namedimage/display.pt:17
 msgid "no_image"
-msgstr "Sin imagen"
+msgstr ""
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82

--- a/src/senaite/core/locales/es/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es/LC_MESSAGES/plone.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: David Molins, 2024\n"
 "Language-Team: Spanish (https://app.transifex.com/senaite/teams/87045/es/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 
 #: senaite/core/browser/user/templates/account-panel.pt:16
 msgid "${action/title}"
-msgstr ""
+msgstr "${action/title}"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:167
 msgid "Activated add-ons"
@@ -98,7 +98,7 @@ msgstr "Salir"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt:275
 msgid "More"
-msgstr ""
+msgstr "Más"
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:79
 msgid "Move down"
@@ -241,12 +241,12 @@ msgstr "Se han definido aquí portlets antiguos. Haga clic en el botón para con
 #. Default: "Next ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:85
 msgid "batch_next_x_items"
-msgstr ""
+msgstr "Siguientes ${number} elementos"
 
 #. Default: "Previous ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:19
 msgid "batch_previous_x_items"
-msgstr ""
+msgstr "Anteriores ${number} elementos"
 
 #. Default: "Add action"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:183
@@ -445,7 +445,7 @@ msgstr "Las cookies no han sido habilitadas. Debe habilitar las cookies antes de
 #. Default: "File already uploaded:"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_input.pt:19
 msgid "file_already_uploaded"
-msgstr ""
+msgstr "Archivo ya subido:"
 
 #. Default: "Get help"
 #: senaite/core/browser/login/templates/login.pt:105
@@ -924,6 +924,11 @@ msgstr "¿Necesita una cuenta?"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
 msgstr "Archivo no encontrado"
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
+msgstr "Sin imagen"
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82

--- a/src/senaite/core/locales/es/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es/LC_MESSAGES/senaite.core.po
@@ -131,7 +131,7 @@ msgstr "±"
 
 # senaite.app.listing: Column-filter row — boolean select placeholder
 msgid "-- Select --"
-msgstr ""
+msgstr "-- Seleccionar --"
 
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
@@ -152,7 +152,7 @@ msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Bienvenido a SENAITE"
 
 #: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
-msgstr ""
+msgstr "<p>El servidor de ID proporciona ID secuenciales únicos para objetos como Muestras y Hojas de trabajo, etc., basándose en un formato especificado para cada tipo de contenido. El formato se construye de forma similar a la sintaxis de formato de Python, p. ej. <code>WS-{seq:03d}</code> produce <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code>, etc.</p><p>Los valores actuales de los contadores persistentes se gestionan en la <a href='ng'>vista del Generador de números</a>.</p><details class='id-server-cheatsheet'><summary>Variables disponibles</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Descripción</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Número de secuencia numérico, opcionalmente rellenado con ceros.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Contador alfanumérico, p. ej. <code>{alpha:2a3d}</code> genera AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Año actual de dos dígitos (p. ej. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Fecha actual como <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>ID de cliente (solo muestras).</td></tr><tr><td><code>{sampleType}</code></td><td>Prefijo del tipo de muestra.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Fechas de muestra (se aplican las especificaciones de <code>strftime</code> de Python).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>Para particiones/reanálisis/secundarias: el ID de la muestra principal.</td></tr><tr><td><code>{partition_count}</code></td><td>Contador de particiones por principal.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Contadores de reanálisis, secundarias y total de análisis.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Campos de configuración</summary><ul><li><strong>Formato</strong>: la plantilla de ID.</li><li><strong>Tipo de secuencia</strong>: <code>generated</code> usa el contador de números persistente; <code>counter</code> usa el recuento de objetos relacionados.</li><li><strong>Contexto</strong>: solo lo usa el tipo <code>counter</code>; el contexto con nombre al que se aplica el contador.</li><li><strong>Tipo de contador</strong>: <code>backreference</code> (obsoleto) o <code>contained</code>.</li><li><strong>Referencia del contador</strong>: nombre de la relación (backreference) o metatipo (contained).</li><li><strong>Prefijo</strong>: prefijo predeterminado si no hay ninguno en el formato.</li><li><strong>Longitud de división</strong>: cuántos segmentos del formato se convierten en el prefijo de la clave de almacenamiento. Determina cómo se particiona el contador (p. ej. por año, por tipo de muestra).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 
 #: bika/lims/content/calculation.py:133
 msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
@@ -297,7 +297,7 @@ msgstr "Añadir muestras"
 
 #: senaite/core/api/remarks.py:492
 msgid "Add a remark..."
-msgstr ""
+msgstr "Añadir un comentario..."
 
 #: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
@@ -322,7 +322,7 @@ msgstr "Añadir uno o más archivos adjuntos con información adicional sobre la
 
 #: senaite/core/browser/samples/view.py:879
 msgid "Add or remove labels on the selected samples"
-msgstr ""
+msgstr "Añadir o quitar etiquetas en las muestras seleccionadas"
 
 #: senaite/core/api/remarks.py:477
 msgid "Add remarks"
@@ -394,7 +394,7 @@ msgstr "Todos los análisis asignados"
 
 # senaite.app.listing: Column config — empty state when no columns are visible
 msgid "All columns are hidden."
-msgstr ""
+msgstr "Todas las columnas están ocultas."
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
@@ -402,7 +402,7 @@ msgstr "Permitir ingreso manual de límite de detección"
 
 #: bika/lims/content/abstractbaseanalysis.py:728
 msgid "Allow Manual Entry"
-msgstr ""
+msgstr "Permitir entrada manual"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -461,15 +461,15 @@ msgstr "Análisis"
 
 #: senaite/core/browser/dashboard/dashboard.py:485
 msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr ""
+msgstr "Análisis asignados a una hoja de trabajo, en espera de resultados"
 
 #: senaite/core/browser/dashboard/dashboard.py:498
 msgid "Analyses included in a published report"
-msgstr ""
+msgstr "Análisis incluidos en un informe publicado"
 
 #: senaite/core/browser/dashboard/dashboard.py:480
 msgid "Analyses not yet assigned to a worksheet"
-msgstr ""
+msgstr "Análisis aún no asignados a una hoja de trabajo"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
@@ -477,7 +477,7 @@ msgstr "Análisis solicitados"
 
 #: senaite/core/browser/dashboard/dashboard.py:494
 msgid "Analyses that have been verified"
-msgstr ""
+msgstr "Análisis que han sido verificados"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -597,7 +597,7 @@ msgstr "Aplicar plantilla"
 
 # senaite.app.listing: Saved filter presets — apply button tooltip
 msgid "Apply this filter"
-msgstr ""
+msgstr "Aplicar este filtro"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -723,7 +723,7 @@ msgstr "Registro de importaciones automáticas"
 
 # senaite.app.listing: Saved filter presets — star action tooltip
 msgid "Auto-apply on open"
-msgstr ""
+msgstr "Aplicar automáticamente al abrir"
 
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
@@ -828,7 +828,7 @@ msgstr "Retraso"
 
 #: senaite/core/browser/dashboard/dashboard.py:139
 msgid "Biannual"
-msgstr ""
+msgstr "Semestral"
 
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
@@ -890,7 +890,7 @@ msgstr "CBID"
 
 #: bika/lims/content/client.py:133
 msgid "CC Contacts"
-msgstr ""
+msgstr "Contactos en CC"
 
 #: bika/lims/content/analysisrequest.py:236
 #: bika/lims/content/client.py:166
@@ -1131,12 +1131,12 @@ msgstr "Clásico"
 
 # senaite.app.listing: Column-filter row — clear button tooltip
 msgid "Clear filter"
-msgstr ""
+msgstr "Borrar filtro"
 
 # senaite.app.listing: Search box — undo button tooltip when only clearing
 # search
 msgid "Clear search"
-msgstr ""
+msgstr "Borrar búsqueda"
 
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
@@ -1149,7 +1149,7 @@ msgstr "Haga clic para desplegar esta categoría"
 # senaite.app.listing: Saved filter presets — release button tooltip on the
 # applied preset
 msgid "Click to release this filter"
-msgstr ""
+msgstr "Haga clic para liberar este filtro"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
@@ -1278,7 +1278,7 @@ msgstr "Falta la columna '{}'"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
 msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
-msgstr ""
+msgstr "La columna {} de la fila de encabezado no tiene nombre. Elimine las columnas vacías de la hoja de cálculo y súbala de nuevo."
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
@@ -1332,7 +1332,7 @@ msgstr "La configuración se ha restaurado a los valores por defecto."
 
 # senaite.app.listing: Column config — trigger button label
 msgid "Configure"
-msgstr ""
+msgstr "Configurar"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
@@ -1443,15 +1443,15 @@ msgstr "Copiar a nuevo"
 
 #: senaite/core/browser/idserver/view.py:131
 msgid "Could not convert {} value(s) to integer: {}"
-msgstr ""
+msgstr "No se pudieron convertir {} valor(es) a entero: {}"
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
-msgstr ""
+msgstr "No se pudieron crear la(s) siguiente(s) muestra(s) debido a conflictos de transacción, vuelva a intentarlo: ${rows}"
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:228
 msgid "Could not link User: ${error}"
-msgstr ""
+msgstr "No se pudo vincular el usuario: ${error}"
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
@@ -1467,7 +1467,7 @@ msgstr "No ha sido posible transicionar las muestras al estado muestreado"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:103
 msgid "Counter <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Contador <span class=\"sort-indicator\" />"
 
 #: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
@@ -1555,7 +1555,7 @@ msgstr "En curso"
 
 # senaite.app.listing: Saved filter presets — dirty tag hover tooltip
 msgid "Current view differs from saved"
-msgstr ""
+msgstr "La vista actual difiere de la guardada"
 
 #: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
@@ -1567,7 +1567,7 @@ msgstr "Límite de Detección"
 
 #: senaite/core/browser/dashboard/dashboard.py:135
 msgid "Daily"
-msgstr ""
+msgstr "Diario"
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1717,7 +1717,7 @@ msgstr "Separador decimal a utilizar en los informes de este Cliente."
 
 #: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
-msgstr ""
+msgstr "Contactos en CC predeterminados para las muestras nuevas. Si se establecen, estos contactos se seleccionan automáticamente en el formulario de creación de muestras."
 
 #: bika/lims/content/analysisservice.py:165
 msgid "Default Container"
@@ -1876,11 +1876,11 @@ msgstr "Eliminar"
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Delete filter"
-msgstr ""
+msgstr "Eliminar filtro"
 
 #: senaite/core/api/remarks.py:484
 msgid "Delete this remark?"
-msgstr ""
+msgstr "¿Eliminar este comentario?"
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
@@ -1959,7 +1959,7 @@ msgstr "No permitir la verificación múltiple por un mismo usuario"
 
 # senaite.app.listing: Saved filter presets — Revert action tooltip
 msgid "Discard edits and restore preset"
-msgstr ""
+msgstr "Descartar los cambios y restaurar el preajuste"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
@@ -2016,7 +2016,7 @@ msgstr "Eliminar"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:15
 msgid "Dispose samples"
-msgstr ""
+msgstr "Desechar muestras"
 
 #: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
@@ -2092,7 +2092,7 @@ msgstr "Descargar los informes seleccionados"
 
 # senaite.app.listing: Column config — drag handle tooltip / aria-label
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Arrastre para reordenar"
 
 #: senaite/core/browser/samples/view.py:327
 msgid "Due"
@@ -2117,7 +2117,7 @@ msgstr "Análisis duplicado"
 
 #: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
-msgstr ""
+msgstr "Formato de ID duplicado para el tipo de portal '${pt}' (filas ${a} y ${b}). Solo se usa la primera fila; elimine o combine el duplicado."
 
 #: bika/lims/content/worksheettemplate.py:59
 msgid "Duplicate Of"
@@ -2129,7 +2129,7 @@ msgstr "Análisis de muestras duplicadas de QC"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr ""
+msgstr "Duplicar muestra"
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
@@ -2141,7 +2141,7 @@ msgstr "Claves duplicadas en el campo de opciones"
 
 #: bika/lims/browser/workflow/analysisrequest.py:443
 msgid "Duplicated samples: {}"
-msgstr ""
+msgstr "Muestras duplicadas: {}"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpec.xml
 msgid "Dynamic Analysis Specification"
@@ -2247,7 +2247,7 @@ msgstr "El correo electrónico se ha enviado"
 
 #: bika/lims/api/snapshot.py:585
 msgid "Empty"
-msgstr ""
+msgstr "Vacío"
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2291,11 +2291,11 @@ msgstr "Activar la funcionalidad de seguimiento de impresión de informes de res
 
 #: senaite/core/content/senaitesetup.py:1000
 msgid "Enable the Sample Dispatch workflow"
-msgstr ""
+msgstr "Habilitar el flujo de trabajo de envío de muestras"
 
 #: senaite/core/content/senaitesetup.py:990
 msgid "Enable the Sample Dispose workflow"
-msgstr ""
+msgstr "Habilitar el flujo de trabajo de desecho de muestras"
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2532,19 +2532,19 @@ msgstr "Filtro por servicios de plantilla"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
-msgstr ""
+msgstr "Filtrar claves (compatible con regex)"
 
 # senaite.app.listing: Saved filter presets — inline editor placeholder
 msgid "Filter name"
-msgstr ""
+msgstr "Nombre del filtro"
 
 #: senaite/core/browser/samples/view.py:601
 msgid "Filter samples by this analysis"
-msgstr ""
+msgstr "Filtrar muestras por este análisis"
 
 # senaite.app.listing: Column-filter row — text-input placeholder
 msgid "Filter..."
-msgstr ""
+msgstr "Filtrar..."
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
@@ -2589,7 +2589,7 @@ msgstr "Desde"
 
 #: senaite/core/browser/dashboard/dashboard.py:134
 msgid "From ${from} to ${to} (updated every 2 hours)"
-msgstr ""
+msgstr "De ${from} a ${to} (actualizado cada 2 horas)"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
@@ -2667,19 +2667,19 @@ msgstr "Oculto del informe"
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
-msgstr ""
+msgstr "Ocultar campos adicionales"
 
 # senaite.app.listing: Column config — bulk action button
 msgid "Hide all"
-msgstr ""
+msgstr "Ocultar todo"
 
 #: senaite/core/api/remarks.py:487
 msgid "Hide history"
-msgstr ""
+msgstr "Ocultar historial"
 
 # senaite.app.listing: Column config — eye-slash button tooltip / aria-label
 msgid "Hide this column"
-msgstr ""
+msgstr "Ocultar esta columna"
 
 #: bika/lims/config.py:140
 msgid "High"
@@ -2708,7 +2708,7 @@ msgstr "Servidor de ID"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:17
 msgid "ID Server Settings"
-msgstr ""
+msgstr "Configuración del servidor de ID"
 
 #: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
@@ -2716,7 +2716,7 @@ msgstr "Valores del servidor de IDs"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:113
 msgid "ID Template <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Plantilla de ID <span class=\"sort-indicator\" />"
 
 #: bika/lims/content/samplepoint.py:84
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
@@ -3047,7 +3047,7 @@ msgstr "Invalidadas"
 
 #: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
-msgstr ""
+msgstr "Formato de ID no válido en la fila ${i} ('${pt}'): ${err}"
 
 #: senaite/core/content/person.py:236
 msgid "Invalid email address"
@@ -3138,7 +3138,7 @@ msgstr "Clave"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:98
 msgid "Key <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Clave <span class=\"sort-indicator\" />"
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
@@ -3161,7 +3161,7 @@ msgstr "Palabras clave"
 
 #: senaite/core/browser/samples/view.py:249
 msgid "Keywords of the analyses contained in the sample"
-msgstr ""
+msgstr "Palabras clave de los análisis contenidos en la muestra"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3347,11 +3347,11 @@ msgstr "Documento de la certificación"
 
 # senaite.core: Sidebar loading state
 msgid "Loading navigation..."
-msgstr ""
+msgstr "Cargando navegación..."
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
-msgstr ""
+msgstr "Cargando..."
 
 #: senaite/core/browser/clients/client/attachments/view.py:79
 #: senaite/core/browser/controlpanel/contacts/view.py:70
@@ -3380,11 +3380,11 @@ msgstr "Ubicación donde se archiva el conjunto de documentos"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Lock"
-msgstr ""
+msgstr "Bloquear"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Locked"
-msgstr ""
+msgstr "Bloqueado"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3454,7 +3454,7 @@ msgstr "Configurar los campos del formulario"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:12
 msgid "Manage Number Generator"
-msgstr ""
+msgstr "Gestionar el generador de números"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:21
 msgid "Manage Partitions"
@@ -3474,7 +3474,7 @@ msgstr "Administrar usuario vinculado"
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
-msgstr ""
+msgstr "Gestionar campos de muestra"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:38
 msgid "Manage the order and visibility of the fields displayed in analysis request add forms."
@@ -3684,7 +3684,7 @@ msgstr "Lunes"
 
 #: senaite/core/browser/dashboard/dashboard.py:137
 msgid "Monthly"
-msgstr ""
+msgstr "Mensual"
 
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
@@ -3741,7 +3741,7 @@ msgstr "Mi Perfil"
 
 # senaite.app.listing: Saved filter presets — default name when saving
 msgid "My filter"
-msgstr ""
+msgstr "Mi filtro"
 
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
@@ -3763,11 +3763,11 @@ msgstr "Los nuevos rangos no se aplicarán ni a los análisis nuevos ni a los ac
 
 #: senaite/core/api/remarks.py:490
 msgid "Newest first"
-msgstr ""
+msgstr "Más recientes primero"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Siguiente ID <span class=\"sort-indicator\" />"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:168
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -3809,7 +3809,7 @@ msgstr "No hay ninguna acción definida"
 
 #: senaite/core/browser/dashboard/dashboard.py:131
 msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
-msgstr ""
+msgstr "No hay acciones disponibles. Póngase en contacto con el responsable de su laboratorio para que le asigne permisos."
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3846,7 +3846,7 @@ msgstr "No ha seleccionado ningún servicio de análisis."
 
 #: senaite/core/browser/idserver/view.py:135
 msgid "No changes"
-msgstr ""
+msgstr "Sin cambios"
 
 #: senaite/core/browser/workflow/worksheet.py:50
 msgid "No changes made"
@@ -3859,7 +3859,7 @@ msgstr "Sin cambios."
 
 #: senaite/core/browser/dashboard/dashboard.py:130
 msgid "No data for the selected period"
-msgstr ""
+msgstr "No hay datos para el período seleccionado"
 
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
@@ -3867,7 +3867,7 @@ msgstr "No se ha indicado fecha"
 
 #: bika/lims/browser/workflow/analysisrequest.py:435
 msgid "No duplicate created"
-msgstr ""
+msgstr "No se creó ningún duplicado"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:135
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:138
@@ -3908,12 +3908,12 @@ msgstr "No ha seleccionado ningún elemento."
 # senaite.app.listing: Column config — empty state for hidden section with
 # search
 msgid "No matches in hidden columns."
-msgstr ""
+msgstr "No hay coincidencias en las columnas ocultas."
 
 # senaite.app.listing: Column config — empty state for visible section with
 # search
 msgid "No matches in visible columns."
-msgstr ""
+msgstr "No hay coincidencias en las columnas visibles."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
@@ -3925,7 +3925,7 @@ msgstr "No se ha creado ninguna partición"
 
 #: senaite/core/api/remarks.py:493
 msgid "No remarks yet"
-msgstr ""
+msgstr "Aún no hay comentarios"
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3945,7 +3945,7 @@ msgstr "Sin flujo de trabajo de muestreo"
 
 # senaite.app.listing: Saved filter presets — empty state
 msgid "No saved filters yet."
-msgstr ""
+msgstr "Aún no hay filtros guardados."
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -4065,7 +4065,7 @@ msgstr "Numérico"
 
 #: senaite/core/api/remarks.py:491
 msgid "Oldest first"
-msgstr ""
+msgstr "Más antiguos primero"
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -4111,7 +4111,7 @@ msgstr "Open Source Web based Laboratory Information Management System"
 
 #: senaite/core/browser/dashboard/dashboard.py:97
 msgid "Open Worksheets"
-msgstr ""
+msgstr "Hojas de trabajo abiertas"
 
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
@@ -4119,7 +4119,7 @@ msgstr "Abra el formulario de correo electrónico para enviar los informes selec
 
 #: senaite/core/browser/dashboard/dashboard.py:522
 msgid "Open worksheets with analyses awaiting results"
-msgstr ""
+msgstr "Hojas de trabajo abiertas con análisis en espera de resultados"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -4204,7 +4204,7 @@ msgstr "% de error permitido"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:23
 msgid "Persistent counters used by the ID Server. Adjust a counter to change the next ID that will be issued for the matching prefix. Setting a counter to 0 removes the entry from the storage."
-msgstr ""
+msgstr "Contadores persistentes utilizados por el servidor de ID. Ajuste un contador para cambiar el siguiente ID que se emitirá para el prefijo coincidente. Establecer un contador en 0 elimina la entrada del almacenamiento."
 
 #: bika/lims/browser/clientfolder.py:81
 #: bika/lims/browser/templates/batch_publish.pt:68
@@ -4308,7 +4308,7 @@ msgstr "Por favor escriba un comentario indicando donde se envían las muestras"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:73
 msgid "Please write a comment where the listed sample(s) are disposed"
-msgstr ""
+msgstr "Escriba un comentario indicando dónde se desecha(n) la(s) muestra(s) listada(s)"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
@@ -4560,7 +4560,7 @@ msgstr "Publicar"
 
 #: senaite/core/browser/dashboard/dashboard.py:112
 msgid "Publish Reports"
-msgstr ""
+msgstr "Publicar informes"
 
 #: senaite/core/browser/dashboard/dashboard.py:150
 #: senaite/core/browser/samples/view.py:369
@@ -4582,7 +4582,7 @@ msgstr "Resultados publicados"
 
 #: senaite/core/browser/dashboard/dashboard.py:448
 msgid "Published samples whose reports have not been printed yet"
-msgstr ""
+msgstr "Muestras publicadas cuyos informes aún no se han impreso"
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4607,11 +4607,11 @@ msgstr "ID Muestra QC"
 
 #: senaite/core/browser/dashboard/dashboard.py:138
 msgid "Quarterly"
-msgstr ""
+msgstr "Trimestral"
 
 #: senaite/core/browser/dashboard/dashboard.py:128
 msgid "Quick Actions"
-msgstr ""
+msgstr "Acciones rápidas"
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4647,7 +4647,7 @@ msgstr "Disponible"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr ""
+msgstr "Volver a adjuntar"
 
 #: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
@@ -4666,7 +4666,7 @@ msgstr "Recepcionadas"
 
 #: senaite/core/browser/dashboard/dashboard.py:420
 msgid "Received samples with analyses awaiting results"
-msgstr ""
+msgstr "Muestras recibidas con análisis en espera de resultados"
 
 #: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
@@ -4733,7 +4733,7 @@ msgstr "Registro"
 
 #: senaite/core/browser/dashboard/dashboard.py:105
 msgid "Register Samples"
-msgstr ""
+msgstr "Registrar muestras"
 
 #: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
@@ -4842,15 +4842,15 @@ msgstr "Eliminar"
 
 #: senaite/core/browser/samples/view.py:597
 msgid "Remove this analysis from the filter"
-msgstr ""
+msgstr "Quitar este análisis del filtro"
 
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
-msgstr ""
+msgstr "Se eliminaron {} clave(s): {}"
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Rename filter"
-msgstr ""
+msgstr "Cambiar el nombre del filtro"
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
@@ -4928,7 +4928,7 @@ msgstr "Reset"
 
 # senaite.app.listing: Reset-columns button tooltip
 msgid "Reset column visibility and order to the defaults"
-msgstr ""
+msgstr "Restablecer la visibilidad y el orden de las columnas a los valores predeterminados"
 
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
@@ -4936,11 +4936,11 @@ msgstr "Inicializar las columnas"
 
 # senaite.app.listing: Column config — reset link tooltip
 msgid "Reset to default columns and order"
-msgstr ""
+msgstr "Restablecer las columnas y el orden predeterminados"
 
 # senaite.app.listing: Search box — undo / reset-view button tooltip
 msgid "Reset view"
-msgstr ""
+msgstr "Restablecer vista"
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
@@ -5015,7 +5015,7 @@ msgstr "Interpretación de resultados"
 
 #: senaite/core/browser/dashboard/dashboard.py:85
 msgid "Results Pending"
-msgstr ""
+msgstr "Resultados pendientes"
 
 #: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
@@ -5096,7 +5096,7 @@ msgstr "Análisis rutinarios"
 
 #: bika/lims/api/snapshot.py:555
 msgid "Row ${num}"
-msgstr ""
+msgstr "Fila ${num}"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
@@ -5112,7 +5112,7 @@ msgstr "SENAITE Core 1.x (no instalar)"
 
 #: senaite/core/browser/frontpage/templates/frontpage.pt:6
 msgid "SENAITE LIMS"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE LIMS front-page"
@@ -5324,15 +5324,15 @@ msgstr "Las muestras ${sample_ids} fueron invalidadas correctamente."
 
 #: senaite/core/browser/dashboard/dashboard.py:400
 msgid "Samples awaiting collection of the sample"
-msgstr ""
+msgstr "Muestras en espera de la recogida de la muestra"
 
 #: senaite/core/browser/dashboard/dashboard.py:404
 msgid "Samples awaiting preservation"
-msgstr ""
+msgstr "Muestras en espera de conservación"
 
 #: senaite/core/browser/dashboard/dashboard.py:416
 msgid "Samples awaiting reception at the laboratory"
-msgstr ""
+msgstr "Muestras en espera de recepción en el laboratorio"
 
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
@@ -5345,19 +5345,19 @@ msgstr "Formulario de informe de rechazo de muestras"
 
 #: senaite/core/browser/dashboard/dashboard.py:81
 msgid "Samples to Receive"
-msgstr ""
+msgstr "Muestras por recibir"
 
 #: senaite/core/browser/dashboard/dashboard.py:432
 msgid "Samples whose reports have been published"
-msgstr ""
+msgstr "Muestras cuyos informes se han publicado"
 
 #: senaite/core/browser/dashboard/dashboard.py:424
 msgid "Samples whose results are awaiting verification"
-msgstr ""
+msgstr "Muestras cuyos resultados están en espera de verificación"
 
 #: senaite/core/browser/dashboard/dashboard.py:409
 msgid "Samples with a scheduled sampling date"
-msgstr ""
+msgstr "Muestras con una fecha de muestreo programada"
 
 #: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
@@ -5401,11 +5401,11 @@ msgstr "Guardar y copiar"
 # senaite.app.listing: Saved filter presets — footer button to save the
 # current view
 msgid "Save current view"
-msgstr ""
+msgstr "Guardar la vista actual"
 
 # senaite.app.listing: Saved filter presets — toggle title + menu header
 msgid "Saved filters"
-msgstr ""
+msgstr "Filtros guardados"
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5438,11 +5438,11 @@ msgstr "Buscar"
 
 # senaite.app.listing: Column config — search input placeholder
 msgid "Search columns…"
-msgstr ""
+msgstr "Buscar columnas…"
 
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
-msgstr ""
+msgstr "Buscar..."
 
 #: bika/lims/browser/fields/coordinatefield.py:38
 msgid "Seconds"
@@ -5584,11 +5584,11 @@ msgstr "Seleccione para permitir que un Coordinador de Muestreo programe un mues
 
 #: senaite/core/content/senaitesetup.py:1001
 msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
-msgstr ""
+msgstr "Seleccione esta opción para permitir el envío de muestras mediante la transición 'dispatch' y habilitar el estado adicional 'dispatched'. Los análisis de una muestra enviada pasan a ser de solo lectura y se restauran a su estado anterior cuando se restaura la muestra. Deshabilitado de forma predeterminada."
 
 #: senaite/core/content/senaitesetup.py:991
 msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
-msgstr ""
+msgstr "Seleccione esta opción para permitir el desecho de muestras mediante la transición 'dispose' y habilitar el estado adicional 'disposed'. Deshabilitado de forma predeterminada."
 
 #: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
@@ -5740,7 +5740,7 @@ msgstr "Desea añadir el contenido de ejemplo en este sitio?"
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
-msgstr ""
+msgstr "Mostrar campos adicionales"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
@@ -5748,7 +5748,7 @@ msgstr "Mostrar todo"
 
 #: senaite/core/api/remarks.py:486
 msgid "Show history"
-msgstr ""
+msgstr "Mostrar historial"
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
@@ -5768,11 +5768,11 @@ msgstr "Mostrar los campos estándar"
 
 # senaite.app.listing: Column config — plus button tooltip / aria-label
 msgid "Show this column"
-msgstr ""
+msgstr "Mostrar esta columna"
 
 #: senaite/core/browser/dashboard/dashboard.py:129
 msgid "Show/hide timeline"
-msgstr ""
+msgstr "Mostrar/ocultar línea de tiempo"
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5839,11 +5839,11 @@ msgstr "Clave de ordenación"
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort ascending"
-msgstr ""
+msgstr "Ordenar de forma ascendente"
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort descending"
-msgstr ""
+msgstr "Ordenar de forma descendente"
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5915,7 +5915,7 @@ msgstr "Previsualización de etiquetas"
 
 # senaite.app.listing: Saved filter presets — star action tooltip when active
 msgid "Stop auto-applying"
-msgstr ""
+msgstr "Detener la aplicación automática"
 
 #: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
@@ -5959,7 +5959,7 @@ msgstr "Proporcione un archivo Open XML (.XLSX) válido que contenga datos de co
 
 #: senaite/core/browser/dashboard/dashboard.py:490
 msgid "Submitted analyses awaiting verification"
-msgstr ""
+msgstr "Análisis enviados en espera de verificación"
 
 #: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
@@ -6157,7 +6157,7 @@ msgstr "La muestra o muestras siguientes serán enviadas"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:47
 msgid "The following sample(s) will be disposed"
-msgstr ""
+msgstr "Se desechará(n) la(s) siguiente(s) muestra(s)"
 
 #: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
@@ -6206,7 +6206,7 @@ msgstr "Volumen mínimo de muestra necesario para efectuar el análisis (por eje
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:40
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
-msgstr ""
+msgstr "El almacenamiento del generador de números está vacío. Los contadores se inicializan en la primera generación de ID para cada prefijo."
 
 #: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
@@ -6434,11 +6434,11 @@ msgstr "Por muestrear"
 
 #: senaite/core/browser/dashboard/dashboard.py:93
 msgid "To be Published"
-msgstr ""
+msgstr "Por publicar"
 
 #: senaite/core/browser/dashboard/dashboard.py:89
 msgid "To be Verified"
-msgstr ""
+msgstr "Por verificar"
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
@@ -6521,7 +6521,7 @@ msgstr "Escriba para filtrar ..."
 
 # senaite.app.listing: Column-filter row — searchable-select placeholder
 msgid "Type to filter..."
-msgstr ""
+msgstr "Escriba para filtrar..."
 
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
@@ -6582,7 +6582,7 @@ msgstr "Usuario desvinculado"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unlock"
-msgstr ""
+msgstr "Desbloquear"
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6608,11 +6608,11 @@ msgstr "Actualizar ficheros adjuntos"
 
 # senaite.app.listing: Saved filter presets — Update preset action tooltip
 msgid "Update preset with current view"
-msgstr ""
+msgstr "Actualizar el preajuste con la vista actual"
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
-msgstr ""
+msgstr "Se actualizaron {} clave(s): {}"
 
 #: bika/lims/content/labcontact.py:47
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
@@ -6947,7 +6947,7 @@ msgstr "Verificado por"
 
 #: senaite/core/browser/dashboard/dashboard.py:428
 msgid "Verified samples ready to be published"
-msgstr ""
+msgstr "Muestras verificadas listas para publicar"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
@@ -6957,7 +6957,7 @@ msgstr "Verificar"
 
 #: senaite/core/browser/dashboard/dashboard.py:109
 msgid "Verify Results"
-msgstr ""
+msgstr "Verificar resultados"
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6975,11 +6975,11 @@ msgstr "Ver el sitio de SENAITE"
 
 # senaite.app.listing: Column config — visible-section header
 msgid "Visible"
-msgstr ""
+msgstr "Visible"
 
 # senaite.app.listing: Column config — counter title attribute
 msgid "Visible / total columns"
-msgstr ""
+msgstr "Columnas visibles / totales"
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -7016,7 +7016,7 @@ msgstr "Miércoles"
 
 #: senaite/core/browser/dashboard/dashboard.py:136
 msgid "Weekly"
-msgstr ""
+msgstr "Semanal"
 
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
@@ -7024,7 +7024,7 @@ msgstr "Semanas para expirar"
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:7
 msgid "Welcome"
-msgstr ""
+msgstr "Bienvenido"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:14
 msgid "Welcome to SENAITE"
@@ -7100,11 +7100,11 @@ msgstr "Hojas de trabajo"
 
 #: senaite/core/browser/dashboard/dashboard.py:531
 msgid "Worksheets that have been verified"
-msgstr ""
+msgstr "Hojas de trabajo que han sido verificadas"
 
 #: senaite/core/browser/dashboard/dashboard.py:526
 msgid "Worksheets whose results are awaiting verification"
-msgstr ""
+msgstr "Hojas de trabajo cuyos resultados están en espera de verificación"
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -7116,7 +7116,7 @@ msgstr "Longitud de IBAN incorrecta por%s: %s corto por %i"
 
 #: senaite/core/browser/dashboard/dashboard.py:140
 msgid "Yearly"
-msgstr ""
+msgstr "Anual"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -7204,7 +7204,7 @@ msgstr "Debe especificarse un analista."
 
 # senaite.app.listing: Saved filter presets — micro-tag on the default preset
 msgid "auto"
-msgstr ""
+msgstr "automático"
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
@@ -7218,8 +7218,9 @@ msgstr "por"
 #. in '${calc}')"
 #. Default: "keyword '${keyword}' must have column title '${title}' (defined in '${calc}')"
 #: senaite/core/validators/interimfields.py:151
+#, fuzzy
 msgid "calcs_interims_validator_dup_keyword_error"
-msgstr ""
+msgstr "la palabra clave '${keyword}' debe tener el título de columna '${title}' (definido en '${calc}')"
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:57
@@ -7241,33 +7242,34 @@ msgstr "Algunos análisis utilizan instrumentos no calibrados o caducados. Edici
 #. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #. Default: "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #: senaite/core/validators/interimfields.py:211
+#, fuzzy
 msgid "choice_syntax_validation_error"
-msgstr ""
+msgstr "No hay un formato válido en el campo de opciones. El formato admitido es: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #. Default: "Control type is not supported for empty choices"
 #: senaite/core/validators/interimfields.py:111
 msgid "choices_and_restype_validator_no_choices_error"
-msgstr ""
+msgstr "El tipo de control no es compatible con opciones vacías"
 
 #. Default: "Chosen control type not supporting choices"
 #: senaite/core/validators/interimfields.py:117
 msgid "choices_and_restype_validator_not_supported_choices_error"
-msgstr ""
+msgstr "El tipo de control elegido no admite opciones"
 
 #. Default: "Empty keys are not supported"
 #: senaite/core/validators/interimfields.py:169
 msgid "choices_empty_keys_validator_error"
-msgstr ""
+msgstr "Las claves vacías no son compatibles"
 
 #. Default: "At least, two options for choices field are required"
 #: senaite/core/validators/interimfields.py:195
 msgid "choices_min_items_validator_error"
-msgstr ""
+msgstr "Se requieren al menos dos opciones para el campo de opciones"
 
 #. Default: "Duplicate keys in choices field"
 #: senaite/core/validators/interimfields.py:183
 msgid "choices_unique_keys_validator_error"
-msgstr ""
+msgstr "Claves duplicadas en el campo de opciones"
 
 #: bika/lims/content/instrumentcertification.py:250
 msgid "daily"
@@ -7297,9 +7299,10 @@ msgstr "${d}/${m}/${Y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
+#. Default: "yy-mm-dd"
+#, fuzzy
 msgid "date_format_short_datepicker"
-msgstr ""
+msgstr "dd/mm/aa"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "days"
@@ -7312,11 +7315,11 @@ msgstr "desactivar"
 #. Default: "Sample disposed after the retention period."
 #: senaite/core/browser/samples/templates/dispose_samples.pt:66
 msgid "default_dispose_reason"
-msgstr ""
+msgstr "Muestra desechada tras el período de retención."
 
 #: senaite/core/api/remarks.py:485
 msgid "deleted by {user} at {time}"
-msgstr ""
+msgstr "eliminado por {user} el {time}"
 
 #. Default: "Attached labels"
 #: senaite/core/behaviors/label.py:126
@@ -7326,37 +7329,39 @@ msgstr "Etiquetas asignadas a este contenido."
 #. Default: "The accreditation standard that applies, e.g. ISO 17025"
 #: senaite/core/content/laboratory.py:174
 msgid "description_accreditation"
-msgstr ""
+msgstr "La norma de acreditación aplicable, p. ej. ISO 17025"
 
 #. Default: "E.g. SANAS, APLAC, etc."
 #: senaite/core/content/laboratory.py:153
 msgid "description_accreditation_body"
-msgstr ""
+msgstr "P. ej. SANAS, APLAC, etc."
 
 #. and results reports by your accreditation body. Maximum size is 175 x 175
 #. pixels."
 #. Default: "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 #: senaite/core/content/laboratory.py:198
+#, fuzzy
 msgid "description_accreditation_body_logo"
-msgstr ""
+msgstr "Suba el logotipo que su organismo de acreditación le autoriza a usar en su sitio web y en los informes de resultados. El tamaño máximo es de 175 x 175 píxeles."
 
 #. Default: "Web address for the accreditation body"
 #: senaite/core/content/laboratory.py:163
 msgid "description_accreditation_body_url"
-msgstr ""
+msgstr "Dirección web del organismo de acreditación"
 
 #. following fields are available: lab_is_accredited, lab_name, lab_country,
 #. confidence, accreditation_body_name, accreditation_standard,
 #. accreditation_reference"
 #. Default: "Enter the details of your lab's service accreditations here. The following fields are available: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 #: senaite/core/content/laboratory.py:220
+#, fuzzy
 msgid "description_accreditation_page_header"
-msgstr ""
+msgstr "Introduzca aquí los datos de las acreditaciones de servicio de su laboratorio. Están disponibles los siguientes campos: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 
 #. Default: "The reference code issued to the lab by the accreditation body"
 #: senaite/core/content/laboratory.py:186
 msgid "description_accreditation_reference"
-msgstr ""
+msgstr "El código de referencia emitido al laboratorio por el organismo de acreditación"
 
 #. Default: "The category the analysis service belongs to"
 #: bika/lims/content/abstractbaseanalysis.py:533
@@ -7650,8 +7655,9 @@ msgstr "Servicios de análisis que dependen del cálculo."
 #. where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #. Default: "<p>The formula you type here will be dynamically calculated be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators, + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #: senaite/core/content/calculation.py:291
+#, fuzzy
 msgid "description_calculation_formula"
-msgstr ""
+msgstr "<p>La fórmula que escriba aquí se calculará dinámicamente cuando se muestre un análisis que utilice este cálculo.</p><p>Para introducir un cálculo, use los operadores matemáticos estándar, + - * / ( ), y todas las palabras clave disponibles, tanto de otros Servicios de análisis como de los Campos provisionales aquí especificados, como variables. Enciérrelas entre corchetes [ ].</p><p>P. ej., el cálculo de la Dureza total, la suma de los iones de Calcio (ppm) y Magnesio (ppm) en el agua, se introduce como [Ca] + [Mg], donde Ca y Mg son las palabras clave de esos dos Servicios de análisis.</p>"
 
 #. library, you can import it here. E.g. if you want to use the 'floor'
 #. function from the Python 'math' module, you add 'math' to the Module field
@@ -7660,8 +7666,9 @@ msgstr ""
 #. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
+#, fuzzy
 msgid "description_calculation_imports"
-msgstr ""
+msgstr "Si su fórmula necesita una función especial de una biblioteca externa de Python, puede importarla aquí. P. ej., si desea usar la función 'floor' del módulo 'math' de Python, añada 'math' al campo Módulo y 'floor' al campo de función. El equivalente en Python sería 'from math import floor'. En su cálculo podría usar entonces 'floor([Ca] + [Mg])'."
 
 #. should your calculation require them. The field title specified here will
 #. be used as column headers and field descriptors where the interim fields
@@ -7670,21 +7677,24 @@ msgstr ""
 #. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
+#, fuzzy
 msgid "description_calculation_interims"
-msgstr ""
+msgstr "Defina campos provisionales como la masa del recipiente o los factores de dilución, en caso de que su cálculo los requiera. El título del campo aquí especificado se usará como encabezado de columna y descriptor de campo donde se muestren los campos provisionales. Si 'Aplicar de forma amplia' está habilitado, el campo se mostrará en un cuadro de selección en la parte superior de la hoja de trabajo, permitiendo aplicar un valor específico a todos los campos correspondientes de la hoja."
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
 #. Default: "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 #: senaite/core/content/calculation.py:321
+#, fuzzy
 msgid "description_calculation_test_params"
-msgstr ""
+msgstr "Para probar el cálculo, introduzca aquí los valores de todos los parámetros del cálculo. Esto incluye los campos provisionales definidos arriba, así como cualquier servicio del que dependa este cálculo para calcular los resultados."
 
 #. values."
 #. Default: "The result after the calculation has taken place with test values."
 #: senaite/core/content/calculation.py:345
+#, fuzzy
 msgid "description_calculation_test_result"
-msgstr ""
+msgstr "El resultado después de que el cálculo se haya realizado con valores de prueba."
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/analysiscategory.py:62
@@ -7704,7 +7714,7 @@ msgstr "Categorías de análisis que a mostrar cuando el usuario seleccione este
 #. Default: "This value is reported at the bottom of all published results"
 #: senaite/core/content/laboratory.py:127
 msgid "description_confidence_level"
-msgstr ""
+msgstr "Este valor se indica al pie de todos los resultados publicados"
 
 #. Default: "Contacts in CC for new samples"
 #: senaite/core/content/contact.py:155
@@ -7817,25 +7827,27 @@ msgstr "Indique los departamentos del laboratorio a los que pertenece este conta
 #. the default style."
 #. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
 #: senaite/core/content/label.py:72
+#, fuzzy
 msgid "description_label_color"
-msgstr ""
+msgstr "Código de color hexadecimal utilizado para el chip (p. ej. #0d6efd). Déjelo vacío para el estilo predeterminado."
 
 #. labeled content. The cascade runs in the same transaction as the save and
 #. may take a moment on large datasets."
 #. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
 #: senaite/core/content/label.py:45
+#, fuzzy
 msgid "description_label_title"
-msgstr ""
+msgstr "Cambiar el nombre de esta etiqueta reescribe el nombre almacenado en todo el contenido actualmente etiquetado. La cascada se ejecuta en la misma transacción que el guardado y puede tardar un momento en conjuntos de datos grandes."
 
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
-msgstr ""
+msgstr "Marque esta casilla si su laboratorio está acreditado"
 
 #. Default: "The Laboratory's web address"
 #: senaite/core/content/laboratory.py:101
 msgid "description_laboratory_lab_url"
-msgstr ""
+msgstr "La dirección web del laboratorio"
 
 #. Default: "Supervisor of the Lab"
 #: bika/lims/content/laboratory.py:78
@@ -7845,7 +7857,7 @@ msgstr "Seleccione el supervisor o persona encargada del correcto functionamient
 #. Default: "Supervisor of the Lab"
 #: senaite/core/content/laboratory.py:77
 msgid "description_laboratory_supervisor"
-msgstr ""
+msgstr "Supervisor del laboratorio"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/labproduct.py:89
@@ -7863,8 +7875,9 @@ msgstr "Proporcione el IVA en porcentaje que se añade al precio del producto"
 #. show or reorder each viewlet."
 #. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+#, fuzzy
 msgid "description_manage_viewlets"
-msgstr ""
+msgstr "Los gestores de viewlets y sus viewlets se muestran en su lugar, anidados y posicionados tal como aparecen en el sitio. Use los controles para ocultar, mostrar o reordenar cada viewlet."
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
@@ -7896,8 +7909,9 @@ msgstr "Los valores para las muestras de referencia son cero o 'blanco'"
 #. definition."
 #. Default: "Hazard categories that apply to samples of this reference definition."
 #: bika/lims/content/referencedefinition.py:106
+#, fuzzy
 msgid "description_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro que se aplican a las muestras de esta definición de referencia."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: bika/lims/content/referencedefinition.py:91
@@ -7919,8 +7933,9 @@ msgstr "Haga clic sobre las cabeceras de categorías de análisis (con fondo gri
 #. inherit from the reference definition."
 #. Default: "Hazard categories for this reference sample. Leave empty to inherit from the reference definition."
 #: bika/lims/content/referencesample.py:118
+#, fuzzy
 msgid "description_referencesample_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro para esta muestra de referencia. Déjelo vacío para heredar de la definición de referencia."
 
 #. Default: "Select the manufacturer for this sample"
 #: bika/lims/content/referencesample.py:136
@@ -7979,8 +7994,9 @@ msgstr "Enviar automáticamente los análisis al importar"
 #. batch is created in a single transaction (legacy behaviour)."
 #. Default: "When enabled, each sample created from the add form is committed in its own ZODB transaction with a per-sample retry on conflict. This reduces the chance that ID-counter or container contention aborts the whole batch on instances with many concurrent users. When disabled, the whole batch is created in a single transaction (legacy behaviour)."
 #: senaite/core/registry/schema.py:391
+#, fuzzy
 msgid "description_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Cuando está habilitado, cada muestra creada desde el formulario de creación se confirma en su propia transacción de ZODB con un reintento por muestra en caso de conflicto. Esto reduce la posibilidad de que la contención del contador de ID o del contenedor aborte todo el lote en instancias con muchos usuarios concurrentes. Cuando está deshabilitado, todo el lote se crea en una sola transacción (comportamiento heredado)."
 
 #. matching the source sample structure. Each partition will be created with
 #. the same configuration (sample type, container, preservation) and analyses
@@ -8067,7 +8083,7 @@ msgstr "Referencia a la muestra de la que se desvinculó esta partición."
 #. Default: "Reference to the source sample this sample was duplicated from"
 #: bika/lims/content/analysisrequest.py:1283
 msgid "description_sample_duplicated_from"
-msgstr ""
+msgstr "Referencia a la muestra de origen desde la que se duplicó esta muestra"
 
 #. Default: "Generated invoice for this sample"
 #: bika/lims/content/analysisrequest.py:1049
@@ -8262,8 +8278,9 @@ msgstr "El periodo durante el que las muestras sin conservar de este tipo pueden
 #. display the appropriate pictograms in reports and lists."
 #. Default: "Hazard categories that apply to samples of this type. Used to display the appropriate pictograms in reports and lists."
 #: senaite/core/content/sampletype.py:180
+#, fuzzy
 msgid "description_sampletype_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro que se aplican a las muestras de este tipo. Se utilizan para mostrar los pictogramas apropiados en los informes y las listas."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: senaite/core/content/sampletype.py:168
@@ -8503,8 +8520,9 @@ msgstr "Separador decimal preferido para los resultados"
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
 #: senaite/core/content/senaitesetup.py:969
+#, fuzzy
 msgid "description_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Si está habilitado, los usuarios con privilegios suficientes pueden crear una muestra hermana directamente a partir de una existente mediante la acción 'Duplicar' en el listado de muestras. Habilitado de forma predeterminada."
 
 #. Default: "Analyses are required for sample registration"
 #: senaite/core/content/senaitesetup.py:351
@@ -8734,42 +8752,42 @@ msgstr "El duplicado en la posición ${dup} referencia esta posición, por lo qu
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr ""
+msgstr "${days} días"
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr ""
+msgstr "${hours} horas"
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr ""
+msgstr "Días"
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr ""
+msgstr "Horas"
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr ""
+msgstr "Minutos"
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr ""
+msgstr "Segundos"
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr ""
+msgstr "${minutes} minutos"
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr ""
+msgstr "${seconds} segundos"
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
@@ -8778,7 +8796,7 @@ msgstr "Contenido del archivo"
 
 #: senaite/core/api/remarks.py:481
 msgid "edited"
-msgstr ""
+msgstr "editado"
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8820,202 +8838,202 @@ msgstr "Particiones"
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/formula.py:121
 msgid "formula_validation_chain_error"
-msgstr ""
+msgstr "Error interno de la cadena de validación: ${error}"
 
 #. Default: "cryogenic / inert gas"
 #: senaite/core/vocabularies/hazard_categories.py:167
 msgid "hazard_ASPH01_common"
-msgstr ""
+msgstr "criogénico / gas inerte"
 
 #. Default: "Asphyxiating atmosphere"
 #: senaite/core/vocabularies/hazard_categories.py:165
 msgid "hazard_ASPH01_name"
-msgstr ""
+msgstr "Atmósfera asfixiante"
 
 #. Default: "infectious / biological"
 #: senaite/core/vocabularies/hazard_categories.py:104
 msgid "hazard_BIO01_common"
-msgstr ""
+msgstr "infeccioso / biológico"
 
 #. Default: "Biohazard"
 #: senaite/core/vocabularies/hazard_categories.py:103
 msgid "hazard_BIO01_name"
-msgstr ""
+msgstr "Riesgo biológico"
 
 #. Default: "freezing / cold storage"
 #: senaite/core/vocabularies/hazard_categories.py:158
 msgid "hazard_COLD01_common"
-msgstr ""
+msgstr "congelación / almacenamiento en frío"
 
 #. Default: "Low temperature"
 #: senaite/core/vocabularies/hazard_categories.py:157
 msgid "hazard_COLD01_name"
-msgstr ""
+msgstr "Baja temperatura"
 
 #. Default: "electric shock"
 #: senaite/core/vocabularies/hazard_categories.py:132
 msgid "hazard_ELEC01_common"
-msgstr ""
+msgstr "descarga eléctrica"
 
 #. Default: "Electricity"
 #: senaite/core/vocabularies/hazard_categories.py:131
 msgid "hazard_ELEC01_name"
-msgstr ""
+msgstr "Electricidad"
 
 #. Default: "explosive"
 #: senaite/core/vocabularies/hazard_categories.py:48
 msgid "hazard_GHS01_common"
-msgstr ""
+msgstr "explosivo"
 
 #. Default: "Explosive"
 #: senaite/core/vocabularies/hazard_categories.py:47
 msgid "hazard_GHS01_name"
-msgstr ""
+msgstr "Explosivo"
 
 #. Default: "flammable"
 #: senaite/core/vocabularies/hazard_categories.py:54
 msgid "hazard_GHS02_common"
-msgstr ""
+msgstr "inflamable"
 
 #. Default: "Flammable"
 #: senaite/core/vocabularies/hazard_categories.py:53
 msgid "hazard_GHS02_name"
-msgstr ""
+msgstr "Inflamable"
 
 #. Default: "oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:60
 msgid "hazard_GHS03_common"
-msgstr ""
+msgstr "oxidante"
 
 #. Default: "Oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:59
 msgid "hazard_GHS03_name"
-msgstr ""
+msgstr "Oxidante"
 
 #. Default: "pressurised gas"
 #: senaite/core/vocabularies/hazard_categories.py:66
 msgid "hazard_GHS04_common"
-msgstr ""
+msgstr "gas presurizado"
 
 #. Default: "Compressed gas"
 #: senaite/core/vocabularies/hazard_categories.py:65
 msgid "hazard_GHS04_name"
-msgstr ""
+msgstr "Gas comprimido"
 
 #. Default: "acid / caustic"
 #: senaite/core/vocabularies/hazard_categories.py:72
 msgid "hazard_GHS05_common"
-msgstr ""
+msgstr "ácido / cáustico"
 
 #. Default: "Corrosive"
 #: senaite/core/vocabularies/hazard_categories.py:71
 msgid "hazard_GHS05_name"
-msgstr ""
+msgstr "Corrosivo"
 
 #. Default: "poisonous"
 #: senaite/core/vocabularies/hazard_categories.py:78
 msgid "hazard_GHS06_common"
-msgstr ""
+msgstr "venenoso"
 
 #. Default: "Acute toxicity"
 #: senaite/core/vocabularies/hazard_categories.py:77
 msgid "hazard_GHS06_name"
-msgstr ""
+msgstr "Toxicidad aguda"
 
 #. Default: "harmful / irritant"
 #: senaite/core/vocabularies/hazard_categories.py:84
 msgid "hazard_GHS07_common"
-msgstr ""
+msgstr "nocivo / irritante"
 
 #. Default: "Health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:83
 msgid "hazard_GHS07_name"
-msgstr ""
+msgstr "Peligro para la salud"
 
 #. Default: "carcinogenic / mutagenic"
 #: senaite/core/vocabularies/hazard_categories.py:90
 msgid "hazard_GHS08_common"
-msgstr ""
+msgstr "cancerígeno / mutágeno"
 
 #. Default: "Serious health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:89
 msgid "hazard_GHS08_name"
-msgstr ""
+msgstr "Peligro grave para la salud"
 
 #. Default: "environmentally hazardous"
 #: senaite/core/vocabularies/hazard_categories.py:97
 msgid "hazard_GHS09_common"
-msgstr ""
+msgstr "peligroso para el medio ambiente"
 
 #. Default: "Environmental hazard"
 #: senaite/core/vocabularies/hazard_categories.py:96
 msgid "hazard_GHS09_name"
-msgstr ""
+msgstr "Peligro medioambiental"
 
 #. Default: "heated material"
 #: senaite/core/vocabularies/hazard_categories.py:145
 msgid "hazard_HOT01_common"
-msgstr ""
+msgstr "material caliente"
 
 #. Default: "Hot content"
 #: senaite/core/vocabularies/hazard_categories.py:144
 msgid "hazard_HOT01_name"
-msgstr ""
+msgstr "Contenido caliente"
 
 #. Default: "hot to touch"
 #: senaite/core/vocabularies/hazard_categories.py:139
 msgid "hazard_HSURF01_common"
-msgstr ""
+msgstr "caliente al tacto"
 
 #. Default: "Hot surface"
 #: senaite/core/vocabularies/hazard_categories.py:138
 msgid "hazard_HSURF01_name"
-msgstr ""
+msgstr "Superficie caliente"
 
 #. Default: "NMR / MRI"
 #: senaite/core/vocabularies/hazard_categories.py:125
 msgid "hazard_MAG01_common"
-msgstr ""
+msgstr "RMN / RM"
 
 #. Default: "Magnetic field"
 #: senaite/core/vocabularies/hazard_categories.py:124
 msgid "hazard_MAG01_name"
-msgstr ""
+msgstr "Campo magnético"
 
 #. Default: "UV / laser / RF"
 #: senaite/core/vocabularies/hazard_categories.py:118
 msgid "hazard_NIR01_common"
-msgstr ""
+msgstr "UV / láser / RF"
 
 #. Default: "Non-ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:117
 msgid "hazard_NIR01_name"
-msgstr ""
+msgstr "Radiación no ionizante"
 
 #. Default: "ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:112
 msgid "hazard_RAD01_common"
-msgstr ""
+msgstr "radiación ionizante"
 
 #. Default: "Radioactive"
 #: senaite/core/vocabularies/hazard_categories.py:111
 msgid "hazard_RAD01_name"
-msgstr ""
+msgstr "Radiactivo"
 
 #. Default: "autoclave / sterilisation"
 #: senaite/core/vocabularies/hazard_categories.py:151
 msgid "hazard_STEAM01_common"
-msgstr ""
+msgstr "autoclave / esterilización"
 
 #. Default: "Hot steam"
 #: senaite/core/vocabularies/hazard_categories.py:150
 msgid "hazard_STEAM01_name"
-msgstr ""
+msgstr "Vapor caliente"
 
 #. Default: "Hazardous"
 #: senaite/core/api/hazard.py:37
 msgid "hazard_warning_label"
-msgstr ""
+msgstr "Peligroso"
 
 #. Default: "Legacy Setup"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:16
@@ -9049,12 +9067,12 @@ msgstr "horas"
 #. Default: "'${function}' not found in module '${module}'"
 #: senaite/core/validators/imports.py:66
 msgid "importable_function_error"
-msgstr ""
+msgstr "'${function}' no se encontró en el módulo '${module}'"
 
 #. Default: "Could not import module '${module}'"
 #: senaite/core/validators/imports.py:49
 msgid "importable_module_error"
-msgstr ""
+msgstr "No se pudo importar el módulo '${module}'"
 
 #: bika/lims/browser/publish/templates/email.pt:189
 msgid "in"
@@ -9068,27 +9086,27 @@ msgstr "Exportador de instrumento no encontrado"
 #. Default: "Interim field ${row_num}: ${message}"
 #: senaite/core/validators/interimfields.py:299
 msgid "interim_field_error"
-msgstr ""
+msgstr "Campo provisional ${row_num}: ${message}"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/interimfields.py:278
 msgid "interims_validation_chain_error"
-msgstr ""
+msgstr "Error interno de la cadena de validación: ${error}"
 
 #. Default: "'${field_name}' contains invalid characters"
 #: senaite/core/validators/interimfields.py:68
 msgid "invalid_characters_validator_error"
-msgstr ""
+msgstr "'${field_name}' contiene caracteres no válidos"
 
 #. Default: "AnalysesServices not found for keywords: ${keywords}"
 #: senaite/core/validators/formula.py:92
 msgid "invalid_keyword_error"
-msgstr ""
+msgstr "No se encontraron Servicios de análisis para las palabras clave: ${keywords}"
 
 #. Default: "Invalid wildcards found: ${wildcards}"
 #: senaite/core/validators/formula.py:71
 msgid "invalid_wildcards_check_error"
-msgstr ""
+msgstr "Se encontraron comodines no válidos: ${wildcards}"
 
 #. Default: "Labels"
 #: senaite/core/behaviors/label.py:125
@@ -9324,7 +9342,7 @@ msgstr "No permitir el registro de muestras sin análisis"
 #. Default: "DependentServices"
 #: senaite/core/content/calculation.py:352
 msgid "label_calculation_dependent_services"
-msgstr ""
+msgstr "Servicios dependientes"
 
 #. Default: "Dependent services"
 #: bika/lims/content/calculation.py:81
@@ -9334,52 +9352,52 @@ msgstr "Servicios dependientes"
 #. Default: "Calculation Formula"
 #: senaite/core/content/calculation.py:287
 msgid "label_calculation_formula"
-msgstr ""
+msgstr "Fórmula de cálculo"
 
 #. Default: "Function"
 #: senaite/core/content/calculation.py:185
 msgid "label_calculation_import_function_name"
-msgstr ""
+msgstr "Función"
 
 #. Default: "Module"
 #: senaite/core/content/calculation.py:179
 msgid "label_calculation_import_module_name"
-msgstr ""
+msgstr "Módulo"
 
 #. Default: "Additional Python Libraries"
 #: senaite/core/content/calculation.py:266
 msgid "label_calculation_imports"
-msgstr ""
+msgstr "Bibliotecas de Python adicionales"
 
 #. Default: "Calculation Interim Fields"
 #: senaite/core/content/calculation.py:243
 msgid "label_calculation_interims"
-msgstr ""
+msgstr "Campos provisionales del cálculo"
 
 #. Default: "Raw Test Result"
 #: senaite/core/content/calculation.py:336
 msgid "label_calculation_raw_test_keywords"
-msgstr ""
+msgstr "Resultado de prueba sin procesar"
 
 #. Default: "Keyword"
 #: senaite/core/content/calculation.py:198
 msgid "label_calculation_test_param_keyword"
-msgstr ""
+msgstr "Palabra clave"
 
 #. Default: "Value"
 #: senaite/core/content/calculation.py:207
 msgid "label_calculation_test_param_value"
-msgstr ""
+msgstr "Valor"
 
 #. Default: "Test Parameters"
 #: senaite/core/content/calculation.py:317
 msgid "label_calculation_test_params"
-msgstr ""
+msgstr "Parámetros de prueba"
 
 #. Default: "Test Result"
 #: senaite/core/content/calculation.py:343
 msgid "label_calculation_test_result"
-msgstr ""
+msgstr "Resultado de prueba"
 
 #. Default: "Department"
 #: bika/lims/content/analysiscategory.py:59
@@ -9511,52 +9529,52 @@ msgstr "Realizada por"
 #. Default: "Allow empty"
 #: senaite/core/schema/interimfields.py:87
 msgid "label_interim_allow_empty"
-msgstr ""
+msgstr "Permitir vacío"
 
 #. Default: "Apply wide"
 #: senaite/core/schema/interimfields.py:127
 msgid "label_interim_apply_wide"
-msgstr ""
+msgstr "Aplicar de forma amplia"
 
 #. Default: "Choices"
 #: senaite/core/schema/interimfields.py:67
 msgid "label_interim_choices"
-msgstr ""
+msgstr "Opciones"
 
 #. Default: "Default value"
 #: senaite/core/schema/interimfields.py:57
 msgid "label_interim_default_value"
-msgstr ""
+msgstr "Valor predeterminado"
 
 #. Default: "Hidden"
 #: senaite/core/schema/interimfields.py:117
 msgid "label_interim_hidden"
-msgstr ""
+msgstr "Oculto"
 
 #. Default: "Keyword"
 #: senaite/core/schema/interimfields.py:37
 msgid "label_interim_keyword"
-msgstr ""
+msgstr "Palabra clave"
 
 #. Default: "Report"
 #: senaite/core/schema/interimfields.py:107
 msgid "label_interim_report"
-msgstr ""
+msgstr "Informe"
 
 #. Default: "Result type"
 #: senaite/core/schema/interimfields.py:76
 msgid "label_interim_result_type"
-msgstr ""
+msgstr "Tipo de resultado"
 
 #. Default: "Field title"
 #: senaite/core/schema/interimfields.py:47
 msgid "label_interim_title"
-msgstr ""
+msgstr "Título del campo"
 
 #. Default: "Unit"
 #: senaite/core/schema/interimfields.py:97
 msgid "label_interim_unit"
-msgstr ""
+msgstr "Unidad"
 
 #. Default: "Default Department"
 #: bika/lims/content/labcontact.py:86
@@ -9711,7 +9729,7 @@ msgstr "Blanco"
 #. Default: "Hazard categories"
 #: bika/lims/content/referencedefinition.py:104
 msgid "label_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro"
 
 #. Default: "Hazardous"
 #: bika/lims/content/referencedefinition.py:89
@@ -9726,7 +9744,7 @@ msgstr "Valores de referencia"
 #. Default: "Hazard categories"
 #: bika/lims/content/referencesample.py:116
 msgid "label_referencesample_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/referencesample.py:133
@@ -9791,7 +9809,7 @@ msgstr "Permitir pegado múltiple"
 #. Default: "Commit each sample in its own transaction"
 #: senaite/core/registry/schema.py:387
 msgid "label_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Confirmar cada muestra en su propia transacción"
 
 #. Default: "Copy sample structure with partitions"
 #: senaite/core/registry/schema.py:324
@@ -9871,7 +9889,7 @@ msgstr "Muestra original"
 #. Default: "Duplicated from sample"
 #: bika/lims/content/analysisrequest.py:1280
 msgid "label_sample_duplicated_from"
-msgstr ""
+msgstr "Duplicada de la muestra"
 
 #. Default: "Invoice"
 #: bika/lims/content/analysisrequest.py:1046
@@ -10117,18 +10135,19 @@ msgstr "Método"
 #. Default: "Added ${count} label(s) to ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:185
 msgid "labels_added"
-msgstr ""
+msgstr "Se añadieron ${count} etiqueta(s) a ${affected} muestra(s)"
 
 #. sample(s)"
 #. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:174
+#, fuzzy
 msgid "labels_changed"
-msgstr ""
+msgstr "Se aplicaron ${added} añadida(s) y ${removed} quitada(s) en ${affected} muestra(s)"
 
 #. Default: "Removed ${count} label(s) from ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:194
 msgid "labels_removed"
-msgstr ""
+msgstr "Se quitaron ${count} etiqueta(s) de ${affected} muestra(s)"
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
@@ -10383,42 +10402,42 @@ msgstr "Etiquetas de lote"
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/calculations/view.py:51
 msgid "listing_calculation_action_add"
-msgstr ""
+msgstr "Añadir"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/calculations/view.py:75
 msgid "listing_calculation_description"
-msgstr ""
+msgstr "Descripción"
 
 #. Default: "Formula"
 #: senaite/core/browser/controlpanel/calculations/view.py:82
 msgid "listing_calculation_formula"
-msgstr ""
+msgstr "Fórmula"
 
 #. Default: "Calculation"
 #: senaite/core/browser/controlpanel/calculations/view.py:68
 msgid "listing_calculation_title"
-msgstr ""
+msgstr "Cálculo"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/calculations/view.py:93
 msgid "listing_calculations_state_active"
-msgstr ""
+msgstr "Activo"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/calculations/view.py:111
 msgid "listing_calculations_state_all"
-msgstr ""
+msgstr "Todos"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/calculations/view.py:102
 msgid "listing_calculations_state_inactive"
-msgstr ""
+msgstr "Inactivo"
 
 #. Default: "Calculations"
 #: senaite/core/browser/controlpanel/calculations/view.py:58
 msgid "listing_calculations_title"
-msgstr ""
+msgstr "Cálculos"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/containertypes/view.py:51
@@ -11440,7 +11459,7 @@ msgstr "minutos"
 # senaite.app.listing: Saved filter presets — dirty indicator on the applied
 # preset
 msgid "modified"
-msgstr ""
+msgstr "modificado"
 
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
@@ -11464,22 +11483,22 @@ msgstr "El instrumento no tiene ninguna interfaz de datos seleccionada"
 #. Default: "Keyword '${duplicate}' duplicate found for a Analysis Service"
 #: senaite/core/validators/interimfields.py:97
 msgid "no_dup_service_keyword_validator_error"
-msgstr ""
+msgstr "Se encontró la palabra clave duplicada '${duplicate}' para un Servicio de análisis"
 
 #. Default: "'${duplicate}' duplicates found"
 #: senaite/core/validators/interimfields.py:83
 msgid "no_dups_values_validator_error"
-msgstr ""
+msgstr "Se encontraron duplicados de '${duplicate}'"
 
 #. Default: "Wildcards for  are not allowed: ${wildcards}"
 #: senaite/core/validators/formula.py:45
 msgid "no_wildcards__error"
-msgstr ""
+msgstr "No se permiten comodines para : ${wildcards}"
 
 #. Default: "'${field_name}' is required"
 #: senaite/core/validators/interimfields.py:54
 msgid "non_blank_validator_error"
-msgstr ""
+msgstr "'${field_name}' es obligatorio"
 
 #. view."
 #. Default: "Layout view '${view}' not found. Set '${default}' as layout view."
@@ -11499,7 +11518,7 @@ msgstr "de"
 
 #: senaite/core/api/remarks.py:494
 msgid "original"
-msgstr ""
+msgstr "original"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
@@ -11507,7 +11526,7 @@ msgstr "Resumen"
 
 # senaite.app.listing: Saved filter presets — menu subtitle
 msgid "per listing"
-msgstr ""
+msgstr "por listado"
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11589,7 +11608,7 @@ msgstr "Esta muestra ha sido enviada el ${date} por ${actor} "
 #. Default: "This sample has been disposed by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
 msgid "this_sample_has_been_disposed_by"
-msgstr ""
+msgstr "Esta muestra ha sido desechada por ${actor} el ${date}"
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11605,32 +11624,32 @@ msgstr "${H}:${M}"
 #. Default: "Accreditation"
 #: senaite/core/content/laboratory.py:170
 msgid "title_accreditation"
-msgstr ""
+msgstr "Acreditación"
 
 #. Default: "Accreditation Body Abbreviation"
 #: senaite/core/content/laboratory.py:149
 msgid "title_accreditation_body"
-msgstr ""
+msgstr "Abreviatura del organismo de acreditación"
 
 #. Default: "Accreditation Logo"
 #: senaite/core/content/laboratory.py:195
 msgid "title_accreditation_body_logo"
-msgstr ""
+msgstr "Logotipo de acreditación"
 
 #. Default: "Accreditation Body URL"
 #: senaite/core/content/laboratory.py:160
 msgid "title_accreditation_body_url"
-msgstr ""
+msgstr "URL del organismo de acreditación"
 
 #. Default: "Accreditation page header"
 #: senaite/core/content/laboratory.py:216
 msgid "title_accreditation_page_header"
-msgstr ""
+msgstr "Encabezado de la página de acreditación"
 
 #. Default: "Accreditation Reference"
 #: senaite/core/content/laboratory.py:182
 msgid "title_accreditation_reference"
-msgstr ""
+msgstr "Referencia de acreditación"
 
 #. Default: "Address"
 #: senaite/core/content/laboratory.py:88
@@ -11736,17 +11755,17 @@ msgstr "Este sitio fue construido usando el CMS/WCM de código abierto Plone."
 #. Default: "Description"
 #: senaite/core/content/calculation.py:228
 msgid "title_calculation_description"
-msgstr ""
+msgstr "Descripción"
 
 #. Default: "Name"
 #: senaite/core/content/calculation.py:220
 msgid "title_calculation_title"
-msgstr ""
+msgstr "Nombre"
 
 #. Default: "Confidence Level %"
 #: senaite/core/content/laboratory.py:123
 msgid "title_confidence_level"
-msgstr ""
+msgstr "Nivel de confianza %"
 
 #. Default: "Description"
 #: senaite/core/content/containertype.py:44
@@ -11826,7 +11845,7 @@ msgstr "Responsable"
 #. Default: "Color"
 #: senaite/core/content/label.py:68
 msgid "title_label_color"
-msgstr ""
+msgstr "Color"
 
 #. Default: "Description"
 #: senaite/core/content/label.py:56
@@ -11841,12 +11860,12 @@ msgstr "Nombre"
 #. Default: "Laboratory Accredited"
 #: senaite/core/content/laboratory.py:136
 msgid "title_laboratory_accredited"
-msgstr ""
+msgstr "Laboratorio acreditado"
 
 #. Default: "Lab URL"
 #: senaite/core/content/laboratory.py:98
 msgid "title_laboratory_lab_url"
-msgstr ""
+msgstr "URL del laboratorio"
 
 #. Default: "Description"
 #: senaite/core/content/labproduct.py:60
@@ -11926,7 +11945,7 @@ msgstr "Tipo de análisis"
 #. Default: "Manage Viewlets"
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
 msgid "title_manage_viewlets"
-msgstr ""
+msgstr "Gestionar viewlets"
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
@@ -12143,7 +12162,7 @@ msgstr "Periodo de conservación"
 #. Default: "Hazard categories"
 #: senaite/core/content/sampletype.py:178
 msgid "title_sampletype_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro"
 
 #. Default: "Hazardous"
 #: senaite/core/content/sampletype.py:166
@@ -12313,7 +12332,7 @@ msgstr "Separador decimal por defecto"
 #. Default: "Allow sample duplication"
 #: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Permitir la duplicación de muestras"
 
 #. Default: "Require sample analyses"
 #: senaite/core/content/senaitesetup.py:349

--- a/src/senaite/core/locales/es/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es/LC_MESSAGES/senaite.core.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Spanish (https://app.transifex.com/senaite/teams/87045/es/)\n"
@@ -131,7 +131,7 @@ msgstr "±"
 
 # senaite.app.listing: Column-filter row — boolean select placeholder
 msgid "-- Select --"
-msgstr "-- Seleccionar --"
+msgstr ""
 
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
@@ -152,7 +152,7 @@ msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Bienvenido a SENAITE"
 
 #: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
-msgstr "<p>El servidor de ID proporciona ID secuenciales únicos para objetos como Muestras y Hojas de trabajo, etc., basándose en un formato especificado para cada tipo de contenido. El formato se construye de forma similar a la sintaxis de formato de Python, p. ej. <code>WS-{seq:03d}</code> produce <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code>, etc.</p><p>Los valores actuales de los contadores persistentes se gestionan en la <a href='ng'>vista del Generador de números</a>.</p><details class='id-server-cheatsheet'><summary>Variables disponibles</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Descripción</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Número de secuencia numérico, opcionalmente rellenado con ceros.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Contador alfanumérico, p. ej. <code>{alpha:2a3d}</code> genera AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Año actual de dos dígitos (p. ej. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Fecha actual como <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>ID de cliente (solo muestras).</td></tr><tr><td><code>{sampleType}</code></td><td>Prefijo del tipo de muestra.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Fechas de muestra (se aplican las especificaciones de <code>strftime</code> de Python).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>Para particiones/reanálisis/secundarias: el ID de la muestra principal.</td></tr><tr><td><code>{partition_count}</code></td><td>Contador de particiones por principal.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Contadores de reanálisis, secundarias y total de análisis.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Campos de configuración</summary><ul><li><strong>Formato</strong>: la plantilla de ID.</li><li><strong>Tipo de secuencia</strong>: <code>generated</code> usa el contador de números persistente; <code>counter</code> usa el recuento de objetos relacionados.</li><li><strong>Contexto</strong>: solo lo usa el tipo <code>counter</code>; el contexto con nombre al que se aplica el contador.</li><li><strong>Tipo de contador</strong>: <code>backreference</code> (obsoleto) o <code>contained</code>.</li><li><strong>Referencia del contador</strong>: nombre de la relación (backreference) o metatipo (contained).</li><li><strong>Prefijo</strong>: prefijo predeterminado si no hay ninguno en el formato.</li><li><strong>Longitud de división</strong>: cuántos segmentos del formato se convierten en el prefijo de la clave de almacenamiento. Determina cómo se particiona el contador (p. ej. por año, por tipo de muestra).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
+msgstr ""
 
 #: bika/lims/content/calculation.py:133
 msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
@@ -297,7 +297,7 @@ msgstr "Añadir muestras"
 
 #: senaite/core/api/remarks.py:492
 msgid "Add a remark..."
-msgstr "Añadir un comentario..."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
@@ -322,7 +322,7 @@ msgstr "Añadir uno o más archivos adjuntos con información adicional sobre la
 
 #: senaite/core/browser/samples/view.py:879
 msgid "Add or remove labels on the selected samples"
-msgstr "Añadir o quitar etiquetas en las muestras seleccionadas"
+msgstr ""
 
 #: senaite/core/api/remarks.py:477
 msgid "Add remarks"
@@ -394,7 +394,7 @@ msgstr "Todos los análisis asignados"
 
 # senaite.app.listing: Column config — empty state when no columns are visible
 msgid "All columns are hidden."
-msgstr "Todas las columnas están ocultas."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
@@ -402,7 +402,7 @@ msgstr "Permitir ingreso manual de límite de detección"
 
 #: bika/lims/content/abstractbaseanalysis.py:728
 msgid "Allow Manual Entry"
-msgstr "Permitir entrada manual"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -461,15 +461,15 @@ msgstr "Análisis"
 
 #: senaite/core/browser/dashboard/dashboard.py:485
 msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr "Análisis asignados a una hoja de trabajo, en espera de resultados"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:498
 msgid "Analyses included in a published report"
-msgstr "Análisis incluidos en un informe publicado"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:480
 msgid "Analyses not yet assigned to a worksheet"
-msgstr "Análisis aún no asignados a una hoja de trabajo"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
@@ -477,7 +477,7 @@ msgstr "Análisis solicitados"
 
 #: senaite/core/browser/dashboard/dashboard.py:494
 msgid "Analyses that have been verified"
-msgstr "Análisis que han sido verificados"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -597,7 +597,7 @@ msgstr "Aplicar plantilla"
 
 # senaite.app.listing: Saved filter presets — apply button tooltip
 msgid "Apply this filter"
-msgstr "Aplicar este filtro"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -723,7 +723,7 @@ msgstr "Registro de importaciones automáticas"
 
 # senaite.app.listing: Saved filter presets — star action tooltip
 msgid "Auto-apply on open"
-msgstr "Aplicar automáticamente al abrir"
+msgstr ""
 
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
@@ -828,7 +828,7 @@ msgstr "Retraso"
 
 #: senaite/core/browser/dashboard/dashboard.py:139
 msgid "Biannual"
-msgstr "Semestral"
+msgstr ""
 
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
@@ -890,7 +890,7 @@ msgstr "CBID"
 
 #: bika/lims/content/client.py:133
 msgid "CC Contacts"
-msgstr "Contactos en CC"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
 #: bika/lims/content/client.py:166
@@ -1131,12 +1131,12 @@ msgstr "Clásico"
 
 # senaite.app.listing: Column-filter row — clear button tooltip
 msgid "Clear filter"
-msgstr "Borrar filtro"
+msgstr ""
 
 # senaite.app.listing: Search box — undo button tooltip when only clearing
 # search
 msgid "Clear search"
-msgstr "Borrar búsqueda"
+msgstr ""
 
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
@@ -1149,7 +1149,7 @@ msgstr "Haga clic para desplegar esta categoría"
 # senaite.app.listing: Saved filter presets — release button tooltip on the
 # applied preset
 msgid "Click to release this filter"
-msgstr "Haga clic para liberar este filtro"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
@@ -1278,7 +1278,7 @@ msgstr "Falta la columna '{}'"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
 msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
-msgstr "La columna {} de la fila de encabezado no tiene nombre. Elimine las columnas vacías de la hoja de cálculo y súbala de nuevo."
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
@@ -1332,7 +1332,7 @@ msgstr "La configuración se ha restaurado a los valores por defecto."
 
 # senaite.app.listing: Column config — trigger button label
 msgid "Configure"
-msgstr "Configurar"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
@@ -1443,15 +1443,15 @@ msgstr "Copiar a nuevo"
 
 #: senaite/core/browser/idserver/view.py:131
 msgid "Could not convert {} value(s) to integer: {}"
-msgstr "No se pudieron convertir {} valor(es) a entero: {}"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
-msgstr "No se pudieron crear la(s) siguiente(s) muestra(s) debido a conflictos de transacción, vuelva a intentarlo: ${rows}"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:228
 msgid "Could not link User: ${error}"
-msgstr "No se pudo vincular el usuario: ${error}"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
@@ -1467,7 +1467,7 @@ msgstr "No ha sido posible transicionar las muestras al estado muestreado"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:103
 msgid "Counter <span class=\"sort-indicator\" />"
-msgstr "Contador <span class=\"sort-indicator\" />"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
@@ -1555,7 +1555,7 @@ msgstr "En curso"
 
 # senaite.app.listing: Saved filter presets — dirty tag hover tooltip
 msgid "Current view differs from saved"
-msgstr "La vista actual difiere de la guardada"
+msgstr ""
 
 #: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
@@ -1567,7 +1567,7 @@ msgstr "Límite de Detección"
 
 #: senaite/core/browser/dashboard/dashboard.py:135
 msgid "Daily"
-msgstr "Diario"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1717,7 +1717,7 @@ msgstr "Separador decimal a utilizar en los informes de este Cliente."
 
 #: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
-msgstr "Contactos en CC predeterminados para las muestras nuevas. Si se establecen, estos contactos se seleccionan automáticamente en el formulario de creación de muestras."
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:165
 msgid "Default Container"
@@ -1876,11 +1876,11 @@ msgstr "Eliminar"
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Delete filter"
-msgstr "Eliminar filtro"
+msgstr ""
 
 #: senaite/core/api/remarks.py:484
 msgid "Delete this remark?"
-msgstr "¿Eliminar este comentario?"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
@@ -1959,7 +1959,7 @@ msgstr "No permitir la verificación múltiple por un mismo usuario"
 
 # senaite.app.listing: Saved filter presets — Revert action tooltip
 msgid "Discard edits and restore preset"
-msgstr "Descartar los cambios y restaurar el preajuste"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
@@ -2016,7 +2016,7 @@ msgstr "Eliminar"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:15
 msgid "Dispose samples"
-msgstr "Desechar muestras"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
@@ -2092,7 +2092,7 @@ msgstr "Descargar los informes seleccionados"
 
 # senaite.app.listing: Column config — drag handle tooltip / aria-label
 msgid "Drag to reorder"
-msgstr "Arrastre para reordenar"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:327
 msgid "Due"
@@ -2117,7 +2117,7 @@ msgstr "Análisis duplicado"
 
 #: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
-msgstr "Formato de ID duplicado para el tipo de portal '${pt}' (filas ${a} y ${b}). Solo se usa la primera fila; elimine o combine el duplicado."
+msgstr ""
 
 #: bika/lims/content/worksheettemplate.py:59
 msgid "Duplicate Of"
@@ -2129,7 +2129,7 @@ msgstr "Análisis de muestras duplicadas de QC"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr "Duplicar muestra"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
@@ -2141,7 +2141,7 @@ msgstr "Claves duplicadas en el campo de opciones"
 
 #: bika/lims/browser/workflow/analysisrequest.py:443
 msgid "Duplicated samples: {}"
-msgstr "Muestras duplicadas: {}"
+msgstr ""
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpec.xml
 msgid "Dynamic Analysis Specification"
@@ -2247,7 +2247,7 @@ msgstr "El correo electrónico se ha enviado"
 
 #: bika/lims/api/snapshot.py:585
 msgid "Empty"
-msgstr "Vacío"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2291,11 +2291,11 @@ msgstr "Activar la funcionalidad de seguimiento de impresión de informes de res
 
 #: senaite/core/content/senaitesetup.py:1000
 msgid "Enable the Sample Dispatch workflow"
-msgstr "Habilitar el flujo de trabajo de envío de muestras"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:990
 msgid "Enable the Sample Dispose workflow"
-msgstr "Habilitar el flujo de trabajo de desecho de muestras"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2532,19 +2532,19 @@ msgstr "Filtro por servicios de plantilla"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
-msgstr "Filtrar claves (compatible con regex)"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — inline editor placeholder
 msgid "Filter name"
-msgstr "Nombre del filtro"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:601
 msgid "Filter samples by this analysis"
-msgstr "Filtrar muestras por este análisis"
+msgstr ""
 
 # senaite.app.listing: Column-filter row — text-input placeholder
 msgid "Filter..."
-msgstr "Filtrar..."
+msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
@@ -2589,7 +2589,7 @@ msgstr "Desde"
 
 #: senaite/core/browser/dashboard/dashboard.py:134
 msgid "From ${from} to ${to} (updated every 2 hours)"
-msgstr "De ${from} a ${to} (actualizado cada 2 horas)"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
@@ -2667,19 +2667,19 @@ msgstr "Oculto del informe"
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
-msgstr "Ocultar campos adicionales"
+msgstr ""
 
 # senaite.app.listing: Column config — bulk action button
 msgid "Hide all"
-msgstr "Ocultar todo"
+msgstr ""
 
 #: senaite/core/api/remarks.py:487
 msgid "Hide history"
-msgstr "Ocultar historial"
+msgstr ""
 
 # senaite.app.listing: Column config — eye-slash button tooltip / aria-label
 msgid "Hide this column"
-msgstr "Ocultar esta columna"
+msgstr ""
 
 #: bika/lims/config.py:140
 msgid "High"
@@ -2708,7 +2708,7 @@ msgstr "Servidor de ID"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:17
 msgid "ID Server Settings"
-msgstr "Configuración del servidor de ID"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
@@ -2716,7 +2716,7 @@ msgstr "Valores del servidor de IDs"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:113
 msgid "ID Template <span class=\"sort-indicator\" />"
-msgstr "Plantilla de ID <span class=\"sort-indicator\" />"
+msgstr ""
 
 #: bika/lims/content/samplepoint.py:84
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
@@ -3047,7 +3047,7 @@ msgstr "Invalidadas"
 
 #: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
-msgstr "Formato de ID no válido en la fila ${i} ('${pt}'): ${err}"
+msgstr ""
 
 #: senaite/core/content/person.py:236
 msgid "Invalid email address"
@@ -3138,7 +3138,7 @@ msgstr "Clave"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:98
 msgid "Key <span class=\"sort-indicator\" />"
-msgstr "Clave <span class=\"sort-indicator\" />"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
@@ -3161,7 +3161,7 @@ msgstr "Palabras clave"
 
 #: senaite/core/browser/samples/view.py:249
 msgid "Keywords of the analyses contained in the sample"
-msgstr "Palabras clave de los análisis contenidos en la muestra"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3347,11 +3347,11 @@ msgstr "Documento de la certificación"
 
 # senaite.core: Sidebar loading state
 msgid "Loading navigation..."
-msgstr "Cargando navegación..."
+msgstr ""
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
-msgstr "Cargando..."
+msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:79
 #: senaite/core/browser/controlpanel/contacts/view.py:70
@@ -3380,11 +3380,11 @@ msgstr "Ubicación donde se archiva el conjunto de documentos"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Lock"
-msgstr "Bloquear"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Locked"
-msgstr "Bloqueado"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3454,7 +3454,7 @@ msgstr "Configurar los campos del formulario"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:12
 msgid "Manage Number Generator"
-msgstr "Gestionar el generador de números"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:21
 msgid "Manage Partitions"
@@ -3474,7 +3474,7 @@ msgstr "Administrar usuario vinculado"
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
-msgstr "Gestionar campos de muestra"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:38
 msgid "Manage the order and visibility of the fields displayed in analysis request add forms."
@@ -3684,7 +3684,7 @@ msgstr "Lunes"
 
 #: senaite/core/browser/dashboard/dashboard.py:137
 msgid "Monthly"
-msgstr "Mensual"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
@@ -3741,7 +3741,7 @@ msgstr "Mi Perfil"
 
 # senaite.app.listing: Saved filter presets — default name when saving
 msgid "My filter"
-msgstr "Mi filtro"
+msgstr ""
 
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
@@ -3763,11 +3763,11 @@ msgstr "Los nuevos rangos no se aplicarán ni a los análisis nuevos ni a los ac
 
 #: senaite/core/api/remarks.py:490
 msgid "Newest first"
-msgstr "Más recientes primero"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
-msgstr "Siguiente ID <span class=\"sort-indicator\" />"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:168
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -3809,7 +3809,7 @@ msgstr "No hay ninguna acción definida"
 
 #: senaite/core/browser/dashboard/dashboard.py:131
 msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
-msgstr "No hay acciones disponibles. Póngase en contacto con el responsable de su laboratorio para que le asigne permisos."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3846,7 +3846,7 @@ msgstr "No ha seleccionado ningún servicio de análisis."
 
 #: senaite/core/browser/idserver/view.py:135
 msgid "No changes"
-msgstr "Sin cambios"
+msgstr ""
 
 #: senaite/core/browser/workflow/worksheet.py:50
 msgid "No changes made"
@@ -3859,7 +3859,7 @@ msgstr "Sin cambios."
 
 #: senaite/core/browser/dashboard/dashboard.py:130
 msgid "No data for the selected period"
-msgstr "No hay datos para el período seleccionado"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
@@ -3867,7 +3867,7 @@ msgstr "No se ha indicado fecha"
 
 #: bika/lims/browser/workflow/analysisrequest.py:435
 msgid "No duplicate created"
-msgstr "No se creó ningún duplicado"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:135
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:138
@@ -3908,12 +3908,12 @@ msgstr "No ha seleccionado ningún elemento."
 # senaite.app.listing: Column config — empty state for hidden section with
 # search
 msgid "No matches in hidden columns."
-msgstr "No hay coincidencias en las columnas ocultas."
+msgstr ""
 
 # senaite.app.listing: Column config — empty state for visible section with
 # search
 msgid "No matches in visible columns."
-msgstr "No hay coincidencias en las columnas visibles."
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
@@ -3925,7 +3925,7 @@ msgstr "No se ha creado ninguna partición"
 
 #: senaite/core/api/remarks.py:493
 msgid "No remarks yet"
-msgstr "Aún no hay comentarios"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3945,7 +3945,7 @@ msgstr "Sin flujo de trabajo de muestreo"
 
 # senaite.app.listing: Saved filter presets — empty state
 msgid "No saved filters yet."
-msgstr "Aún no hay filtros guardados."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -4065,7 +4065,7 @@ msgstr "Numérico"
 
 #: senaite/core/api/remarks.py:491
 msgid "Oldest first"
-msgstr "Más antiguos primero"
+msgstr ""
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -4111,7 +4111,7 @@ msgstr "Open Source Web based Laboratory Information Management System"
 
 #: senaite/core/browser/dashboard/dashboard.py:97
 msgid "Open Worksheets"
-msgstr "Hojas de trabajo abiertas"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
@@ -4119,7 +4119,7 @@ msgstr "Abra el formulario de correo electrónico para enviar los informes selec
 
 #: senaite/core/browser/dashboard/dashboard.py:522
 msgid "Open worksheets with analyses awaiting results"
-msgstr "Hojas de trabajo abiertas con análisis en espera de resultados"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -4204,7 +4204,7 @@ msgstr "% de error permitido"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:23
 msgid "Persistent counters used by the ID Server. Adjust a counter to change the next ID that will be issued for the matching prefix. Setting a counter to 0 removes the entry from the storage."
-msgstr "Contadores persistentes utilizados por el servidor de ID. Ajuste un contador para cambiar el siguiente ID que se emitirá para el prefijo coincidente. Establecer un contador en 0 elimina la entrada del almacenamiento."
+msgstr ""
 
 #: bika/lims/browser/clientfolder.py:81
 #: bika/lims/browser/templates/batch_publish.pt:68
@@ -4308,7 +4308,7 @@ msgstr "Por favor escriba un comentario indicando donde se envían las muestras"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:73
 msgid "Please write a comment where the listed sample(s) are disposed"
-msgstr "Escriba un comentario indicando dónde se desecha(n) la(s) muestra(s) listada(s)"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
@@ -4560,7 +4560,7 @@ msgstr "Publicar"
 
 #: senaite/core/browser/dashboard/dashboard.py:112
 msgid "Publish Reports"
-msgstr "Publicar informes"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:150
 #: senaite/core/browser/samples/view.py:369
@@ -4582,7 +4582,7 @@ msgstr "Resultados publicados"
 
 #: senaite/core/browser/dashboard/dashboard.py:448
 msgid "Published samples whose reports have not been printed yet"
-msgstr "Muestras publicadas cuyos informes aún no se han impreso"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4607,11 +4607,11 @@ msgstr "ID Muestra QC"
 
 #: senaite/core/browser/dashboard/dashboard.py:138
 msgid "Quarterly"
-msgstr "Trimestral"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:128
 msgid "Quick Actions"
-msgstr "Acciones rápidas"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4647,7 +4647,7 @@ msgstr "Disponible"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr "Volver a adjuntar"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
@@ -4666,7 +4666,7 @@ msgstr "Recepcionadas"
 
 #: senaite/core/browser/dashboard/dashboard.py:420
 msgid "Received samples with analyses awaiting results"
-msgstr "Muestras recibidas con análisis en espera de resultados"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
@@ -4733,7 +4733,7 @@ msgstr "Registro"
 
 #: senaite/core/browser/dashboard/dashboard.py:105
 msgid "Register Samples"
-msgstr "Registrar muestras"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
@@ -4842,15 +4842,15 @@ msgstr "Eliminar"
 
 #: senaite/core/browser/samples/view.py:597
 msgid "Remove this analysis from the filter"
-msgstr "Quitar este análisis del filtro"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
-msgstr "Se eliminaron {} clave(s): {}"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Rename filter"
-msgstr "Cambiar el nombre del filtro"
+msgstr ""
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
@@ -4928,7 +4928,7 @@ msgstr "Reset"
 
 # senaite.app.listing: Reset-columns button tooltip
 msgid "Reset column visibility and order to the defaults"
-msgstr "Restablecer la visibilidad y el orden de las columnas a los valores predeterminados"
+msgstr ""
 
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
@@ -4936,11 +4936,11 @@ msgstr "Inicializar las columnas"
 
 # senaite.app.listing: Column config — reset link tooltip
 msgid "Reset to default columns and order"
-msgstr "Restablecer las columnas y el orden predeterminados"
+msgstr ""
 
 # senaite.app.listing: Search box — undo / reset-view button tooltip
 msgid "Reset view"
-msgstr "Restablecer vista"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
@@ -5015,7 +5015,7 @@ msgstr "Interpretación de resultados"
 
 #: senaite/core/browser/dashboard/dashboard.py:85
 msgid "Results Pending"
-msgstr "Resultados pendientes"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
@@ -5096,7 +5096,7 @@ msgstr "Análisis rutinarios"
 
 #: bika/lims/api/snapshot.py:555
 msgid "Row ${num}"
-msgstr "Fila ${num}"
+msgstr ""
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
@@ -5112,7 +5112,7 @@ msgstr "SENAITE Core 1.x (no instalar)"
 
 #: senaite/core/browser/frontpage/templates/frontpage.pt:6
 msgid "SENAITE LIMS"
-msgstr "SENAITE LIMS"
+msgstr ""
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE LIMS front-page"
@@ -5324,15 +5324,15 @@ msgstr "Las muestras ${sample_ids} fueron invalidadas correctamente."
 
 #: senaite/core/browser/dashboard/dashboard.py:400
 msgid "Samples awaiting collection of the sample"
-msgstr "Muestras en espera de la recogida de la muestra"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:404
 msgid "Samples awaiting preservation"
-msgstr "Muestras en espera de conservación"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:416
 msgid "Samples awaiting reception at the laboratory"
-msgstr "Muestras en espera de recepción en el laboratorio"
+msgstr ""
 
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
@@ -5345,19 +5345,19 @@ msgstr "Formulario de informe de rechazo de muestras"
 
 #: senaite/core/browser/dashboard/dashboard.py:81
 msgid "Samples to Receive"
-msgstr "Muestras por recibir"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:432
 msgid "Samples whose reports have been published"
-msgstr "Muestras cuyos informes se han publicado"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:424
 msgid "Samples whose results are awaiting verification"
-msgstr "Muestras cuyos resultados están en espera de verificación"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:409
 msgid "Samples with a scheduled sampling date"
-msgstr "Muestras con una fecha de muestreo programada"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
@@ -5401,11 +5401,11 @@ msgstr "Guardar y copiar"
 # senaite.app.listing: Saved filter presets — footer button to save the
 # current view
 msgid "Save current view"
-msgstr "Guardar la vista actual"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — toggle title + menu header
 msgid "Saved filters"
-msgstr "Filtros guardados"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5438,11 +5438,11 @@ msgstr "Buscar"
 
 # senaite.app.listing: Column config — search input placeholder
 msgid "Search columns…"
-msgstr "Buscar columnas…"
+msgstr ""
 
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
-msgstr "Buscar..."
+msgstr ""
 
 #: bika/lims/browser/fields/coordinatefield.py:38
 msgid "Seconds"
@@ -5584,11 +5584,11 @@ msgstr "Seleccione para permitir que un Coordinador de Muestreo programe un mues
 
 #: senaite/core/content/senaitesetup.py:1001
 msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
-msgstr "Seleccione esta opción para permitir el envío de muestras mediante la transición 'dispatch' y habilitar el estado adicional 'dispatched'. Los análisis de una muestra enviada pasan a ser de solo lectura y se restauran a su estado anterior cuando se restaura la muestra. Deshabilitado de forma predeterminada."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:991
 msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
-msgstr "Seleccione esta opción para permitir el desecho de muestras mediante la transición 'dispose' y habilitar el estado adicional 'disposed'. Deshabilitado de forma predeterminada."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
@@ -5740,7 +5740,7 @@ msgstr "Desea añadir el contenido de ejemplo en este sitio?"
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
-msgstr "Mostrar campos adicionales"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
@@ -5748,7 +5748,7 @@ msgstr "Mostrar todo"
 
 #: senaite/core/api/remarks.py:486
 msgid "Show history"
-msgstr "Mostrar historial"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
@@ -5768,11 +5768,11 @@ msgstr "Mostrar los campos estándar"
 
 # senaite.app.listing: Column config — plus button tooltip / aria-label
 msgid "Show this column"
-msgstr "Mostrar esta columna"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:129
 msgid "Show/hide timeline"
-msgstr "Mostrar/ocultar línea de tiempo"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5839,11 +5839,11 @@ msgstr "Clave de ordenación"
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort ascending"
-msgstr "Ordenar de forma ascendente"
+msgstr ""
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort descending"
-msgstr "Ordenar de forma descendente"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5915,7 +5915,7 @@ msgstr "Previsualización de etiquetas"
 
 # senaite.app.listing: Saved filter presets — star action tooltip when active
 msgid "Stop auto-applying"
-msgstr "Detener la aplicación automática"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
@@ -5959,7 +5959,7 @@ msgstr "Proporcione un archivo Open XML (.XLSX) válido que contenga datos de co
 
 #: senaite/core/browser/dashboard/dashboard.py:490
 msgid "Submitted analyses awaiting verification"
-msgstr "Análisis enviados en espera de verificación"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
@@ -6157,7 +6157,7 @@ msgstr "La muestra o muestras siguientes serán enviadas"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:47
 msgid "The following sample(s) will be disposed"
-msgstr "Se desechará(n) la(s) siguiente(s) muestra(s)"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
@@ -6206,7 +6206,7 @@ msgstr "Volumen mínimo de muestra necesario para efectuar el análisis (por eje
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:40
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
-msgstr "El almacenamiento del generador de números está vacío. Los contadores se inicializan en la primera generación de ID para cada prefijo."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
@@ -6434,11 +6434,11 @@ msgstr "Por muestrear"
 
 #: senaite/core/browser/dashboard/dashboard.py:93
 msgid "To be Published"
-msgstr "Por publicar"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:89
 msgid "To be Verified"
-msgstr "Por verificar"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
@@ -6521,7 +6521,7 @@ msgstr "Escriba para filtrar ..."
 
 # senaite.app.listing: Column-filter row — searchable-select placeholder
 msgid "Type to filter..."
-msgstr "Escriba para filtrar..."
+msgstr ""
 
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
@@ -6582,7 +6582,7 @@ msgstr "Usuario desvinculado"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unlock"
-msgstr "Desbloquear"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6608,11 +6608,11 @@ msgstr "Actualizar ficheros adjuntos"
 
 # senaite.app.listing: Saved filter presets — Update preset action tooltip
 msgid "Update preset with current view"
-msgstr "Actualizar el preajuste con la vista actual"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
-msgstr "Se actualizaron {} clave(s): {}"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:47
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
@@ -6947,7 +6947,7 @@ msgstr "Verificado por"
 
 #: senaite/core/browser/dashboard/dashboard.py:428
 msgid "Verified samples ready to be published"
-msgstr "Muestras verificadas listas para publicar"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
@@ -6957,7 +6957,7 @@ msgstr "Verificar"
 
 #: senaite/core/browser/dashboard/dashboard.py:109
 msgid "Verify Results"
-msgstr "Verificar resultados"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6975,11 +6975,11 @@ msgstr "Ver el sitio de SENAITE"
 
 # senaite.app.listing: Column config — visible-section header
 msgid "Visible"
-msgstr "Visible"
+msgstr ""
 
 # senaite.app.listing: Column config — counter title attribute
 msgid "Visible / total columns"
-msgstr "Columnas visibles / totales"
+msgstr ""
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -7016,7 +7016,7 @@ msgstr "Miércoles"
 
 #: senaite/core/browser/dashboard/dashboard.py:136
 msgid "Weekly"
-msgstr "Semanal"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
@@ -7024,7 +7024,7 @@ msgstr "Semanas para expirar"
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:7
 msgid "Welcome"
-msgstr "Bienvenido"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:14
 msgid "Welcome to SENAITE"
@@ -7100,11 +7100,11 @@ msgstr "Hojas de trabajo"
 
 #: senaite/core/browser/dashboard/dashboard.py:531
 msgid "Worksheets that have been verified"
-msgstr "Hojas de trabajo que han sido verificadas"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:526
 msgid "Worksheets whose results are awaiting verification"
-msgstr "Hojas de trabajo cuyos resultados están en espera de verificación"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -7116,7 +7116,7 @@ msgstr "Longitud de IBAN incorrecta por%s: %s corto por %i"
 
 #: senaite/core/browser/dashboard/dashboard.py:140
 msgid "Yearly"
-msgstr "Anual"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -7204,7 +7204,7 @@ msgstr "Debe especificarse un analista."
 
 # senaite.app.listing: Saved filter presets — micro-tag on the default preset
 msgid "auto"
-msgstr "automático"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
@@ -7218,9 +7218,8 @@ msgstr "por"
 #. in '${calc}')"
 #. Default: "keyword '${keyword}' must have column title '${title}' (defined in '${calc}')"
 #: senaite/core/validators/interimfields.py:151
-#, fuzzy
 msgid "calcs_interims_validator_dup_keyword_error"
-msgstr "la palabra clave '${keyword}' debe tener el título de columna '${title}' (definido en '${calc}')"
+msgstr ""
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:57
@@ -7242,34 +7241,33 @@ msgstr "Algunos análisis utilizan instrumentos no calibrados o caducados. Edici
 #. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #. Default: "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #: senaite/core/validators/interimfields.py:211
-#, fuzzy
 msgid "choice_syntax_validation_error"
-msgstr "No hay un formato válido en el campo de opciones. El formato admitido es: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
+msgstr ""
 
 #. Default: "Control type is not supported for empty choices"
 #: senaite/core/validators/interimfields.py:111
 msgid "choices_and_restype_validator_no_choices_error"
-msgstr "El tipo de control no es compatible con opciones vacías"
+msgstr ""
 
 #. Default: "Chosen control type not supporting choices"
 #: senaite/core/validators/interimfields.py:117
 msgid "choices_and_restype_validator_not_supported_choices_error"
-msgstr "El tipo de control elegido no admite opciones"
+msgstr ""
 
 #. Default: "Empty keys are not supported"
 #: senaite/core/validators/interimfields.py:169
 msgid "choices_empty_keys_validator_error"
-msgstr "Las claves vacías no son compatibles"
+msgstr ""
 
 #. Default: "At least, two options for choices field are required"
 #: senaite/core/validators/interimfields.py:195
 msgid "choices_min_items_validator_error"
-msgstr "Se requieren al menos dos opciones para el campo de opciones"
+msgstr ""
 
 #. Default: "Duplicate keys in choices field"
 #: senaite/core/validators/interimfields.py:183
 msgid "choices_unique_keys_validator_error"
-msgstr "Claves duplicadas en el campo de opciones"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:250
 msgid "daily"
@@ -7299,10 +7297,9 @@ msgstr "${d}/${m}/${Y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "yy-mm-dd"
-#, fuzzy
+#. Default: "mm/dd/yy"
 msgid "date_format_short_datepicker"
-msgstr "dd/mm/aa"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "days"
@@ -7315,11 +7312,11 @@ msgstr "desactivar"
 #. Default: "Sample disposed after the retention period."
 #: senaite/core/browser/samples/templates/dispose_samples.pt:66
 msgid "default_dispose_reason"
-msgstr "Muestra desechada tras el período de retención."
+msgstr ""
 
 #: senaite/core/api/remarks.py:485
 msgid "deleted by {user} at {time}"
-msgstr "eliminado por {user} el {time}"
+msgstr ""
 
 #. Default: "Attached labels"
 #: senaite/core/behaviors/label.py:126
@@ -7329,39 +7326,37 @@ msgstr "Etiquetas asignadas a este contenido."
 #. Default: "The accreditation standard that applies, e.g. ISO 17025"
 #: senaite/core/content/laboratory.py:174
 msgid "description_accreditation"
-msgstr "La norma de acreditación aplicable, p. ej. ISO 17025"
+msgstr ""
 
 #. Default: "E.g. SANAS, APLAC, etc."
 #: senaite/core/content/laboratory.py:153
 msgid "description_accreditation_body"
-msgstr "P. ej. SANAS, APLAC, etc."
+msgstr ""
 
 #. and results reports by your accreditation body. Maximum size is 175 x 175
 #. pixels."
 #. Default: "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 #: senaite/core/content/laboratory.py:198
-#, fuzzy
 msgid "description_accreditation_body_logo"
-msgstr "Suba el logotipo que su organismo de acreditación le autoriza a usar en su sitio web y en los informes de resultados. El tamaño máximo es de 175 x 175 píxeles."
+msgstr ""
 
 #. Default: "Web address for the accreditation body"
 #: senaite/core/content/laboratory.py:163
 msgid "description_accreditation_body_url"
-msgstr "Dirección web del organismo de acreditación"
+msgstr ""
 
 #. following fields are available: lab_is_accredited, lab_name, lab_country,
 #. confidence, accreditation_body_name, accreditation_standard,
 #. accreditation_reference"
 #. Default: "Enter the details of your lab's service accreditations here. The following fields are available: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 #: senaite/core/content/laboratory.py:220
-#, fuzzy
 msgid "description_accreditation_page_header"
-msgstr "Introduzca aquí los datos de las acreditaciones de servicio de su laboratorio. Están disponibles los siguientes campos: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
+msgstr ""
 
 #. Default: "The reference code issued to the lab by the accreditation body"
 #: senaite/core/content/laboratory.py:186
 msgid "description_accreditation_reference"
-msgstr "El código de referencia emitido al laboratorio por el organismo de acreditación"
+msgstr ""
 
 #. Default: "The category the analysis service belongs to"
 #: bika/lims/content/abstractbaseanalysis.py:533
@@ -7655,9 +7650,8 @@ msgstr "Servicios de análisis que dependen del cálculo."
 #. where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #. Default: "<p>The formula you type here will be dynamically calculated be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators, + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #: senaite/core/content/calculation.py:291
-#, fuzzy
 msgid "description_calculation_formula"
-msgstr "<p>La fórmula que escriba aquí se calculará dinámicamente cuando se muestre un análisis que utilice este cálculo.</p><p>Para introducir un cálculo, use los operadores matemáticos estándar, + - * / ( ), y todas las palabras clave disponibles, tanto de otros Servicios de análisis como de los Campos provisionales aquí especificados, como variables. Enciérrelas entre corchetes [ ].</p><p>P. ej., el cálculo de la Dureza total, la suma de los iones de Calcio (ppm) y Magnesio (ppm) en el agua, se introduce como [Ca] + [Mg], donde Ca y Mg son las palabras clave de esos dos Servicios de análisis.</p>"
+msgstr ""
 
 #. library, you can import it here. E.g. if you want to use the 'floor'
 #. function from the Python 'math' module, you add 'math' to the Module field
@@ -7666,9 +7660,8 @@ msgstr "<p>La fórmula que escriba aquí se calculará dinámicamente cuando se 
 #. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
-#, fuzzy
 msgid "description_calculation_imports"
-msgstr "Si su fórmula necesita una función especial de una biblioteca externa de Python, puede importarla aquí. P. ej., si desea usar la función 'floor' del módulo 'math' de Python, añada 'math' al campo Módulo y 'floor' al campo de función. El equivalente en Python sería 'from math import floor'. En su cálculo podría usar entonces 'floor([Ca] + [Mg])'."
+msgstr ""
 
 #. should your calculation require them. The field title specified here will
 #. be used as column headers and field descriptors where the interim fields
@@ -7677,24 +7670,21 @@ msgstr "Si su fórmula necesita una función especial de una biblioteca externa 
 #. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
-#, fuzzy
 msgid "description_calculation_interims"
-msgstr "Defina campos provisionales como la masa del recipiente o los factores de dilución, en caso de que su cálculo los requiera. El título del campo aquí especificado se usará como encabezado de columna y descriptor de campo donde se muestren los campos provisionales. Si 'Aplicar de forma amplia' está habilitado, el campo se mostrará en un cuadro de selección en la parte superior de la hoja de trabajo, permitiendo aplicar un valor específico a todos los campos correspondientes de la hoja."
+msgstr ""
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
 #. Default: "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 #: senaite/core/content/calculation.py:321
-#, fuzzy
 msgid "description_calculation_test_params"
-msgstr "Para probar el cálculo, introduzca aquí los valores de todos los parámetros del cálculo. Esto incluye los campos provisionales definidos arriba, así como cualquier servicio del que dependa este cálculo para calcular los resultados."
+msgstr ""
 
 #. values."
 #. Default: "The result after the calculation has taken place with test values."
 #: senaite/core/content/calculation.py:345
-#, fuzzy
 msgid "description_calculation_test_result"
-msgstr "El resultado después de que el cálculo se haya realizado con valores de prueba."
+msgstr ""
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/analysiscategory.py:62
@@ -7714,7 +7704,7 @@ msgstr "Categorías de análisis que a mostrar cuando el usuario seleccione este
 #. Default: "This value is reported at the bottom of all published results"
 #: senaite/core/content/laboratory.py:127
 msgid "description_confidence_level"
-msgstr "Este valor se indica al pie de todos los resultados publicados"
+msgstr ""
 
 #. Default: "Contacts in CC for new samples"
 #: senaite/core/content/contact.py:155
@@ -7827,27 +7817,25 @@ msgstr "Indique los departamentos del laboratorio a los que pertenece este conta
 #. the default style."
 #. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
 #: senaite/core/content/label.py:72
-#, fuzzy
 msgid "description_label_color"
-msgstr "Código de color hexadecimal utilizado para el chip (p. ej. #0d6efd). Déjelo vacío para el estilo predeterminado."
+msgstr ""
 
 #. labeled content. The cascade runs in the same transaction as the save and
 #. may take a moment on large datasets."
 #. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
 #: senaite/core/content/label.py:45
-#, fuzzy
 msgid "description_label_title"
-msgstr "Cambiar el nombre de esta etiqueta reescribe el nombre almacenado en todo el contenido actualmente etiquetado. La cascada se ejecuta en la misma transacción que el guardado y puede tardar un momento en conjuntos de datos grandes."
+msgstr ""
 
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
-msgstr "Marque esta casilla si su laboratorio está acreditado"
+msgstr ""
 
 #. Default: "The Laboratory's web address"
 #: senaite/core/content/laboratory.py:101
 msgid "description_laboratory_lab_url"
-msgstr "La dirección web del laboratorio"
+msgstr ""
 
 #. Default: "Supervisor of the Lab"
 #: bika/lims/content/laboratory.py:78
@@ -7857,7 +7845,7 @@ msgstr "Seleccione el supervisor o persona encargada del correcto functionamient
 #. Default: "Supervisor of the Lab"
 #: senaite/core/content/laboratory.py:77
 msgid "description_laboratory_supervisor"
-msgstr "Supervisor del laboratorio"
+msgstr ""
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/labproduct.py:89
@@ -7875,9 +7863,8 @@ msgstr "Proporcione el IVA en porcentaje que se añade al precio del producto"
 #. show or reorder each viewlet."
 #. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
-#, fuzzy
 msgid "description_manage_viewlets"
-msgstr "Los gestores de viewlets y sus viewlets se muestran en su lugar, anidados y posicionados tal como aparecen en el sitio. Use los controles para ocultar, mostrar o reordenar cada viewlet."
+msgstr ""
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
@@ -7909,9 +7896,8 @@ msgstr "Los valores para las muestras de referencia son cero o 'blanco'"
 #. definition."
 #. Default: "Hazard categories that apply to samples of this reference definition."
 #: bika/lims/content/referencedefinition.py:106
-#, fuzzy
 msgid "description_referencedefinition_hazard_categories"
-msgstr "Categorías de peligro que se aplican a las muestras de esta definición de referencia."
+msgstr ""
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: bika/lims/content/referencedefinition.py:91
@@ -7933,9 +7919,8 @@ msgstr "Haga clic sobre las cabeceras de categorías de análisis (con fondo gri
 #. inherit from the reference definition."
 #. Default: "Hazard categories for this reference sample. Leave empty to inherit from the reference definition."
 #: bika/lims/content/referencesample.py:118
-#, fuzzy
 msgid "description_referencesample_hazard_categories"
-msgstr "Categorías de peligro para esta muestra de referencia. Déjelo vacío para heredar de la definición de referencia."
+msgstr ""
 
 #. Default: "Select the manufacturer for this sample"
 #: bika/lims/content/referencesample.py:136
@@ -7994,9 +7979,8 @@ msgstr "Enviar automáticamente los análisis al importar"
 #. batch is created in a single transaction (legacy behaviour)."
 #. Default: "When enabled, each sample created from the add form is committed in its own ZODB transaction with a per-sample retry on conflict. This reduces the chance that ID-counter or container contention aborts the whole batch on instances with many concurrent users. When disabled, the whole batch is created in a single transaction (legacy behaviour)."
 #: senaite/core/registry/schema.py:391
-#, fuzzy
 msgid "description_registry_sample_add_commit_per_sample"
-msgstr "Cuando está habilitado, cada muestra creada desde el formulario de creación se confirma en su propia transacción de ZODB con un reintento por muestra en caso de conflicto. Esto reduce la posibilidad de que la contención del contador de ID o del contenedor aborte todo el lote en instancias con muchos usuarios concurrentes. Cuando está deshabilitado, todo el lote se crea en una sola transacción (comportamiento heredado)."
+msgstr ""
 
 #. matching the source sample structure. Each partition will be created with
 #. the same configuration (sample type, container, preservation) and analyses
@@ -8083,7 +8067,7 @@ msgstr "Referencia a la muestra de la que se desvinculó esta partición."
 #. Default: "Reference to the source sample this sample was duplicated from"
 #: bika/lims/content/analysisrequest.py:1283
 msgid "description_sample_duplicated_from"
-msgstr "Referencia a la muestra de origen desde la que se duplicó esta muestra"
+msgstr ""
 
 #. Default: "Generated invoice for this sample"
 #: bika/lims/content/analysisrequest.py:1049
@@ -8278,9 +8262,8 @@ msgstr "El periodo durante el que las muestras sin conservar de este tipo pueden
 #. display the appropriate pictograms in reports and lists."
 #. Default: "Hazard categories that apply to samples of this type. Used to display the appropriate pictograms in reports and lists."
 #: senaite/core/content/sampletype.py:180
-#, fuzzy
 msgid "description_sampletype_hazard_categories"
-msgstr "Categorías de peligro que se aplican a las muestras de este tipo. Se utilizan para mostrar los pictogramas apropiados en los informes y las listas."
+msgstr ""
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: senaite/core/content/sampletype.py:168
@@ -8520,9 +8503,8 @@ msgstr "Separador decimal preferido para los resultados"
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
 #: senaite/core/content/senaitesetup.py:969
-#, fuzzy
 msgid "description_senaitesetup_sample_duplicate_enabled"
-msgstr "Si está habilitado, los usuarios con privilegios suficientes pueden crear una muestra hermana directamente a partir de una existente mediante la acción 'Duplicar' en el listado de muestras. Habilitado de forma predeterminada."
+msgstr ""
 
 #. Default: "Analyses are required for sample registration"
 #: senaite/core/content/senaitesetup.py:351
@@ -8752,42 +8734,42 @@ msgstr "El duplicado en la posición ${dup} referencia esta posición, por lo qu
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr "${days} días"
+msgstr ""
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr "${hours} horas"
+msgstr ""
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr "Días"
+msgstr ""
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr "Horas"
+msgstr ""
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr "Minutos"
+msgstr ""
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr "Segundos"
+msgstr ""
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr "${minutes} minutos"
+msgstr ""
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr "${seconds} segundos"
+msgstr ""
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
@@ -8796,7 +8778,7 @@ msgstr "Contenido del archivo"
 
 #: senaite/core/api/remarks.py:481
 msgid "edited"
-msgstr "editado"
+msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8838,202 +8820,202 @@ msgstr "Particiones"
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/formula.py:121
 msgid "formula_validation_chain_error"
-msgstr "Error interno de la cadena de validación: ${error}"
+msgstr ""
 
 #. Default: "cryogenic / inert gas"
 #: senaite/core/vocabularies/hazard_categories.py:167
 msgid "hazard_ASPH01_common"
-msgstr "criogénico / gas inerte"
+msgstr ""
 
 #. Default: "Asphyxiating atmosphere"
 #: senaite/core/vocabularies/hazard_categories.py:165
 msgid "hazard_ASPH01_name"
-msgstr "Atmósfera asfixiante"
+msgstr ""
 
 #. Default: "infectious / biological"
 #: senaite/core/vocabularies/hazard_categories.py:104
 msgid "hazard_BIO01_common"
-msgstr "infeccioso / biológico"
+msgstr ""
 
 #. Default: "Biohazard"
 #: senaite/core/vocabularies/hazard_categories.py:103
 msgid "hazard_BIO01_name"
-msgstr "Riesgo biológico"
+msgstr ""
 
 #. Default: "freezing / cold storage"
 #: senaite/core/vocabularies/hazard_categories.py:158
 msgid "hazard_COLD01_common"
-msgstr "congelación / almacenamiento en frío"
+msgstr ""
 
 #. Default: "Low temperature"
 #: senaite/core/vocabularies/hazard_categories.py:157
 msgid "hazard_COLD01_name"
-msgstr "Baja temperatura"
+msgstr ""
 
 #. Default: "electric shock"
 #: senaite/core/vocabularies/hazard_categories.py:132
 msgid "hazard_ELEC01_common"
-msgstr "descarga eléctrica"
+msgstr ""
 
 #. Default: "Electricity"
 #: senaite/core/vocabularies/hazard_categories.py:131
 msgid "hazard_ELEC01_name"
-msgstr "Electricidad"
+msgstr ""
 
 #. Default: "explosive"
 #: senaite/core/vocabularies/hazard_categories.py:48
 msgid "hazard_GHS01_common"
-msgstr "explosivo"
+msgstr ""
 
 #. Default: "Explosive"
 #: senaite/core/vocabularies/hazard_categories.py:47
 msgid "hazard_GHS01_name"
-msgstr "Explosivo"
+msgstr ""
 
 #. Default: "flammable"
 #: senaite/core/vocabularies/hazard_categories.py:54
 msgid "hazard_GHS02_common"
-msgstr "inflamable"
+msgstr ""
 
 #. Default: "Flammable"
 #: senaite/core/vocabularies/hazard_categories.py:53
 msgid "hazard_GHS02_name"
-msgstr "Inflamable"
+msgstr ""
 
 #. Default: "oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:60
 msgid "hazard_GHS03_common"
-msgstr "oxidante"
+msgstr ""
 
 #. Default: "Oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:59
 msgid "hazard_GHS03_name"
-msgstr "Oxidante"
+msgstr ""
 
 #. Default: "pressurised gas"
 #: senaite/core/vocabularies/hazard_categories.py:66
 msgid "hazard_GHS04_common"
-msgstr "gas presurizado"
+msgstr ""
 
 #. Default: "Compressed gas"
 #: senaite/core/vocabularies/hazard_categories.py:65
 msgid "hazard_GHS04_name"
-msgstr "Gas comprimido"
+msgstr ""
 
 #. Default: "acid / caustic"
 #: senaite/core/vocabularies/hazard_categories.py:72
 msgid "hazard_GHS05_common"
-msgstr "ácido / cáustico"
+msgstr ""
 
 #. Default: "Corrosive"
 #: senaite/core/vocabularies/hazard_categories.py:71
 msgid "hazard_GHS05_name"
-msgstr "Corrosivo"
+msgstr ""
 
 #. Default: "poisonous"
 #: senaite/core/vocabularies/hazard_categories.py:78
 msgid "hazard_GHS06_common"
-msgstr "venenoso"
+msgstr ""
 
 #. Default: "Acute toxicity"
 #: senaite/core/vocabularies/hazard_categories.py:77
 msgid "hazard_GHS06_name"
-msgstr "Toxicidad aguda"
+msgstr ""
 
 #. Default: "harmful / irritant"
 #: senaite/core/vocabularies/hazard_categories.py:84
 msgid "hazard_GHS07_common"
-msgstr "nocivo / irritante"
+msgstr ""
 
 #. Default: "Health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:83
 msgid "hazard_GHS07_name"
-msgstr "Peligro para la salud"
+msgstr ""
 
 #. Default: "carcinogenic / mutagenic"
 #: senaite/core/vocabularies/hazard_categories.py:90
 msgid "hazard_GHS08_common"
-msgstr "cancerígeno / mutágeno"
+msgstr ""
 
 #. Default: "Serious health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:89
 msgid "hazard_GHS08_name"
-msgstr "Peligro grave para la salud"
+msgstr ""
 
 #. Default: "environmentally hazardous"
 #: senaite/core/vocabularies/hazard_categories.py:97
 msgid "hazard_GHS09_common"
-msgstr "peligroso para el medio ambiente"
+msgstr ""
 
 #. Default: "Environmental hazard"
 #: senaite/core/vocabularies/hazard_categories.py:96
 msgid "hazard_GHS09_name"
-msgstr "Peligro medioambiental"
+msgstr ""
 
 #. Default: "heated material"
 #: senaite/core/vocabularies/hazard_categories.py:145
 msgid "hazard_HOT01_common"
-msgstr "material caliente"
+msgstr ""
 
 #. Default: "Hot content"
 #: senaite/core/vocabularies/hazard_categories.py:144
 msgid "hazard_HOT01_name"
-msgstr "Contenido caliente"
+msgstr ""
 
 #. Default: "hot to touch"
 #: senaite/core/vocabularies/hazard_categories.py:139
 msgid "hazard_HSURF01_common"
-msgstr "caliente al tacto"
+msgstr ""
 
 #. Default: "Hot surface"
 #: senaite/core/vocabularies/hazard_categories.py:138
 msgid "hazard_HSURF01_name"
-msgstr "Superficie caliente"
+msgstr ""
 
 #. Default: "NMR / MRI"
 #: senaite/core/vocabularies/hazard_categories.py:125
 msgid "hazard_MAG01_common"
-msgstr "RMN / RM"
+msgstr ""
 
 #. Default: "Magnetic field"
 #: senaite/core/vocabularies/hazard_categories.py:124
 msgid "hazard_MAG01_name"
-msgstr "Campo magnético"
+msgstr ""
 
 #. Default: "UV / laser / RF"
 #: senaite/core/vocabularies/hazard_categories.py:118
 msgid "hazard_NIR01_common"
-msgstr "UV / láser / RF"
+msgstr ""
 
 #. Default: "Non-ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:117
 msgid "hazard_NIR01_name"
-msgstr "Radiación no ionizante"
+msgstr ""
 
 #. Default: "ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:112
 msgid "hazard_RAD01_common"
-msgstr "radiación ionizante"
+msgstr ""
 
 #. Default: "Radioactive"
 #: senaite/core/vocabularies/hazard_categories.py:111
 msgid "hazard_RAD01_name"
-msgstr "Radiactivo"
+msgstr ""
 
 #. Default: "autoclave / sterilisation"
 #: senaite/core/vocabularies/hazard_categories.py:151
 msgid "hazard_STEAM01_common"
-msgstr "autoclave / esterilización"
+msgstr ""
 
 #. Default: "Hot steam"
 #: senaite/core/vocabularies/hazard_categories.py:150
 msgid "hazard_STEAM01_name"
-msgstr "Vapor caliente"
+msgstr ""
 
 #. Default: "Hazardous"
 #: senaite/core/api/hazard.py:37
 msgid "hazard_warning_label"
-msgstr "Peligroso"
+msgstr ""
 
 #. Default: "Legacy Setup"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:16
@@ -9067,12 +9049,12 @@ msgstr "horas"
 #. Default: "'${function}' not found in module '${module}'"
 #: senaite/core/validators/imports.py:66
 msgid "importable_function_error"
-msgstr "'${function}' no se encontró en el módulo '${module}'"
+msgstr ""
 
 #. Default: "Could not import module '${module}'"
 #: senaite/core/validators/imports.py:49
 msgid "importable_module_error"
-msgstr "No se pudo importar el módulo '${module}'"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:189
 msgid "in"
@@ -9086,27 +9068,27 @@ msgstr "Exportador de instrumento no encontrado"
 #. Default: "Interim field ${row_num}: ${message}"
 #: senaite/core/validators/interimfields.py:299
 msgid "interim_field_error"
-msgstr "Campo provisional ${row_num}: ${message}"
+msgstr ""
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/interimfields.py:278
 msgid "interims_validation_chain_error"
-msgstr "Error interno de la cadena de validación: ${error}"
+msgstr ""
 
 #. Default: "'${field_name}' contains invalid characters"
 #: senaite/core/validators/interimfields.py:68
 msgid "invalid_characters_validator_error"
-msgstr "'${field_name}' contiene caracteres no válidos"
+msgstr ""
 
 #. Default: "AnalysesServices not found for keywords: ${keywords}"
 #: senaite/core/validators/formula.py:92
 msgid "invalid_keyword_error"
-msgstr "No se encontraron Servicios de análisis para las palabras clave: ${keywords}"
+msgstr ""
 
 #. Default: "Invalid wildcards found: ${wildcards}"
 #: senaite/core/validators/formula.py:71
 msgid "invalid_wildcards_check_error"
-msgstr "Se encontraron comodines no válidos: ${wildcards}"
+msgstr ""
 
 #. Default: "Labels"
 #: senaite/core/behaviors/label.py:125
@@ -9342,7 +9324,7 @@ msgstr "No permitir el registro de muestras sin análisis"
 #. Default: "DependentServices"
 #: senaite/core/content/calculation.py:352
 msgid "label_calculation_dependent_services"
-msgstr "Servicios dependientes"
+msgstr ""
 
 #. Default: "Dependent services"
 #: bika/lims/content/calculation.py:81
@@ -9352,52 +9334,52 @@ msgstr "Servicios dependientes"
 #. Default: "Calculation Formula"
 #: senaite/core/content/calculation.py:287
 msgid "label_calculation_formula"
-msgstr "Fórmula de cálculo"
+msgstr ""
 
 #. Default: "Function"
 #: senaite/core/content/calculation.py:185
 msgid "label_calculation_import_function_name"
-msgstr "Función"
+msgstr ""
 
 #. Default: "Module"
 #: senaite/core/content/calculation.py:179
 msgid "label_calculation_import_module_name"
-msgstr "Módulo"
+msgstr ""
 
 #. Default: "Additional Python Libraries"
 #: senaite/core/content/calculation.py:266
 msgid "label_calculation_imports"
-msgstr "Bibliotecas de Python adicionales"
+msgstr ""
 
 #. Default: "Calculation Interim Fields"
 #: senaite/core/content/calculation.py:243
 msgid "label_calculation_interims"
-msgstr "Campos provisionales del cálculo"
+msgstr ""
 
 #. Default: "Raw Test Result"
 #: senaite/core/content/calculation.py:336
 msgid "label_calculation_raw_test_keywords"
-msgstr "Resultado de prueba sin procesar"
+msgstr ""
 
 #. Default: "Keyword"
 #: senaite/core/content/calculation.py:198
 msgid "label_calculation_test_param_keyword"
-msgstr "Palabra clave"
+msgstr ""
 
 #. Default: "Value"
 #: senaite/core/content/calculation.py:207
 msgid "label_calculation_test_param_value"
-msgstr "Valor"
+msgstr ""
 
 #. Default: "Test Parameters"
 #: senaite/core/content/calculation.py:317
 msgid "label_calculation_test_params"
-msgstr "Parámetros de prueba"
+msgstr ""
 
 #. Default: "Test Result"
 #: senaite/core/content/calculation.py:343
 msgid "label_calculation_test_result"
-msgstr "Resultado de prueba"
+msgstr ""
 
 #. Default: "Department"
 #: bika/lims/content/analysiscategory.py:59
@@ -9529,52 +9511,52 @@ msgstr "Realizada por"
 #. Default: "Allow empty"
 #: senaite/core/schema/interimfields.py:87
 msgid "label_interim_allow_empty"
-msgstr "Permitir vacío"
+msgstr ""
 
 #. Default: "Apply wide"
 #: senaite/core/schema/interimfields.py:127
 msgid "label_interim_apply_wide"
-msgstr "Aplicar de forma amplia"
+msgstr ""
 
 #. Default: "Choices"
 #: senaite/core/schema/interimfields.py:67
 msgid "label_interim_choices"
-msgstr "Opciones"
+msgstr ""
 
 #. Default: "Default value"
 #: senaite/core/schema/interimfields.py:57
 msgid "label_interim_default_value"
-msgstr "Valor predeterminado"
+msgstr ""
 
 #. Default: "Hidden"
 #: senaite/core/schema/interimfields.py:117
 msgid "label_interim_hidden"
-msgstr "Oculto"
+msgstr ""
 
 #. Default: "Keyword"
 #: senaite/core/schema/interimfields.py:37
 msgid "label_interim_keyword"
-msgstr "Palabra clave"
+msgstr ""
 
 #. Default: "Report"
 #: senaite/core/schema/interimfields.py:107
 msgid "label_interim_report"
-msgstr "Informe"
+msgstr ""
 
 #. Default: "Result type"
 #: senaite/core/schema/interimfields.py:76
 msgid "label_interim_result_type"
-msgstr "Tipo de resultado"
+msgstr ""
 
 #. Default: "Field title"
 #: senaite/core/schema/interimfields.py:47
 msgid "label_interim_title"
-msgstr "Título del campo"
+msgstr ""
 
 #. Default: "Unit"
 #: senaite/core/schema/interimfields.py:97
 msgid "label_interim_unit"
-msgstr "Unidad"
+msgstr ""
 
 #. Default: "Default Department"
 #: bika/lims/content/labcontact.py:86
@@ -9729,7 +9711,7 @@ msgstr "Blanco"
 #. Default: "Hazard categories"
 #: bika/lims/content/referencedefinition.py:104
 msgid "label_referencedefinition_hazard_categories"
-msgstr "Categorías de peligro"
+msgstr ""
 
 #. Default: "Hazardous"
 #: bika/lims/content/referencedefinition.py:89
@@ -9744,7 +9726,7 @@ msgstr "Valores de referencia"
 #. Default: "Hazard categories"
 #: bika/lims/content/referencesample.py:116
 msgid "label_referencesample_hazard_categories"
-msgstr "Categorías de peligro"
+msgstr ""
 
 #. Default: "Manufacturer"
 #: bika/lims/content/referencesample.py:133
@@ -9809,7 +9791,7 @@ msgstr "Permitir pegado múltiple"
 #. Default: "Commit each sample in its own transaction"
 #: senaite/core/registry/schema.py:387
 msgid "label_registry_sample_add_commit_per_sample"
-msgstr "Confirmar cada muestra en su propia transacción"
+msgstr ""
 
 #. Default: "Copy sample structure with partitions"
 #: senaite/core/registry/schema.py:324
@@ -9889,7 +9871,7 @@ msgstr "Muestra original"
 #. Default: "Duplicated from sample"
 #: bika/lims/content/analysisrequest.py:1280
 msgid "label_sample_duplicated_from"
-msgstr "Duplicada de la muestra"
+msgstr ""
 
 #. Default: "Invoice"
 #: bika/lims/content/analysisrequest.py:1046
@@ -10135,19 +10117,18 @@ msgstr "Método"
 #. Default: "Added ${count} label(s) to ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:185
 msgid "labels_added"
-msgstr "Se añadieron ${count} etiqueta(s) a ${affected} muestra(s)"
+msgstr ""
 
 #. sample(s)"
 #. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:174
-#, fuzzy
 msgid "labels_changed"
-msgstr "Se aplicaron ${added} añadida(s) y ${removed} quitada(s) en ${affected} muestra(s)"
+msgstr ""
 
 #. Default: "Removed ${count} label(s) from ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:194
 msgid "labels_removed"
-msgstr "Se quitaron ${count} etiqueta(s) de ${affected} muestra(s)"
+msgstr ""
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
@@ -10402,42 +10383,42 @@ msgstr "Etiquetas de lote"
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/calculations/view.py:51
 msgid "listing_calculation_action_add"
-msgstr "Añadir"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/calculations/view.py:75
 msgid "listing_calculation_description"
-msgstr "Descripción"
+msgstr ""
 
 #. Default: "Formula"
 #: senaite/core/browser/controlpanel/calculations/view.py:82
 msgid "listing_calculation_formula"
-msgstr "Fórmula"
+msgstr ""
 
 #. Default: "Calculation"
 #: senaite/core/browser/controlpanel/calculations/view.py:68
 msgid "listing_calculation_title"
-msgstr "Cálculo"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/calculations/view.py:93
 msgid "listing_calculations_state_active"
-msgstr "Activo"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/calculations/view.py:111
 msgid "listing_calculations_state_all"
-msgstr "Todos"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/calculations/view.py:102
 msgid "listing_calculations_state_inactive"
-msgstr "Inactivo"
+msgstr ""
 
 #. Default: "Calculations"
 #: senaite/core/browser/controlpanel/calculations/view.py:58
 msgid "listing_calculations_title"
-msgstr "Cálculos"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/containertypes/view.py:51
@@ -11459,7 +11440,7 @@ msgstr "minutos"
 # senaite.app.listing: Saved filter presets — dirty indicator on the applied
 # preset
 msgid "modified"
-msgstr "modificado"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
@@ -11483,22 +11464,22 @@ msgstr "El instrumento no tiene ninguna interfaz de datos seleccionada"
 #. Default: "Keyword '${duplicate}' duplicate found for a Analysis Service"
 #: senaite/core/validators/interimfields.py:97
 msgid "no_dup_service_keyword_validator_error"
-msgstr "Se encontró la palabra clave duplicada '${duplicate}' para un Servicio de análisis"
+msgstr ""
 
 #. Default: "'${duplicate}' duplicates found"
 #: senaite/core/validators/interimfields.py:83
 msgid "no_dups_values_validator_error"
-msgstr "Se encontraron duplicados de '${duplicate}'"
+msgstr ""
 
 #. Default: "Wildcards for  are not allowed: ${wildcards}"
 #: senaite/core/validators/formula.py:45
 msgid "no_wildcards__error"
-msgstr "No se permiten comodines para : ${wildcards}"
+msgstr ""
 
 #. Default: "'${field_name}' is required"
 #: senaite/core/validators/interimfields.py:54
 msgid "non_blank_validator_error"
-msgstr "'${field_name}' es obligatorio"
+msgstr ""
 
 #. view."
 #. Default: "Layout view '${view}' not found. Set '${default}' as layout view."
@@ -11518,7 +11499,7 @@ msgstr "de"
 
 #: senaite/core/api/remarks.py:494
 msgid "original"
-msgstr "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
@@ -11526,7 +11507,7 @@ msgstr "Resumen"
 
 # senaite.app.listing: Saved filter presets — menu subtitle
 msgid "per listing"
-msgstr "por listado"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11608,7 +11589,7 @@ msgstr "Esta muestra ha sido enviada el ${date} por ${actor} "
 #. Default: "This sample has been disposed by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
 msgid "this_sample_has_been_disposed_by"
-msgstr "Esta muestra ha sido desechada por ${actor} el ${date}"
+msgstr ""
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11624,32 +11605,32 @@ msgstr "${H}:${M}"
 #. Default: "Accreditation"
 #: senaite/core/content/laboratory.py:170
 msgid "title_accreditation"
-msgstr "Acreditación"
+msgstr ""
 
 #. Default: "Accreditation Body Abbreviation"
 #: senaite/core/content/laboratory.py:149
 msgid "title_accreditation_body"
-msgstr "Abreviatura del organismo de acreditación"
+msgstr ""
 
 #. Default: "Accreditation Logo"
 #: senaite/core/content/laboratory.py:195
 msgid "title_accreditation_body_logo"
-msgstr "Logotipo de acreditación"
+msgstr ""
 
 #. Default: "Accreditation Body URL"
 #: senaite/core/content/laboratory.py:160
 msgid "title_accreditation_body_url"
-msgstr "URL del organismo de acreditación"
+msgstr ""
 
 #. Default: "Accreditation page header"
 #: senaite/core/content/laboratory.py:216
 msgid "title_accreditation_page_header"
-msgstr "Encabezado de la página de acreditación"
+msgstr ""
 
 #. Default: "Accreditation Reference"
 #: senaite/core/content/laboratory.py:182
 msgid "title_accreditation_reference"
-msgstr "Referencia de acreditación"
+msgstr ""
 
 #. Default: "Address"
 #: senaite/core/content/laboratory.py:88
@@ -11755,17 +11736,17 @@ msgstr "Este sitio fue construido usando el CMS/WCM de código abierto Plone."
 #. Default: "Description"
 #: senaite/core/content/calculation.py:228
 msgid "title_calculation_description"
-msgstr "Descripción"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/calculation.py:220
 msgid "title_calculation_title"
-msgstr "Nombre"
+msgstr ""
 
 #. Default: "Confidence Level %"
 #: senaite/core/content/laboratory.py:123
 msgid "title_confidence_level"
-msgstr "Nivel de confianza %"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/containertype.py:44
@@ -11845,7 +11826,7 @@ msgstr "Responsable"
 #. Default: "Color"
 #: senaite/core/content/label.py:68
 msgid "title_label_color"
-msgstr "Color"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/label.py:56
@@ -11860,12 +11841,12 @@ msgstr "Nombre"
 #. Default: "Laboratory Accredited"
 #: senaite/core/content/laboratory.py:136
 msgid "title_laboratory_accredited"
-msgstr "Laboratorio acreditado"
+msgstr ""
 
 #. Default: "Lab URL"
 #: senaite/core/content/laboratory.py:98
 msgid "title_laboratory_lab_url"
-msgstr "URL del laboratorio"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/labproduct.py:60
@@ -11945,7 +11926,7 @@ msgstr "Tipo de análisis"
 #. Default: "Manage Viewlets"
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
 msgid "title_manage_viewlets"
-msgstr "Gestionar viewlets"
+msgstr ""
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
@@ -12162,7 +12143,7 @@ msgstr "Periodo de conservación"
 #. Default: "Hazard categories"
 #: senaite/core/content/sampletype.py:178
 msgid "title_sampletype_hazard_categories"
-msgstr "Categorías de peligro"
+msgstr ""
 
 #. Default: "Hazardous"
 #: senaite/core/content/sampletype.py:166
@@ -12332,7 +12313,7 @@ msgstr "Separador decimal por defecto"
 #. Default: "Allow sample duplication"
 #: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
-msgstr "Permitir la duplicación de muestras"
+msgstr ""
 
 #. Default: "Require sample analyses"
 #: senaite/core/content/senaitesetup.py:349

--- a/src/senaite/core/locales/es/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es/LC_MESSAGES/senaite.core.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Spanish (https://app.transifex.com/senaite/teams/87045/es/)\n"
@@ -24,7 +24,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: es\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr " <p>El servidor de Identificadores (IDs) de Senaite LIMS proporciona identificadores secuenciales únicos para objetos como muestras, hojas de trabajo, peticiones de análisis, etc., en función del formato especificado para cada tipo de contenido.</p><p>La sintaxis es similar a la utlizada para el formateo de cadenas en Python, con variables predefinidas por tipo de contenido y con el incremento de los IDs a partir de un número de secuencia 'seq' para definir el número de dígitos a utilizar. Por ejemplo: '03d' para una secuencia de IDs de 001 a 999.</p><p>Los prefijos alfanuméricos para IDs se incluirán como se haya definido en el formato, p. WS para Hoja de trabajo en WS- {seq: 03d} produce identificadores para las hojas de trabajo de forma secuencial: WS-001, WS-002, WS-003, etc.</p><p>Las variables que se pueden usar son:<table><tr><th style='width:150px'>Tipo de contenido (Content Type)</th><th>Variables</th></tr><tr><td>Cliente</td><td>{clientId}</td></tr><tr><td>Año</td><td>{year}</td></tr><tr><td>Identificador de muestra</td><td>{sampleId}</td></tr><tr><td>Tipo de muestra</td><td>{sampleType}</td></tr><tr><td>Fecha prevista de muestreo</td><td>{samplingDate}</td></tr><tr><td>Fecha de muestreo</td><td>{dateSampled}</td></tr></table></p><p>Elementos de configuración:<ul><li>Formato:<ul><li>una cadena en formato Python construida a partir de variables predefinidas como sampleId, client, sampleType.</li><li>La variable especial 'seq' debe colocarse en último lugar de la cadena que define el formato</li></ul></li><li>Tipo de secuéncia: [Generada|Contador]</li><li>Contexto: si el tipo de secuéncia es 'Contador', proporciona el contexto para la función contador</li><li>Tipo de cuenta: [retroreferencia|contenida]</li><li>Referencia para cuenta: un parámetro para la función de conteo</li><li>Prefijo: prefijo predeterminado si no se proporciona el formato en cadena</li><li>Longitud de la división: la cantidad de partes que se incluirán en el prefijo</li></ul></p>"
 
@@ -33,6 +33,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} archivos adjuntos con un tamaño total de ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -58,6 +59,7 @@ msgid "%s has no '%s' column."
 msgstr "%s no tiene la columna '%s'."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Volver"
@@ -127,6 +129,10 @@ msgstr "*** Este es un correo electrónico generado automáticamente, por favor 
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr "-- Seleccionar --"
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr "... Selecciona un instrumento ..."
@@ -144,9 +150,9 @@ msgstr "Ir a la vista de configuración de plantillas de hojas de trabajo"
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Bienvenido a SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
-msgstr ""
+msgstr "<p>El servidor de ID proporciona ID secuenciales únicos para objetos como Muestras y Hojas de trabajo, etc., basándose en un formato especificado para cada tipo de contenido. El formato se construye de forma similar a la sintaxis de formato de Python, p. ej. <code>WS-{seq:03d}</code> produce <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code>, etc.</p><p>Los valores actuales de los contadores persistentes se gestionan en la <a href='ng'>vista del Generador de números</a>.</p><details class='id-server-cheatsheet'><summary>Variables disponibles</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Descripción</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Número de secuencia numérico, opcionalmente rellenado con ceros.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Contador alfanumérico, p. ej. <code>{alpha:2a3d}</code> genera AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Año actual de dos dígitos (p. ej. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Fecha actual como <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>ID de cliente (solo muestras).</td></tr><tr><td><code>{sampleType}</code></td><td>Prefijo del tipo de muestra.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Fechas de muestra (se aplican las especificaciones de <code>strftime</code> de Python).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>Para particiones/reanálisis/secundarias: el ID de la muestra principal.</td></tr><tr><td><code>{partition_count}</code></td><td>Contador de particiones por principal.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Contadores de reanálisis, secundarias y total de análisis.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Campos de configuración</summary><ul><li><strong>Formato</strong>: la plantilla de ID.</li><li><strong>Tipo de secuencia</strong>: <code>generated</code> usa el contador de números persistente; <code>counter</code> usa el recuento de objetos relacionados.</li><li><strong>Contexto</strong>: solo lo usa el tipo <code>counter</code>; el contexto con nombre al que se aplica el contador.</li><li><strong>Tipo de contador</strong>: <code>backreference</code> (obsoleto) o <code>contained</code>.</li><li><strong>Referencia del contador</strong>: nombre de la relación (backreference) o metatipo (contained).</li><li><strong>Prefijo</strong>: prefijo predeterminado si no hay ninguno en el formato.</li><li><strong>Longitud de división</strong>: cuántos segmentos del formato se convierten en el prefijo de la clave de almacenamiento. Determina cómo se particiona el contador (p. ej. por año, por tipo de muestra).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 
 #: bika/lims/content/calculation.py:133
 msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
@@ -202,7 +208,7 @@ msgid "Account Type"
 msgstr "Tipo de cuenta"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr "Contabilidad"
 
@@ -247,21 +253,21 @@ msgstr "Activar"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Activo/a"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Actor"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr "Nombre completo del actor"
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Nuevo..."
 
@@ -289,15 +295,19 @@ msgstr "Añadir duplicado"
 msgid "Add Samples"
 msgstr "Añadir muestras"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr "Añadir un comentario..."
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Añadir un campo de comentarios a todos los análisis"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "Añadir reglas de estilo CSS personalizadas para el logo (e.g. height:15px;width;150px;)"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "Añadir etiquetas seleccionables por defecto"
 
@@ -310,8 +320,11 @@ msgstr "Añadir nuevo fichero adjunto"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Añadir uno o más archivos adjuntos con información adicional sobre la muestra."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr "Añadir o quitar etiquetas en las muestras seleccionadas"
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Añadir comentarios"
 
@@ -375,13 +388,21 @@ msgstr "Se muestran todos los análisis acreditados"
 msgid "All Analyses of Service"
 msgstr "Todas las analíticas del Servicio de Análisis"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Todos los análisis asignados"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr "Todas las columnas están ocultas."
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Permitir ingreso manual de límite de detección"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr "Permitir entrada manual"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -399,11 +420,11 @@ msgstr "Permitir que un mismo usuario pueda verificar múltiples veces"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Permitir que un mismo usuario pueda verificar múltiples veces, pero no consecutivamente"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Permitir verificación de resultados por el mismo usuario"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr "Permitir el envío de resultados para análisis no asignados"
 
@@ -432,15 +453,31 @@ msgstr "Estados de muestra permitidos: {allowed_states}, "
 msgid "Analysed by"
 msgstr "Analizado por"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Análisis"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr "Análisis asignados a una hoja de trabajo, en espera de resultados"
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr "Análisis incluidos en un informe publicado"
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr "Análisis aún no asignados a una hoja de trabajo"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Análisis solicitados"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr "Análisis que han sido verificados"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -509,7 +546,7 @@ msgstr "Condiciones de análisis"
 msgid "Analysis conditions updated: {}"
 msgstr "Condiciones de análisis actualizadas: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Marque la casilla si desea que se puedan modificar los rangos de validez para cada análisis de forma individualizada y directamente desde la vista de muestra."
 
@@ -546,7 +583,7 @@ msgstr "Debe indicar un analista."
 msgid "Any"
 msgstr "Sin definir"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "Apariencia"
 
@@ -557,6 +594,10 @@ msgstr "Aplicar cambios"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Aplicar plantilla"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr "Aplicar este filtro"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -570,19 +611,15 @@ msgstr "Número de lote"
 msgid "Assign"
 msgstr "Asignar"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Asignado"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Asignado a: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Pendientes de asignar"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -596,7 +633,7 @@ msgstr "Adjuntar a la muestra"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr "Archivo '{filename}' adjuntado a la hoja de trabajo {worksheet}"
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr "Etiquetas asignadas a este contenido"
 
@@ -684,11 +721,15 @@ msgstr "Generación automática de identificadores para contenidos de tipo Dexte
 msgid "Auto-Import Logs"
 msgstr "Registro de importaciones automáticas"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr "Aplicar automáticamente al abrir"
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Partición automática a la recepción"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Recepción automática de muestras"
 
@@ -696,15 +737,15 @@ msgstr "Recepción automática de muestras"
 msgid "Autofill"
 msgstr "Auto-rellenado"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr "Impresión automática de etiquetas"
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Cierre de sesión automático"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr "Verificación automática de muestras"
 
@@ -755,7 +796,7 @@ msgstr "Lote"
 msgid "Batch Book"
 msgstr "Libro de lotes"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID Lote"
 
@@ -785,6 +826,10 @@ msgstr "Tenga en cuenta que los rangos provistos en el archivo de hoja de cálcu
 msgid "Bearing"
 msgstr "Retraso"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr "Semestral"
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Dirección de facturación"
@@ -805,7 +850,7 @@ msgstr "Marca"
 msgid "Bulk Discount"
 msgstr "Descuento por volumen"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Descuento por volumen aplicable"
@@ -823,19 +868,19 @@ msgstr "Teléfono del negocio"
 msgid "Business address"
 msgstr "Dirección profesional"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr "Por valor a mostrar, ascendente"
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr "Por valor a mostrar, descendente"
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr "Por valor, ascendente"
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr "Por valor, descendente"
 
@@ -843,12 +888,12 @@ msgstr "Por valor, descendente"
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
-msgstr ""
+msgstr "Contactos en CC"
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "Correos electrónicos en copia"
 
@@ -904,23 +949,23 @@ msgstr "Calibraciones"
 msgid "Calibrator"
 msgstr "Calibrador"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Puede verificar a pesar de que también ha tramitado el resultado"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Puede verificar a pesar que ya lo verificó anteriormente"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Cancelados"
 
@@ -940,15 +985,15 @@ msgstr "No se puede invalidar ${sample_id}: ${error}"
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr "Error al enviar correo electrónico para la muestra ${sample_id}: ${error}"
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "No se puede verificar, ultima verificación realizada por el usuario actual"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "No se puede verificar, los resultados fueron enviados por el usuario actual"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "No se puede verificar, ya fue verificado por el usuario actual"
 
@@ -974,7 +1019,7 @@ msgstr "Cataloga contenidos de tipo Dexterity en múltiples catálogos"
 msgid "Catalogue Number"
 msgstr "Número de catálogo"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Categorizar los servicios de análisis"
 
@@ -1006,11 +1051,11 @@ msgid "Changes Saved"
 msgstr "Cambios guardados."
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Cambios guardados."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Los cambios se propagarán a particiones"
 
@@ -1047,31 +1092,31 @@ msgstr "Casilla de verificación"
 msgid "Choices"
 msgstr "Opciones para selección"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr "Seleccione la plantilla predeterminada para etiquetas 'grandes'. Nota: Las etiquetas 'grandes' específicas por tipo de muestra se configuran en el tipo de muestra correspondiente."
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr "Seleccione la plantilla predeterminada para etiquetas 'grandes'.<br/><strong>Nota:</strong> Las etiquetas 'grandes' específicas por tipo de muestra se configuran en el tipo de muestra correspondiente."
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr "Seleccione la plantilla predeterminada para etiquetas 'pequeñas'. Nota: Las etiquetas 'pequeñas' específicas por tipo de muestra se configuran en el tipo de muestra correspondiente."
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr "Seleccione la plantilla predeterminada para etiquetas 'pequeñas'.<br/><strong>Nota:</strong> Las etiquetas 'pequeñas' específicas por tipo de muestra se configuran en el tipo de muestra correspondiente."
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Seleccione el tipo de verificación múltiple a aplicar para un mismo usuario."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr "Seleccione cuándo se deben imprimir las etiquetas automáticamente:<br/><ul><li><strong>Registro:</strong> Las etiquetas se imprimen automáticamente cuando se crean nuevas muestras.</li><li><strong>Recepción:</strong> Las etiquetas se imprimen automáticamente cuando se reciben las muestras.</li><li><strong>Nunca:</strong> Desactiva la impresión automática de etiquetas.</li></ul>"
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr "Seleccione cuándo se deben imprimir las etiquetas automáticamente:<br/><ul><li><strong>Registro:</strong> Las etiquetas se imprimen automáticamente cuando se crean nuevas muestras.</li><li><strong>Recepción:</strong> Las etiquetas se imprimen automáticamente cuando se reciben las muestras.</li><li><strong>Nunca:</strong> Desactiva la impresión automática de etiquetas.</li></ul>"
 
@@ -1084,20 +1129,34 @@ msgstr "Ciudad"
 msgid "Classic"
 msgstr "Clásico"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr "Borrar filtro"
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr "Borrar búsqueda"
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "Limpiar selección"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Haga clic para desplegar esta categoría"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr "Haga clic para liberar este filtro"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "Haga clic para alternar la visibilidad o arrastre y suelte para cambiar el orden"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Cliente"
@@ -1109,7 +1168,7 @@ msgstr "ID Lote de cliente"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID del cliente"
 
@@ -1121,7 +1180,7 @@ msgstr "Página de inicio del cliente"
 msgid "Client Name"
 msgstr "Nombre del cliente"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Pedido de cliente"
 
@@ -1131,7 +1190,7 @@ msgstr "Pedido de cliente"
 msgid "Client Order Number"
 msgstr "Número de pedido de cliente"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Ref. del cliente"
 
@@ -1140,7 +1199,7 @@ msgstr "Ref. del cliente"
 msgid "Client Reference"
 msgstr "Referencia del cliente"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "ID de muestra del cliente"
 
@@ -1219,7 +1278,7 @@ msgstr "Falta la columna '{}'"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
 msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
-msgstr ""
+msgstr "La columna {} de la fila de encabezado no tiene nombre. Elimine las columnas vacías de la hoja de cálculo y súbala de nuevo."
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
@@ -1233,7 +1292,7 @@ msgstr "Comentarios"
 msgid "Comments or results interpretation"
 msgstr "Comentarios o interpretación de resultados"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "ID comercial"
@@ -1271,6 +1330,10 @@ msgstr "Configuración de la sección de cabecera de muestra"
 msgid "Configuration restored to default values."
 msgstr "La configuración se ha restaurado a los valores por defecto."
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr "Configurar"
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr "Configurar las columnas de la tabla"
@@ -1289,7 +1352,7 @@ msgstr "Confirme la contraseña"
 msgid "Considerations"
 msgstr "Consideraciones"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contacto"
@@ -1333,7 +1396,7 @@ msgstr "Recipientes de muestras"
 msgid "Contents of the file {}"
 msgstr "Contenido del archivo {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr "Contexto"
 
@@ -1366,25 +1429,29 @@ msgstr "Copiar servicio de análisis"
 msgid "Copy from"
 msgstr "Copiar desde"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr "Copiar el valor de la columna mostrada a las demás columnas de la derecha"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr "Copiar el valor de la primera muestra a las demás"
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Copiar a nuevo"
 
 #: senaite/core/browser/idserver/view.py:131
 msgid "Could not convert {} value(s) to integer: {}"
-msgstr ""
+msgstr "No se pudieron convertir {} valor(es) a entero: {}"
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
-msgstr ""
+msgstr "No se pudieron crear la(s) siguiente(s) muestra(s) debido a conflictos de transacción, vuelva a intentarlo: ${rows}"
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
+msgstr "No se pudo vincular el usuario: ${error}"
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
@@ -1400,13 +1467,13 @@ msgstr "No ha sido posible transicionar las muestras al estado muestreado"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:103
 msgid "Counter <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Contador <span class=\"sort-indicator\" />"
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr "Referencia de contador"
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr "Tipo de contador"
 
@@ -1419,7 +1486,7 @@ msgstr "País"
 msgid "Create Invoice PDF"
 msgstr "Crear factura en PDF"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Crear particiones"
 
@@ -1427,7 +1494,7 @@ msgstr "Crear particiones"
 msgid "Create SENAITE Site"
 msgstr "Crear un sitio SENAITE"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr "Crear hoja de trabajo"
 
@@ -1439,7 +1506,7 @@ msgstr "Crear un nuevo sitio SENAITE"
 msgid "Create a new User"
 msgstr "Crear un nuevo usuario"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr "Crear una hoja de trabajo con las muestras selecionadas"
 
@@ -1469,7 +1536,7 @@ msgid "Created {} partitions: {}"
 msgstr "Creadas {} particiones: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Creado por"
 
@@ -1478,7 +1545,7 @@ msgstr "Creado por"
 msgid "Criteria"
 msgstr "Criterios"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1486,13 +1553,21 @@ msgstr "Moneda"
 msgid "Current"
 msgstr "En curso"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr "La vista actual difiere de la guardada"
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Separador decimal personalizado"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "Límite de Detección"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr "Diario"
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1539,23 +1614,23 @@ msgstr "Fecha de modificación"
 msgid "Date Opened"
 msgstr "Fecha de apertura"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Fecha de conservación"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Fecha de impresión"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Fecha de publicación"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Fecha de recepción"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Fecha de registro"
 
@@ -1567,11 +1642,11 @@ msgstr "Fecha de petición"
 msgid "Date Sample Received"
 msgstr "Fecha de recepción"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Fecha de muestreo"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Fecha de verificación"
 
@@ -1613,7 +1688,7 @@ msgstr "Fecha del certificado de calibración"
 msgid "Date when the certificate is valid"
 msgstr "Fecha de inicio de validez del certificado de calibración"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr "Fecha en que se imprimió el informe"
 
@@ -1636,13 +1711,13 @@ msgstr "Desactivado hasta la próxima calibración"
 msgid "Deactivate"
 msgstr "Desactivar"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Separador decimal a utilizar en los informes de este Cliente."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
-msgstr ""
+msgstr "Contactos en CC predeterminados para las muestras nuevas. Si se establecen, estos contactos se seleccionan automáticamente en el formulario de creación de muestras."
 
 #: bika/lims/content/analysisservice.py:165
 msgid "Default Container"
@@ -1652,7 +1727,7 @@ msgstr "Recipiente por defecto"
 msgid "Default Department"
 msgstr "Departamento predeterminado"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Direcciones de correo electrónico a las que se enviará una copia de los informes de resultados para este cliente"
 
@@ -1664,7 +1739,7 @@ msgstr "Instrumento analítico predeterminado"
 msgid "Default Method"
 msgstr "Método predeterminado"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr "Número predeterminado de copias"
 
@@ -1672,20 +1747,20 @@ msgstr "Número predeterminado de copias"
 msgid "Default Preservation"
 msgstr "Método de conservación predeterminado"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr "Plantilla de etiqueta predeterminada"
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr "Contacto predeterminado para nuevas muestras. Si se establece, este contacto se seleccionará automáticamente en el formulario de registro de muestra."
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Número predeterminado de muestras a ser añadidas"
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Separador decimal predeterminado"
 
@@ -1697,7 +1772,7 @@ msgstr "Instrumento utilizado por defecto en analíticas de este tipo"
 msgid "Default large sticker"
 msgstr "Plantilla predeterminada para la etiqueta de código barras grande"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Orientación predeterminada en la vista de hojas de trabajo"
 
@@ -1729,15 +1804,15 @@ msgstr "El resultado predeterminado tiene que ser una de las opciones de resulta
 msgid "Default result to display on result entry"
 msgstr "Resultado a mostrar por defecto en la vista de entrada de resultados"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Periodo de retención por defecto de la muestra"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Formato predeterminado de notación científica en los informes"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Formato predeterminado de notación científica para los resultados"
 
@@ -1749,7 +1824,7 @@ msgstr "Plantilla predeterminada para la etiqueta de código de barras pequeña"
 msgid "Default timezone"
 msgstr "Zona horaria predeterminada"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Tiempo requerido predeterminado para el procesado de análisis."
 
@@ -1758,7 +1833,7 @@ msgstr "Tiempo requerido predeterminado para el procesado de análisis."
 msgid "Default value"
 msgstr "Valor predeterminado"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "Número predeterminado de muestras (columnas) en la página de registro de muestra."
 
@@ -1782,7 +1857,7 @@ msgstr "Precisión al convertir el resultado a notación exponencial. Valor pred
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Persona que realizará el muestreo en la fecha programada"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr "Defina la plantilla del cuerpo del correo electrónico que se enviará automáticamente a los contactos principales y a los responsables de laboratorio cuando se invalide una muestra. Los marcadores de posición disponibles son: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 
@@ -1794,9 +1869,18 @@ msgstr "Etiquetas de código de barras predeterminadas para éste tipo de muestr
 msgid "Degrees"
 msgstr "Grados"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
 msgstr "Eliminar"
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr "Eliminar filtro"
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
+msgstr "¿Eliminar este comentario?"
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
@@ -1824,9 +1908,9 @@ msgstr "Departamentos"
 msgid "Dependent Analyses"
 msgstr "Análisis dependientes"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Descripción"
 
@@ -1873,7 +1957,11 @@ msgstr "Desactivar la consulta automática de transiciones"
 msgid "Disable multi-verification for the same user"
 msgstr "No permitir la verificación múltiple por un mismo usuario"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr "Descartar los cambios y restaurar el preajuste"
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Descuento"
@@ -1891,7 +1979,7 @@ msgstr "Enviar"
 msgid "Dispatch samples"
 msgstr "Envío de muestras"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Enviado"
@@ -1916,15 +2004,23 @@ msgstr "El valor a mostrar tiene que ser único"
 msgid "Display a Detection Limit selector"
 msgstr "Mostrar el selector de límites de detección"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr "Mostrar particiones de muestra a los clientes"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Eliminar"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr "Desechar muestras"
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminados"
 
@@ -1994,11 +2090,15 @@ msgstr "Descargar PDF"
 msgid "Download selected reports"
 msgstr "Descargar los informes seleccionados"
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr "Arrastre para reordenar"
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Pendientes"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
@@ -2015,9 +2115,9 @@ msgstr "Duplicado"
 msgid "Duplicate Analysis"
 msgstr "Análisis duplicado"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
-msgstr ""
+msgstr "Formato de ID duplicado para el tipo de portal '${pt}' (filas ${a} y ${b}). Solo se usa la primera fila; elimine o combine el duplicado."
 
 #: bika/lims/content/worksheettemplate.py:59
 msgid "Duplicate Of"
@@ -2029,7 +2129,7 @@ msgstr "Análisis de muestras duplicadas de QC"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr ""
+msgstr "Duplicar muestra"
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
@@ -2041,7 +2141,7 @@ msgstr "Claves duplicadas en el campo de opciones"
 
 #: bika/lims/browser/workflow/analysisrequest.py:443
 msgid "Duplicated samples: {}"
-msgstr ""
+msgstr "Muestras duplicadas: {}"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpec.xml
 msgid "Dynamic Analysis Specification"
@@ -2063,6 +2163,7 @@ msgstr "P.ej., ENAC, Applus, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "Para cada interfaz de importación se puede indicar un directorio donde el sistema busque nuevos resultados a importar cada vez que se ejecute la vista <code>auto_import_results</code>."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Editar"
@@ -2077,21 +2178,21 @@ msgstr "Elevación"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Correo electrónico"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Dirección de correo electrónico"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr "Adjuntos del correo electrónico"
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr "Cuerpo del correo electrónico"
 
@@ -2099,27 +2200,27 @@ msgstr "Cuerpo del correo electrónico"
 msgid "Email Log"
 msgstr "Registro de correo electrónico"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr "Destinatarios del correo electrónico"
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr "Responsables del correo electrónico"
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr "Fecha de envío del correo electrónico"
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr "Asunto del correo electrónico"
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "Cuerpo del correo electrónico para enviar notificaciones de Invalidación"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr "Cuerpo del correo electrónico para enviar notificaciones de rechazo"
 
@@ -2132,17 +2233,21 @@ msgstr "Correo electrónico cancelado"
 msgid "Email notification"
 msgstr "Notificación por correo electrónico"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "Notificar por correo electrónico el rechazo de muestras"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr "Registro de envío de correos electrónicos"
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
 msgstr "El correo electrónico se ha enviado"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr "Vacío"
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2152,27 +2257,27 @@ msgstr "Las claves no pueden ser vacías"
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Activar el uso de múltiples instrumentos analíticos en hojas de trabajo."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Activar la funcionalidad de conservación de muestras"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "Activar las funcionalidad de especificaciones para muestras"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "Activar la funcionalidad de muestreo"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "Activar la funcionalidad de planificación periódica de muestreos"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr "Activar el registro global de auditoría"
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr "Activar el registro global de auditoría"
 
@@ -2180,9 +2285,17 @@ msgstr "Activar el registro global de auditoría"
 msgid "Enable sampling workflow for the created sample"
 msgstr "Activar el flujo de muestreo para la muestra creada"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "Activar la funcionalidad de seguimiento de impresión de informes de resultados"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr "Habilitar el flujo de trabajo de envío de muestras"
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr "Habilitar el flujo de trabajo de desecho de muestras"
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2205,7 +2318,7 @@ msgstr "Introduzca su dirección de correo electrónico. Es necesaria en caso de
 msgid "Enter discount percentage value"
 msgstr "Introducir el porcentaje de descuento"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr "Introduzca valores individuales para este campo por muestra"
 
@@ -2218,7 +2331,7 @@ msgstr "Introducir un porcentaje, p.ej. 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Introducir un porcentaje, p.ej. 14.0. Este porcentaje solo se aplicará al perfil de análisis y sobrescribirá el impuesto definido por defecto."
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Introducir un porcentaje, p.ej. 14.0. Este porcentaje se aplicará a todo el sistema, pero podrá ser sobrescrito individualmente para cada elemento."
 
@@ -2242,7 +2355,7 @@ msgstr "Introducir los detalles de cada uno de los servicios de análisis a copi
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Introducir los detalles sobre las acreditaciones del laboratorio. Los campos disponibles son los siguientes: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference <br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr "Introducir el resultado en formato decimal o notación científica, por ejemplo 0.00005 o 1e-5, 10000 o 1e5"
 
@@ -2254,15 +2367,15 @@ msgstr "Condiciones ambientales"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr "Publicación de resultados errónea: ${sample_id}"
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Evolución de análisis"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Evolución de muestras"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Evolución de hojas de trabajo"
 
@@ -2274,7 +2387,7 @@ msgstr "Ejemplo de cronjob para ejecutar la importación automática de resultad
 msgid "Example content"
 msgstr "Contenido de ejemplo"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Excluir de la factura"
 
@@ -2284,7 +2397,7 @@ msgstr "Excluir de la factura"
 msgid "Expected Result"
 msgstr "Resultado esperado"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Fecha esperada de muestreo"
 
@@ -2310,7 +2423,7 @@ msgstr "Fecha de caducidad"
 msgid "Exponential format precision"
 msgstr "Precisión en formato exponencial"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Límite del formato exponencial"
 
@@ -2318,7 +2431,7 @@ msgstr "Límite del formato exponencial"
 msgid "Export"
 msgstr "Exportar"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "No se ha podido cargar la etiqueta de impressión con el código de barras"
 
@@ -2405,7 +2518,7 @@ msgstr "Nombre de archivo"
 msgid "Filesize"
 msgstr "Tamaño del fichero"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr "Filtrar análisis por nombre..."
 
@@ -2419,7 +2532,19 @@ msgstr "Filtro por servicios de plantilla"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
-msgstr ""
+msgstr "Filtrar claves (compatible con regex)"
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr "Nombre del filtro"
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr "Filtrar muestras por este análisis"
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
+msgstr "Filtrar..."
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
@@ -2435,11 +2560,11 @@ msgstr "Primer nombre"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Valor numérico entre 0.0 y 1000.0 que indica el orden de los elementos. Los elementos duplicados se ordenan alfabéticamente."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr "Formato"
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Formato de los identificadores"
 
@@ -2462,13 +2587,17 @@ msgstr "Viernes"
 msgid "From"
 msgstr "Desde"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr "De ${from} a ${to} (actualizado cada 2 horas)"
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Nombre completo"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Nombre completo"
 
@@ -2476,7 +2605,7 @@ msgstr "Nombre completo"
 msgid "Function"
 msgstr "Función"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Muestra con fecha de asignación futura"
 
@@ -2509,7 +2638,7 @@ msgstr "Ir a la instancia"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Título de cortesía, como p.ej. Sr., Sra. o Dr."
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Agrupar los servicios de análisis por categorías. Esto es útil cuando la lista de servicios de análisis es demasiado larga"
 
@@ -2523,7 +2652,7 @@ msgid "Hazardous"
 msgstr "Peligroso"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Oculto"
@@ -2536,9 +2665,21 @@ msgstr "Campo Oculto"
 msgid "Hidden from report"
 msgstr "Oculto del informe"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
-msgstr ""
+msgstr "Ocultar campos adicionales"
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr "Ocultar todo"
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr "Ocultar historial"
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
+msgstr "Ocultar esta columna"
 
 #: bika/lims/config.py:140
 msgid "High"
@@ -2561,21 +2702,21 @@ msgstr "IBAN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr "Servidor de ID"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:17
 msgid "ID Server Settings"
-msgstr ""
+msgstr "Configuración del servidor de ID"
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr "Valores del servidor de IDs"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:113
 msgid "ID Template <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Plantilla de ID <span class=\"sort-indicator\" />"
 
 #: bika/lims/content/samplepoint.py:84
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
@@ -2589,15 +2730,15 @@ msgstr "Si está marcado, se mostrará una lista de selección junto al campo de
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Si está marcado, el instrumento no estará disponible hasta que se realice una calibración válida. Esta casilla de verificación se desactivará automáticamente."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Si está marcado, se mostrará un campo de texto libre cerca de cada análisis en la vista de entrada de resultados"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Si está marcado, el usuario que introduzco el resultado para un análisis también podrá verificarlo. Esta configuración solo tiene efecto para aquellos usuarios con un rol que les permite verificar los resultados (por defecto, gerentes, labmanagers y verificadores). La opción establecida aquí tiene prioridad sobre la opción establecida en \"Configuración general\""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Si está marcado, el usuario que introdució el resultado también podrá verificarlo. Esta configuración solo tiene efecto para los usuarios con un rol que les permite verificar los resultados (por defecto, gerentes, labmanagers y verificadores). Esta configuración puede anularse para una vista de edición de Análisis en un Servicio de Análisis determinada. Por defecto, está deshabilitado."
 
@@ -2605,7 +2746,7 @@ msgstr "Si está marcado, el usuario que introdució el resultado también podr�
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Si está marcado, el nombre del análisis se mostrará en cursiva."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "Si está marcado, este análisis y sus resultados no se mostrarán por defecto en los informes. Esta configuración también puede modificarse en perfiles de análisis y en muestras"
 
@@ -2645,7 +2786,7 @@ msgstr "Si está marcado, los reponsables del laboratorio no podrán asignar el 
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "Si tu fórmula necesita una función especial de una biblioteca Python externa, puedes importarla aquí. P.ej. si desea usar la función 'floor' del módulo 'math' de Python, agregue 'math' al campo Módulo y 'floor' al campo de función. El equivalente en Python sería 'from math import floor'. En tu cálculo, podrás usar 'floor ([Ca] + [Mg])'."
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr "Entrada immediata de resultados"
 
@@ -2676,11 +2817,11 @@ msgstr "Procedimiento de calibración en el laboratorio"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Inactivo"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Incluir y mostrar información de precios"
 
@@ -2877,7 +3018,7 @@ msgid "Internal Certificate"
 msgstr "Certificado de calibración interno"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "Uso interno"
 
@@ -2898,15 +3039,15 @@ msgstr "Plantillas de interpretación de resultados"
 msgid "Interval"
 msgstr "Intervalo"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Invalidadas"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
-msgstr ""
+msgstr "Formato de ID no válido en la fila ${i} ('${pt}'): ${err}"
 
 #: senaite/core/content/person.py:236
 msgid "Invalid email address"
@@ -2967,15 +3108,15 @@ msgstr "Facturar a"
 msgid "Invoice {} created"
 msgstr "Factura {} creada"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "No se ha especificado fecha de fin para el lote de facturación"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "No se ha especificado fecha de inicio para el lote de facturación"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "Lote de facturación sin título"
 
@@ -2987,7 +3128,7 @@ msgstr "Cargo"
 msgid "Job title"
 msgstr "Cargo"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr "Mantener el orden indicado arriba"
 
@@ -2997,11 +3138,11 @@ msgstr "Clave"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:98
 msgid "Key <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Clave <span class=\"sort-indicator\" />"
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Palabra clave"
 
@@ -3017,6 +3158,10 @@ msgstr "La palabra clave es obligatoria"
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Palabras clave"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr "Palabras clave de los análisis contenidos en la muestra"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3061,8 +3206,8 @@ msgstr "Productos del laboratorio"
 msgid "Lab URL"
 msgstr "URL del laboratorio"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Etiqueta"
@@ -3071,7 +3216,7 @@ msgstr "Etiqueta"
 msgid "Label configuration"
 msgstr "Configuración de etiquetas"
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr "Nombres de etiquetas deben ser unicos"
 
@@ -3079,13 +3224,13 @@ msgstr "Nombres de etiquetas deben ser unicos"
 msgid "Label schema extender"
 msgstr "Etiquetado de contenido"
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr "Contenidos etiquetados"
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr "Etiquetas"
 
@@ -3098,7 +3243,7 @@ msgstr "Laboratorio"
 msgid "Laboratory Accredited"
 msgstr "Laboratorio acreditado"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Días laborables del Laboratorio"
 
@@ -3110,7 +3255,7 @@ msgstr "Idioma"
 msgid "Large Sticker"
 msgstr "Etiqueta grande"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr "Plantilla de etiqueta grande"
 
@@ -3122,11 +3267,11 @@ msgstr "Últimos registros de importación automática"
 msgid "Last Login Time"
 msgstr "Último registro de inicio de sesión"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Con retraso"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Análisis con retraso"
 
@@ -3172,15 +3317,15 @@ msgstr "Vincular usuario"
 msgid "Link an existing User"
 msgstr "Linka un usuario existente"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr "Lista con contenidos etiquetados"
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr "Lista de resultados predefinidos para su selección. El usuario no podrá introducir un resultado distinto de los predefinidos."
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr "Lista de razones de rechazo predefinidas. Introduzca una razón por línea."
 
@@ -3202,11 +3347,11 @@ msgstr "Documento de la certificación"
 
 # senaite.core: Sidebar loading state
 msgid "Loading navigation..."
-msgstr ""
+msgstr "Cargando navegación..."
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
-msgstr ""
+msgstr "Cargando..."
 
 #: senaite/core/browser/clients/client/attachments/view.py:79
 #: senaite/core/browser/controlpanel/contacts/view.py:70
@@ -3232,6 +3377,14 @@ msgstr "Tipo de Ubicación"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Ubicación donde se archiva el conjunto de documentos"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr "Bloquear"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr "Bloqueado"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3295,13 +3448,13 @@ msgstr "Hombre"
 msgid "Manage Analyses"
 msgstr "Administrar análisis"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "Configurar los campos del formulario"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:12
 msgid "Manage Number Generator"
-msgstr ""
+msgstr "Gestionar el generador de números"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:21
 msgid "Manage Partitions"
@@ -3319,9 +3472,9 @@ msgstr "Configurar los campos del formulario para Muestras"
 msgid "Manage linked User"
 msgstr "Administrar usuario vinculado"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
-msgstr ""
+msgstr "Gestionar campos de muestra"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:38
 msgid "Manage the order and visibility of the fields displayed in analysis request add forms."
@@ -3343,7 +3496,7 @@ msgstr "Correo del responsable"
 msgid "Manager Phone"
 msgstr "Teléfono del responsable"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Manual"
 
@@ -3372,7 +3525,7 @@ msgstr "Fabricantes"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "Marque la muestra solo para uso interno. Esto significa que solo es accesible para el personal del laboratorio y no para los clientes."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3387,7 +3540,7 @@ msgstr "Tiempo máximo"
 msgid "Max operator"
 msgstr "Operador max"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3422,15 +3575,15 @@ msgid "Member Discount"
 msgstr "Descuento para miembros"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "% de descuento para clientes habituales"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Aplicar descuento de cliente habitual"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Miembro registrado y vinculado al contacto actual."
 
@@ -3438,7 +3591,7 @@ msgstr "Miembro registrado y vinculado al contacto actual."
 msgid "Message sent to {}, "
 msgstr "Mensaje enviado a {},"
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr "Metadatos"
 
@@ -3469,7 +3622,7 @@ msgstr "Inicial de segundo nombre"
 msgid "Middle name"
 msgstr "Segundo nombre"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3480,7 +3633,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr "Operador min"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3498,7 +3651,7 @@ msgstr "Tamaño mínimo de 5 caracteres"
 msgid "Minimum Volume"
 msgstr "Volumen mínimo"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Número mínimo de resultados para los cálculos estadísticos de QC"
 
@@ -3529,6 +3682,10 @@ msgstr "Módulo"
 msgid "Monday"
 msgstr "Lunes"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr "Mensual"
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr "Se encontró más de un análisis para {sid} y la clave '{keyword}'"
@@ -3542,11 +3699,11 @@ msgstr "Comportamiento de Catálogo múltiple para contenidos de Dexterity"
 msgid "Multi Results"
 msgstr "Multi-resultados"
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "Tipo de verificación múltiple"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Se requiere verificación múltiple"
 
@@ -3582,13 +3739,17 @@ msgstr "Mi Organización"
 msgid "My Profile"
 msgstr "Mi Perfil"
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr "Mi filtro"
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "Código Cuenta Cliente (IBAN/CCC/BIC)"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nombre"
 
@@ -3600,9 +3761,13 @@ msgstr "Nueva configuración LIMS"
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
 msgstr "Los nuevos rangos no se aplicarán ni a los análisis nuevos ni a los actuales. Vuelva a asignar la especificación si desea aplicar los últimos cambios."
 
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
+msgstr "Más recientes primero"
+
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Siguiente ID <span class=\"sort-indicator\" />"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:168
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -3642,6 +3807,10 @@ msgstr "No ha seleccionado ningún subgrupo"
 msgid "No action defined."
 msgstr "No hay ninguna acción definida"
 
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr "No hay acciones disponibles. Póngase en contacto con el responsable de su laboratorio para que le asigne permisos."
+
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
 msgstr "No se encontraron análisis para {sid} y la clave '{keyword}'"
@@ -3677,7 +3846,7 @@ msgstr "No ha seleccionado ningún servicio de análisis."
 
 #: senaite/core/browser/idserver/view.py:135
 msgid "No changes"
-msgstr ""
+msgstr "Sin cambios"
 
 #: senaite/core/browser/workflow/worksheet.py:50
 msgid "No changes made"
@@ -3688,13 +3857,17 @@ msgstr "No se han realizado cambios"
 msgid "No changes made."
 msgstr "Sin cambios."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr "No hay datos para el período seleccionado"
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "No se ha indicado fecha"
 
 #: bika/lims/browser/workflow/analysisrequest.py:435
 msgid "No duplicate created"
-msgstr ""
+msgstr "No se creó ningún duplicado"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:135
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:138
@@ -3732,6 +3905,16 @@ msgstr "No ha seleccionado ningún elemento"
 msgid "No items selected."
 msgstr "No ha seleccionado ningún elemento."
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr "No hay coincidencias en las columnas ocultas."
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr "No hay coincidencias en las columnas visibles."
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "No se han creado ítems nuevos."
@@ -3739,6 +3922,10 @@ msgstr "No se han creado ítems nuevos."
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "No se ha creado ninguna partición"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr "Aún no hay comentarios"
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3755,6 +3942,10 @@ msgstr "Ninguna muestra fue rechazada"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Sin flujo de trabajo de muestreo"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr "Aún no hay filtros guardados."
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3782,7 +3973,7 @@ msgstr "No hay análisis visibles para esta muestra"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Ninguno"
 
@@ -3798,11 +3989,11 @@ msgstr "No se pueden actualizar las condiciones de análisis: {}"
 msgid "Not defined"
 msgstr "Sin definir"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr "No impreso"
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "No establecido"
@@ -3823,7 +4014,7 @@ msgstr "Nota: esta confguración es global y afecta a las vistas de todas las mu
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "Nota: También puede arrastrar y soltar las filas de archivos adjuntos para cambiar el orden en que aparecen en el informe."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr "Notificaciones"
 
@@ -3835,7 +4026,7 @@ msgstr "Número de columnas"
 msgid "Number"
 msgstr "Número"
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Número de análisis"
 
@@ -3851,16 +4042,16 @@ msgstr "Número de copias"
 msgid "Number of prominent columns"
 msgstr "Número de columnas prominentes"
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Número de verificaciones necesarias"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Número de verificaciones requeridas antes de que un resultado determinado se considere 'verificado'. Esta configuración se puede anular para una vista de edición de análisis en un servicio de análisis. Por defecto, 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Número de verificaciones necesarias de diferentes usuarios antes de que un resultado determinado para este análisis se considere como 'verificado'. La opción establecida aquí tiene prioridad sobre la opción establecida en la Configuración general."
 
@@ -3871,6 +4062,10 @@ msgstr "Número de columnas estándar"
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
 msgstr "Numérico"
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
+msgstr "Más antiguos primero"
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -3888,11 +4083,11 @@ msgstr "Solo es posible renderizar imágenes en el informe de resultados"
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr "Solo se muestran los instrumentos que tienen configurada una interfaz de importación"
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr "Solo se consideran los días laborables del laboratorio para el cálculo del tiempo de respuesta del análisis."
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "Solo se consideran los días laborables de laboratorio para el cálculo del tiempo de respuesta del análisis."
 
@@ -3900,13 +4095,13 @@ msgstr "Solo se consideran los días laborables de laboratorio para el cálculo 
 msgid "Only to empty or zero fields"
 msgstr "Solo campos sin valor o con valor cero"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Abierto"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr "Abierto / Pendiente de verificar / Verificado / Total"
 
@@ -3914,9 +4109,17 @@ msgstr "Abierto / Pendiente de verificar / Verificado / Total"
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Open Source Web based Laboratory Information Management System"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr "Hojas de trabajo abiertas"
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "Abra el formulario de correo electrónico para enviar los informes seleccionados a los destinatarios. Esto también publicará las muestras contenidas de los informes después de que el correo electrónico se haya enviado correctamente."
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr "Hojas de trabajo abiertas con análisis en espera de resultados"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3943,7 +4146,7 @@ msgstr "Otras razones"
 msgid "Other reasons:"
 msgstr "Otras razones:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Otro estado"
 
@@ -3965,11 +4168,11 @@ msgstr "Sobreescribir los resultados ya existentes del analisis"
 msgid "Override non-empty analysis results, also with empty"
 msgstr "Sobreescribir resultados de análisis no vacíos, incluidos con vacíos"
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr "PDF"
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr "Archivo PDF del informe"
 
@@ -4001,7 +4204,7 @@ msgstr "% de error permitido"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:23
 msgid "Persistent counters used by the ID Server. Adjust a counter to change the next ID that will be issued for the matching prefix. Setting a counter to 0 removes the entry from the storage."
-msgstr ""
+msgstr "Contadores persistentes utilizados por el servidor de ID. Ajuste un contador para cambiar el siguiente ID que se emitirá para el prefijo coincidente. Establecer un contador en 0 elimina la entrada del almacenamiento."
 
 #: bika/lims/browser/clientfolder.py:81
 #: bika/lims/browser/templates/batch_publish.pt:68
@@ -4066,11 +4269,11 @@ msgstr "Proporcione un comentario que explique el motivo de invalidación de la 
 msgid "Please provide the reason for invalidating the sample."
 msgstr "Proporcione el motivo de invalidación de la muestra."
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Seleccione un usuario de la lista"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr "Seleccione una plantilla de etiqueta"
 
@@ -4083,6 +4286,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr "Por favor seleccione el número de particiones a crear y pulse el botón de previsualización"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr "Por favor, indique el motivo del envío"
 
@@ -4102,12 +4306,16 @@ msgstr "Por favor utilice el formato siguiente para las opciones de selección: 
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr "Por favor escriba un comentario indicando donde se envían las muestras"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr "Escriba un comentario indicando dónde se desecha(n) la(s) muestra(s) listada(s)"
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Punto de muestreo"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr "Tipo de portal"
 
@@ -4146,31 +4354,31 @@ msgstr "Precisión en el número de decimales"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Precisión como el número de dígitos significativos en función del valor de la incertidumbre. La posición decimal viene determinada por el primer número distinto de cero del valor de la incertidumbre. En esa posición, el sistema redondea el valor de la incertidumbre y del resultado. Por ejemplo, para un resultado de 5.243 y un valor de incertidumbre de 0.22, el sistema formatea el resultado como 5.2 ±0.2. Cuando el resultado no está dentro de ningún rango de incertidumbre especificado, el sistema trunca el resultado en función de la precisión decimal fija indicada."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr "Resultados predefinidos"
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Marcador decimal preferida para informes."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Marca decimal preferida para los resultados"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "Diseño de la vista de entada de resultados. El diseño clásico muestra las muestras en filas y los análisis en columnas. El diseño transpuesto muestra las muestras en columnas y los análisis en filas."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Formato de notación científica para informes"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Formato de notación científica para los resultados"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr "Prefijo"
 
@@ -4203,7 +4411,7 @@ msgstr "Método de conservación por tipo de muestra"
 msgid "Preserve"
 msgstr "Conservar"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Conservador"
 
@@ -4220,11 +4428,11 @@ msgstr "Preventivo"
 msgid "Preventive maintenance procedure"
 msgstr "Procedimiento de mantenimiento preventivo"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "Previsualizar"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4252,7 +4460,7 @@ msgstr "Lista de precios"
 msgid "Pricelists"
 msgstr "Listas de precios"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr "Contacto principal"
 
@@ -4261,7 +4469,7 @@ msgstr "Contacto principal"
 msgid "Primary Sample"
 msgstr "Muestra Primaria"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4283,11 +4491,11 @@ msgstr "Fecha de impresión:"
 msgid "Print pricelist"
 msgstr "Imprimir la lista de precios"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Imprimir pegatinas"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Impreso"
 
@@ -4300,7 +4508,7 @@ msgstr "Impreso en"
 msgid "Priority"
 msgstr "Prioridad"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Perfil de análisis"
 
@@ -4324,7 +4532,7 @@ msgstr "Nombre del perfil"
 msgid "Profile keyword must be unique"
 msgstr "La clave del perfil debe ser única"
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Progreso"
 
@@ -4333,7 +4541,7 @@ msgstr "Progreso"
 msgid "Prominent fields"
 msgstr "Campos destacados"
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "ID de protocolo"
 
@@ -4341,7 +4549,7 @@ msgstr "ID de protocolo"
 msgid "Province"
 msgstr "Provincia"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr "Modos de publicación"
 
@@ -4350,8 +4558,12 @@ msgstr "Modos de publicación"
 msgid "Publish"
 msgstr "Publicar"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr "Publicar informes"
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Publicadas"
@@ -4367,6 +4579,10 @@ msgstr "Fecha de publicación"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Resultados publicados"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr "Muestras publicadas cuyos informes aún no se han impreso"
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4388,6 +4604,14 @@ msgstr "Resultados QC"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "ID Muestra QC"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr "Trimestral"
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr "Acciones rápidas"
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4413,7 +4637,7 @@ msgstr "Introduzca de nuevo la clave. Asegúrese que las claves coinciden."
 msgid "Reasons for rejection"
 msgstr "Motivos de rechazo"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Reasignar"
 
@@ -4423,32 +4647,36 @@ msgstr "Disponible"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr ""
+msgstr "Volver a adjuntar"
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr "Recalcular"
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Recibir"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Recepcionadas"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr "Muestras recibidas con análisis en espera de resultados"
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Pendientes de recibir"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr "Destinatario"
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Destinatarios"
 
@@ -4499,11 +4727,15 @@ msgstr "Valores de referencia"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Los valores para las muestras de referencia son cero o 'blanco'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registro"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr "Registrar muestras"
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4529,9 +4761,9 @@ msgstr "Rechazar análisis"
 msgid "Reject samples"
 msgstr "Rechazar muestras"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Rechazado"
 
@@ -4547,7 +4779,7 @@ msgstr "Muestras rechazadas"
 msgid "Rejected {} samples: {}"
 msgstr "Rechazadas {} muestras: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr "Razones de rechazo"
 
@@ -4608,9 +4840,17 @@ msgstr "IP Remoto"
 msgid "Remove"
 msgstr "Eliminar"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr "Quitar este análisis del filtro"
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
-msgstr ""
+msgstr "Se eliminaron {} clave(s): {}"
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
+msgstr "Cambiar el nombre del filtro"
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
@@ -4645,11 +4885,11 @@ msgstr "ID de informe"
 msgid "Report identification number"
 msgstr "Número de identificación de informe"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr "Metadatos del informe"
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr "Destinatarios del informe"
 
@@ -4661,7 +4901,7 @@ msgstr "Cargar informe"
 msgid "Republish"
 msgstr "Volver a publicar"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "Republicado después de la última impresión"
 
@@ -4670,7 +4910,7 @@ msgstr "Republicado después de la última impresión"
 msgid "Request ID"
 msgstr "ID de la solicitud"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Solicitar nuevos análisis"
 
@@ -4686,24 +4926,37 @@ msgstr "Volumen necesario"
 msgid "Reset"
 msgstr "Reset"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr "Restablecer la visibilidad y el orden de las columnas a los valores predeterminados"
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr "Inicializar las columnas"
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr "Restablecer las columnas y el orden predeterminados"
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr "Restablecer vista"
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
 msgstr "Responsables"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr "Restaurar"
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr "Restringir el acceso a la hoja de trabajo a los analistas asignados"
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr "Restringir la gestión de hojas de trabajo a los responsables de laboratorio"
 
@@ -4728,15 +4981,15 @@ msgstr "El valor del resultado tiene que ser numérico"
 msgid "Result Value must be unique"
 msgstr "El valor del resultado tiene que ser único"
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Resultado en el límite del rango"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "El resultado está fuera de rango"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr "El rango de resultados es diferente de la especificación: {}"
 
@@ -4744,7 +4997,7 @@ msgstr "El rango de resultados es diferente de la especificación: {}"
 msgid "Result type"
 msgstr "Tipo de resultado"
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Los resultados con al menos este número de dígitos significativos se muestran en notación científica con la letra 'e' para indicar el exponente. La precisión se puede configurar en los servicios de análisis individuales."
 
@@ -4760,16 +5013,20 @@ msgstr "Resultados"
 msgid "Results Interpretation"
 msgstr "Interpretación de resultados"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr "Resultados pendientes"
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr "Informe de resultados"
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr "Informes de resultados"
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Los resultados han sido descartados"
 
@@ -4777,7 +5034,7 @@ msgstr "Los resultados han sido descartados"
 msgid "Results interpretation"
 msgstr "Interpretación de resultados"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Resultados pendientes"
 
@@ -4801,7 +5058,7 @@ msgstr "Prueba repetida"
 msgid "Retract"
 msgstr "Retirar"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4837,6 +5094,10 @@ msgstr "Restablecer"
 msgid "Routine Analyses"
 msgstr "Análisis rutinarios"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr "Fila ${num}"
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr "SENAITE CORE"
@@ -4851,7 +5112,7 @@ msgstr "SENAITE Core 1.x (no instalar)"
 
 #: senaite/core/browser/frontpage/templates/frontpage.pt:6
 msgid "SENAITE LIMS"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE LIMS front-page"
@@ -4862,6 +5123,7 @@ msgstr "SENAITE LIMS front-page"
 msgid "SENAITE Registry"
 msgstr "SENAITE Registry"
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4871,7 +5133,7 @@ msgstr "SENAITE Setup"
 msgid "SENAITE front-page"
 msgstr "SENAITE LIMS front-page"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "Servidor SMTP desconectado. No se ha creado el usuario."
 
@@ -4885,7 +5147,7 @@ msgstr "Tratamiento"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Muestra"
 
@@ -4922,7 +5184,7 @@ msgid "Sample Header"
 msgstr "Cabecera de muestra"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "ID de muestra"
 
@@ -4942,7 +5204,7 @@ msgstr "Soporte de la muestra"
 msgid "Sample Partitions"
 msgstr "Particiones de muestras"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4969,7 +5231,7 @@ msgid "Sample Templates"
 msgstr "Plantillas de muestras"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Tipo de muestra"
@@ -5030,7 +5292,7 @@ msgstr "Tipo de muestra"
 msgid "SampleTypes"
 msgstr "Tipos de muestra"
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Muestreado por"
 
@@ -5042,8 +5304,8 @@ msgstr "Muestreador para el muestreo programado"
 msgid "Sampler required for sample %s"
 msgstr "Muestrador requerido para muestra %s"
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Muestras"
@@ -5060,6 +5322,18 @@ msgstr "Las muestras ${sample_ids} fueron invalidadas correctamente, con correos
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr "Las muestras ${sample_ids} fueron invalidadas correctamente."
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr "Muestras en espera de la recogida de la muestra"
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr "Muestras en espera de conservación"
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr "Muestras en espera de recepción en el laboratorio"
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5069,7 +5343,23 @@ msgstr "Las muestras de este tipo deben ser tratadas como peligrosas"
 msgid "Samples rejection reporting form"
 msgstr "Formulario de informe de rechazo de muestras"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr "Muestras por recibir"
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr "Muestras cuyos informes se han publicado"
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr "Muestras cuyos resultados están en espera de verificación"
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr "Muestras con una fecha de muestreo programada"
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr "Muestreo"
 
@@ -5077,7 +5367,7 @@ msgstr "Muestreo"
 msgid "Sampling Date"
 msgstr "Fecha prevista de muestreo"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Anomalías en el muestreo"
@@ -5090,7 +5380,7 @@ msgstr "Anomalías en el muestreo"
 msgid "Sampling Frequency"
 msgstr "Frecuencia de muestreo"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "Muestreo programado"
 
@@ -5098,15 +5388,24 @@ msgstr "Muestreo programado"
 msgid "Saturday"
 msgstr "Sábado"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Guardar"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
 msgstr "Guardar y copiar"
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr "Guardar la vista actual"
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr "Filtros guardados"
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5120,7 +5419,7 @@ msgstr "Tarea programada"
 msgid "Schedule sampling"
 msgstr "Programar el muestreo"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Muestreo programado"
@@ -5137,15 +5436,19 @@ msgstr "Nombre científico"
 msgid "Search"
 msgstr "Buscar"
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr "Buscar columnas…"
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
-msgstr ""
+msgstr "Buscar..."
 
 #: bika/lims/browser/fields/coordinatefield.py:38
 msgid "Seconds"
 msgstr "Segundos"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr "Seguridad"
 
@@ -5235,11 +5538,11 @@ msgstr "Seleccionar razones"
 msgid "Select template"
 msgstr "Seleccionar la plantilla"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "País a mostrar por defecto"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Seleccione la moneda que se debe utilizar al mostrar los importes."
 
@@ -5251,11 +5554,11 @@ msgstr "Seleccionar el recipiente por defecto que debe ser utilizado para este s
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Seleccione la página de inicio predeterminada. Se muestra cuando un usuario de Cliente inicia la sesión en el sistema, o cuando se selecciona un cliente de la lista de carpetas del cliente."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr "Seleccione la plantilla de etiqueta predeterminada para la impresión automática."
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr "Seleccione la plantilla de etiqueta predeterminada para la impresión automática.<br/>"
 
@@ -5263,31 +5566,39 @@ msgstr "Seleccione la plantilla de etiqueta predeterminada para la impresión au
 msgid "Select the types that this ID is used to identify."
 msgstr "Seleccione los tipos que este ID se usa para identificar."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "Seleccione para activar el envío automático de notificaciones por correo electrónico al cliente cuando una muestra sea rechazada"
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "Seleccione para activar el tablero de control como página inicial predeterminada."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Seleccione esta casilla para activar el flujo de trabajo de los pasos para la recogida de muestras."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Seleccione para permitir que un Coordinador de Muestreo programe un muestreo. Esta funcionalidad solo tiene efecto cuando el 'Flujo de trabajo de muestreo' está activo."
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr "Seleccione esta opción para permitir el envío de muestras mediante la transición 'dispatch' y habilitar el estado adicional 'dispatched'. Los análisis de una muestra enviada pasan a ser de solo lectura y se restauran a su estado anterior cuando se restaura la muestra. Deshabilitado de forma predeterminada."
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr "Seleccione esta opción para permitir el desecho de muestras mediante la transición 'dispose' y habilitar el estado adicional 'disposed'. Deshabilitado de forma predeterminada."
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr "Seleccione esto para permitir al usuario asignar un estado adicional 'Impreso' a las muestras publicadas. Desactivado por defecto."
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "Seleccione recibir las muestras automáticamente cuando sea creado por el personal del laboratorio y el flujo de trabajo de muestreo esté desactivado. Las muestras creadas por los contactos del cliente no se recibirán automáticamente"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr "Seleccione para mostrar particiones de muestra a los contactos del cliente. Si se desactiva, las particiones no se incluirán en los listados y no se mostrará ningún mensaje de información con enlaces a la muestra principal a los contactos del cliente."
 
@@ -5299,7 +5610,7 @@ msgstr "Seleccione qué análisis desea incluir a la hoja de trabajo"
 msgid "Selection list"
 msgstr "Lista de selección simple"
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Autoverificación de resultados"
 
@@ -5311,11 +5622,11 @@ msgstr "Enviar"
 msgid "Send Analysis Reports via Email"
 msgstr "Enviar informes de análisis por correo electrónico"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr "Registro de envíos"
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr "Entrada del registro de envíos"
 
@@ -5337,7 +5648,7 @@ msgstr "Destinatarios"
 msgid "Separate Container"
 msgstr "Recipiente por separado"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr "Tipo de secuencia"
 
@@ -5351,7 +5662,7 @@ msgstr "Nº de serie"
 msgid "Service"
 msgstr "Servicio"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "El servicio no puede ser deseleccionado. Por favor, haga clic en el botón de información para más detalles."
 
@@ -5379,7 +5690,7 @@ msgstr "Establezca el flujo de trabajo de rechazo de muestra y las razones"
 msgid "Set the maintenance task as closed."
 msgstr "Asignar la tarea de mantenimiento como cerrada"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr "Configure el texto para el cuerpo del correo electrónico que se enviará, si la opción \"Notificación de correo electrónico en el 'rechazo' de la Muestra\" está habilitada, al contacto del cliente de la Muestra. Puede usar palabras clave reservadas: $sample_id, $sample_link, $reasons, $lab_address"
 
@@ -5427,29 +5738,41 @@ msgstr "¿Deben excluirse los análisis de la factura?"
 msgid "Should the default example content be added to the site?"
 msgstr "Desea añadir el contenido de ejemplo en este sitio?"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
-msgstr ""
+msgstr "Mostrar campos adicionales"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
 msgstr "Mostrar todo"
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
+msgstr "Mostrar historial"
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr "Mostrar los últimos registros de importación automática"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr "Mostrar menos"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr "Más"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
 msgstr "Mostrar los campos estándar"
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr "Mostrar esta columna"
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
+msgstr "Mostrar/ocultar línea de tiempo"
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5471,11 +5794,11 @@ msgstr "Código del lugar"
 msgid "Site Description"
 msgstr "Descripción del lugar"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr "Logo del sitio"
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr "CSS para el logo del sitio"
 
@@ -5496,7 +5819,7 @@ msgstr "Omitiendo resultado para el análisis '{keyword}' de la muestra '{sid}' 
 msgid "Small Sticker"
 msgstr "Etiqueta pequeña"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr "Plantilla de etiqueta pequeña"
 
@@ -5513,6 +5836,14 @@ msgstr "Algunos servicios de análisis utilizan instrumentos sin calibración vi
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Clave de ordenación"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr "Ordenar de forma ascendente"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr "Ordenar de forma descendente"
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5538,7 +5869,7 @@ msgstr "Los rangos de especificación han cambiado desde que fueron asignados"
 msgid "Specifications"
 msgstr "Especificaciones"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr "Indique cuántas copias de cada etiqueta se deben imprimir por defecto."
 
@@ -5546,7 +5877,7 @@ msgstr "Indique cuántas copias de cada etiqueta se deben imprimir por defecto."
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Especifique el tamaño de la hoja de trabajo, por ejemplo, correspondiente al tamaño de la bandeja de un instrumento específico. Luego seleccione un 'tipo' de Análisis por posición de la Hoja de trabajo. Cuando se seleccionen muestras de QC, seleccione también qué Muestra de Referencia se debe usar. Si se selecciona un análisis duplicado, indique en qué posición de la muestra debería ser un duplicado de"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr "Longitud de división"
 
@@ -5563,17 +5894,17 @@ msgstr "Fecha de inicio"
 msgid "Start date must be before End Date"
 msgstr "La fecha de inicio debe ser anterior a la fecha de finalización"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Estado"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Estado"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Etiqueta"
@@ -5582,7 +5913,11 @@ msgstr "Etiqueta"
 msgid "Stickers preview"
 msgstr "Previsualización de etiquetas"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr "Detener la aplicación automática"
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Ubicación de almacenamiento"
@@ -5622,7 +5957,11 @@ msgstr "Tramitar"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr "Proporcione un archivo Open XML (.XLSX) válido que contenga datos de configuración inicial para continuar."
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr "Análisis enviados en espera de verificación"
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "Enviado y verificado por el mismo usuario: {}"
 
@@ -5630,7 +5969,7 @@ msgstr "Enviado y verificado por el mismo usuario: {}"
 msgid "Submitter"
 msgstr "Remitente"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotal"
@@ -5672,7 +6011,7 @@ msgstr "Cambiar al tablero de control"
 msgid "Switch to transposed view"
 msgstr "Ir a la vista transpuesta"
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "Por defecto del sistema"
 
@@ -5698,7 +6037,7 @@ msgstr "Impuestos"
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descripción técnica e instrucciones para los analistas"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5780,7 +6119,7 @@ msgstr "La fecha en que se preservó la muestra"
 msgid "The date when the sample was received"
 msgstr "La fecha en que se recibió la muestra"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Se usará la tipo de separador decimal seleccionado en la configuración general del sistema."
 
@@ -5788,7 +6127,7 @@ msgstr "Se usará la tipo de separador decimal seleccionado en la configuración
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr "La zona horaria por defecto del sitio. Los usuarios podrán establecer su propia zona horaria si se permite en la vista de configuración de fecha."
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "El porcentaje de descuento solo se aplicará a clientes que estén etiquetados como 'clientes habituales'. Normalmente, se trata de miembros que forman parte de una cooperativa, asociados o clientes con contrato de mantenimiento."
 
@@ -5816,7 +6155,11 @@ msgstr "Se han creado las particiones siguientes:"
 msgid "The following sample(s) will be dispatched"
 msgstr "La muestra o muestras siguientes serán enviadas"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr "Se desechará(n) la(s) siguiente(s) muestra(s)"
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr "En el registro global de auditoría se muestran todas las modificaciones efectuadas en el sistema. Cuando está activo, todos los registros electrónicos son indexados por separado en un catálogo específico que solo es utilizado para el registro de auditoría. Esto conlleva un incremento en el tiempo que necesita el sistema para crear o modificar objetos."
 
@@ -5824,11 +6167,11 @@ msgstr "En el registro global de auditoría se muestran todas las modificaciones
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Altura o profundidad del muestreo"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr "El tiempo de estabilidad para esta muestra y análisis ha expirado. Continuar con el análisis puede comprometer la fiabilidad de los resultados."
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr "El tiempo de estabilidad para esta muestra y análisis está a punto de expirar. Complete el análisis lo antes posible para garantizar la exactitud y fiabilidad de los datos."
 
@@ -5863,13 +6206,13 @@ msgstr "Volumen mínimo de muestra necesario para efectuar el análisis (por eje
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:40
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
-msgstr ""
+msgstr "El almacenamiento del generador de números está vacío. Los contadores se inicializan en la primera generación de ID para cada prefijo."
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "El número de días antes que caduque la muestras sin que pueda ser analizada más. Esta propiedad puede ser sobreescrita individualmente para cada tipo de muestra desde la página de configuración de tipos de muestras."
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Duración en minutos de la sesión de usuario en el sistema. Si desea desactivar la expulsión automática de usuarios, introduzca el valor 0."
 
@@ -5909,7 +6252,7 @@ msgstr "Código de referencia que la entidad de acreditación ha concedido al la
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "El resultado del cálculo ha sido obtenido a partir de los valores de la prueba. Es necesario guardar para que el cálculo se realize."
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr "El resultado fue capturado después del límite del tiempo de estabilidad."
 
@@ -5933,11 +6276,11 @@ msgstr "La muestra es un conjunto de sub-muestras"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Número de serie que identifica inequívocamente al instrumento analítico"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "Identificación del protocolo analítico del servicio."
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "La identificación comercial del servicio para fines contables."
 
@@ -5989,11 +6332,11 @@ msgstr "Esta es una Muestra Secundaria de"
 msgid "This is a detached partition from Sample"
 msgstr "Esta es una partición separada de la Muestra"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "Este es el tiempo máximo predeterminado permitido para realizar análisis. Solo se usa para análisis en los que el servicio de análisis no especifica un tiempo de respuesta. Solo se consideran los días laborables de laboratorio."
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "Este es el tiempo máximo predeterminado permitido para realizar análisis. Solo se usa para análisis en los que el servicio no especifica un tiempo de respuesta. Solo se consideran los días laborables del laboratorio."
 
@@ -6017,11 +6360,11 @@ msgstr "Esta muestra fue invalidada por ${actor_fullname} (${actor_id}) el ${dat
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr "Esta muestra fue invalidada por ${actor_fullname} (${actor_id}) el ${date}."
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr "Este servicio no puede ser seleccionado para evitar que el análisis se realice más allá del tiempo de estabilidad analítica."
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr "Muestra un logotipo personalizado en su sitio SENAITE."
 
@@ -6053,8 +6396,8 @@ msgstr "Fecha"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Consejo. Los documentos adjuntos no se cargarán a menos que estén presentes en la instancia."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Título"
@@ -6081,34 +6424,42 @@ msgstr "Nombre del lugar"
 msgid "To"
 msgstr "A"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Por conservar"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Por muestrear"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr "Por publicar"
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr "Por verificar"
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Se mostrará debajo de cada sección de Categoría de Análisis en los informes de resultados."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Por conservar"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "Pendientes de imprimir"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Por muestrear"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Pendientes de verificar"
@@ -6121,7 +6472,7 @@ msgstr "Para probar el cálculo, puedes introducir valores aquí para todos los 
 msgid "Toggle visibility of standard sample header fields"
 msgstr "Alternar la visibilidad de los campos estándar de la cabecera de muestra"
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6143,7 +6494,7 @@ msgid "Tuesday"
 msgstr "Martes"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Tipo"
@@ -6168,6 +6519,10 @@ msgstr "Tipo de contenedor"
 msgid "Type to filter ..."
 msgstr "Escriba para filtrar ..."
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr "Escriba para filtrar..."
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr "Tipos de contenido que soportan etiquetado.<br/>Importante: para instalaciones en modo clúster, recuerde que debe reiniciar las otras instancias para que los cambios tengan efecto!."
@@ -6176,7 +6531,7 @@ msgstr "Tipos de contenido que soportan etiquetado.<br/>Importante: para instala
 msgid "Types with labels"
 msgstr "Tipos etiquetables"
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr "UID"
 
@@ -6188,6 +6543,7 @@ msgstr "No se puede cargar la plantilla"
 msgid "Unassign"
 msgstr "Desasignar"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sin asignar"
@@ -6220,9 +6576,13 @@ msgstr "IBAN del país desconocido %s"
 msgid "Unlink User"
 msgstr "Desvincular usuario"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
 msgstr "Usuario desvinculado"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr "Desbloquear"
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6238,7 +6598,7 @@ msgstr "Formato de fichero no válido: ${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr "Formato de fichero no válido: ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "Sin asignar"
 
@@ -6246,15 +6606,19 @@ msgstr "Sin asignar"
 msgid "Update Attachments"
 msgstr "Actualizar ficheros adjuntos"
 
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr "Actualizar el preajuste con la vista actual"
+
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
-msgstr ""
+msgstr "Se actualizaron {} clave(s): {}"
 
 #: bika/lims/content/labcontact.py:47
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Cargar una firma digitalizada para que sea imprimida en los informes de resultados. Las dimensiones idóneas son 250 píxels de ancho por 150 píxels de alto."
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr "Cargue archivos e imágenes para este cliente. Los archivos se almacenarán en la carpeta del cliente y podrán descargarse más tarde."
 
@@ -6262,7 +6626,7 @@ msgstr "Cargue archivos e imágenes para este cliente. Los archivos se almacenar
 msgid "Use Analysis Profile Price"
 msgstr "Utilizar el precio del perfil de análisis"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Use el tablero de control como página inicial predeterminada."
 
@@ -6300,7 +6664,7 @@ msgstr "El usuario está vinculado al contacto '${fullname}'"
 msgid "User is linked to the global contact '${fullname}'"
 msgstr "El usuario está vinculado al contacto global '${fullname}'"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "Usuario vinculado a este contacto"
 
@@ -6308,15 +6672,15 @@ msgstr "Usuario vinculado a este contacto"
 msgid "User name"
 msgstr "Nombre de usuario"
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "El uso de un número bajo de puntos de datos suele conllevar que los resultados del cálculo estadístico no tengan sentido. Establezca un número mínimo aceptable de resultados antes que se ejecuten los cálculos estadísticos de Control de Calidad (QC)"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6324,7 +6688,7 @@ msgstr "IVA"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "% IVA"
 
@@ -6571,8 +6935,8 @@ msgstr "El valor en segundos debe estar entre 0 y 59.9999"
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Los valores ingresados aquí anularan los establecidos en los campos de la sección de Cálculo Provisional"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verificadas"
@@ -6581,11 +6945,19 @@ msgstr "Verificadas"
 msgid "Verified By"
 msgstr "Verificado por"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr "Muestras verificadas listas para publicar"
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Verificar"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr "Verificar resultados"
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6600,6 +6972,14 @@ msgstr "Detalle"
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
 msgstr "Ver el sitio de SENAITE"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr "Visible"
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr "Columnas visibles / totales"
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -6634,31 +7014,35 @@ msgstr "Sitio web"
 msgid "Wednesday"
 msgstr "Miércoles"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr "Semanal"
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Semanas para expirar"
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:7
 msgid "Welcome"
-msgstr ""
+msgstr "Bienvenido"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:14
 msgid "Welcome to SENAITE"
 msgstr "Bienvenido a SENAITE"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr "Cuando está activado, los analistas solo pueden acceder a las hojas de trabajo que tienen asignadas. Cuando está desactivado, los analistas tienen acceso a todas las hojas de trabajo."
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr "Cuando está activado, solo los responsables de laboratorio pueden crear y gestionar hojas de trabajo. Cuando está desactivado, también los analistas y recepcionistas pueden gestionar hojas de trabajo. Nota: Esta configuración se activa y bloquea automáticamente cuando el acceso a hojas de trabajo está restringido a los analistas asignados."
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr "Cuando esta casilla esté activa, la muestra se verificará automáticamente tan pronto como todos sus resultados sean verificados. En caso contrario, los usuarios con suficientes permisos tendrán que verificar la muestra de forma manual tras verificar todas sus analíticas. Valor por defecto: activo"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr "Cuando está activado, los usuarios pueden enviar resultados para análisis no asignados o para análisis que no les están asignados. Cuando está desactivado, los usuarios solo pueden enviar resultados para análisis asignados a ellos mismos. Esta configuración no se aplica a los usuarios con rol de Responsable de laboratorio."
 
@@ -6709,10 +7093,18 @@ msgstr "Plantillas para hojas de trabajo"
 msgid "Worksheet printing templates order"
 msgstr "Orden de plantillas de impresión de hojas de trabajo"
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Hojas de trabajo"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr "Hojas de trabajo que han sido verificadas"
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr "Hojas de trabajo cuyos resultados están en espera de verificación"
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6721,6 +7113,10 @@ msgstr "Longitud de IBAN incorrecta por %s: %s"
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Longitud de IBAN incorrecta por%s: %s corto por %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr "Anual"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6806,6 +7202,10 @@ msgstr "Duplicado"
 msgid "analyst_must_be_specified_message"
 msgstr "Debe especificarse un analista."
 
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
+msgstr "automático"
+
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
 msgstr "semestral"
@@ -6818,8 +7218,9 @@ msgstr "por"
 #. in '${calc}')"
 #. Default: "keyword '${keyword}' must have column title '${title}' (defined in '${calc}')"
 #: senaite/core/validators/interimfields.py:151
+#, fuzzy
 msgid "calcs_interims_validator_dup_keyword_error"
-msgstr ""
+msgstr "la palabra clave '${keyword}' debe tener el título de columna '${title}' (definido en '${calc}')"
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:57
@@ -6841,33 +7242,34 @@ msgstr "Algunos análisis utilizan instrumentos no calibrados o caducados. Edici
 #. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #. Default: "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #: senaite/core/validators/interimfields.py:211
+#, fuzzy
 msgid "choice_syntax_validation_error"
-msgstr ""
+msgstr "No hay un formato válido en el campo de opciones. El formato admitido es: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #. Default: "Control type is not supported for empty choices"
 #: senaite/core/validators/interimfields.py:111
 msgid "choices_and_restype_validator_no_choices_error"
-msgstr ""
+msgstr "El tipo de control no es compatible con opciones vacías"
 
 #. Default: "Chosen control type not supporting choices"
 #: senaite/core/validators/interimfields.py:117
 msgid "choices_and_restype_validator_not_supported_choices_error"
-msgstr ""
+msgstr "El tipo de control elegido no admite opciones"
 
 #. Default: "Empty keys are not supported"
 #: senaite/core/validators/interimfields.py:169
 msgid "choices_empty_keys_validator_error"
-msgstr ""
+msgstr "Las claves vacías no son compatibles"
 
 #. Default: "At least, two options for choices field are required"
 #: senaite/core/validators/interimfields.py:195
 msgid "choices_min_items_validator_error"
-msgstr ""
+msgstr "Se requieren al menos dos opciones para el campo de opciones"
 
 #. Default: "Duplicate keys in choices field"
 #: senaite/core/validators/interimfields.py:183
 msgid "choices_unique_keys_validator_error"
-msgstr ""
+msgstr "Claves duplicadas en el campo de opciones"
 
 #: bika/lims/content/instrumentcertification.py:250
 msgid "daily"
@@ -6897,9 +7299,10 @@ msgstr "${d}/${m}/${Y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
+#. Default: "yy-mm-dd"
+#, fuzzy
 msgid "date_format_short_datepicker"
-msgstr ""
+msgstr "dd/mm/aa"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "days"
@@ -6909,45 +7312,56 @@ msgstr "días"
 msgid "deactivate"
 msgstr "desactivar"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr "Muestra desechada tras el período de retención."
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr "eliminado por {user} el {time}"
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr "Etiquetas asignadas a este contenido."
 
 #. Default: "The accreditation standard that applies, e.g. ISO 17025"
 #: senaite/core/content/laboratory.py:174
 msgid "description_accreditation"
-msgstr ""
+msgstr "La norma de acreditación aplicable, p. ej. ISO 17025"
 
 #. Default: "E.g. SANAS, APLAC, etc."
 #: senaite/core/content/laboratory.py:153
 msgid "description_accreditation_body"
-msgstr ""
+msgstr "P. ej. SANAS, APLAC, etc."
 
 #. and results reports by your accreditation body. Maximum size is 175 x 175
 #. pixels."
 #. Default: "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 #: senaite/core/content/laboratory.py:198
+#, fuzzy
 msgid "description_accreditation_body_logo"
-msgstr ""
+msgstr "Suba el logotipo que su organismo de acreditación le autoriza a usar en su sitio web y en los informes de resultados. El tamaño máximo es de 175 x 175 píxeles."
 
 #. Default: "Web address for the accreditation body"
 #: senaite/core/content/laboratory.py:163
 msgid "description_accreditation_body_url"
-msgstr ""
+msgstr "Dirección web del organismo de acreditación"
 
 #. following fields are available: lab_is_accredited, lab_name, lab_country,
 #. confidence, accreditation_body_name, accreditation_standard,
 #. accreditation_reference"
 #. Default: "Enter the details of your lab's service accreditations here. The following fields are available: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 #: senaite/core/content/laboratory.py:220
+#, fuzzy
 msgid "description_accreditation_page_header"
-msgstr ""
+msgstr "Introduzca aquí los datos de las acreditaciones de servicio de su laboratorio. Están disponibles los siguientes campos: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 
 #. Default: "The reference code issued to the lab by the accreditation body"
 #: senaite/core/content/laboratory.py:186
 msgid "description_accreditation_reference"
-msgstr ""
+msgstr "El código de referencia emitido al laboratorio por el organismo de acreditación"
 
 #. Default: "The category the analysis service belongs to"
 #: bika/lims/content/abstractbaseanalysis.py:533
@@ -6976,7 +7390,7 @@ msgstr "Este servicio no estará disponible para su selección en el formulario 
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 #, fuzzy
 msgid "description_analysis_results_options_sorting"
 msgstr "Criterio a utilizar para la ordenación de las opciones de resultados. Esta configuración solo aplica a las opciones que se muestran en la lista de selección, no tiene ningún efecto sobre el orden de los resultados tras su captura y tramitación."
@@ -7152,27 +7566,27 @@ msgstr "Cliente al que pertenece este lote. Cuando el usuario indique un cliente
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 #, fuzzy
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr "Si esta opción está activada, la fecha de captura del resultado puede introducirse manualmente para los análisis"
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 #, fuzzy
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr "Marque esta casilla si desea que los responsables de todos los departamentos involucrados también reciban correos electrónicos en copia al publicar informes de resultados."
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr "Marque esta casilla si desea que las listas de análisis dentro de la vista de muestra se mostraran agrupadas por categorías."
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 #, fuzzy
 msgid "description_bikasetup_date_sampled_required"
 msgstr "Seleccione esto para que el campo Fecha de muestreo sea obligatorio al crear la muestra. Esta funcionalidad solo tiene efecto cuando el flujo de trabajo de muestreo no está activo"
@@ -7180,7 +7594,7 @@ msgstr "Seleccione esto para que el campo Fecha de muestreo sea obligatorio al c
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 #, fuzzy
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr "Texto por defecto del cuerpo del correo electrónico que debe utilizarse por defecto al enviar informes de resultados a los destinatarios seleccionados. Puede utilizar las palabras reservadas siguientes: $client_name (nombre de cliente), $recipients (lista de recipientes), $lab_name (nombre del laboratorio), $lab_address (dirección física del laboratorio)."
@@ -7188,7 +7602,7 @@ msgstr "Texto por defecto del cuerpo del correo electrónico que debe utilizarse
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 #, fuzzy
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr "Correo electrónico para usar como dirección 'De' en los correos de publicación de informes de resultados. Esta dirección reemplaza el valor establecido en la configuración de correo del portal."
@@ -7196,7 +7610,7 @@ msgstr "Correo electrónico para usar como dirección 'De' en los correos de pub
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 #, fuzzy
 msgid "description_bikasetup_immediateresultsentry"
 msgstr "Marque esta casilla si desea que el usuario pueda efectuar el registro directo de resultados justo después de crear la muestra, ya sean para análisis de campo o para análisis de laboratorio. Esta funcionalidad es útil por ejemplo para la captura de resultados durante el muestreo."
@@ -7209,7 +7623,7 @@ msgstr "Marque esta casilla si desea que el usuario pueda efectuar el registro d
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 #, fuzzy
 msgid "description_bikasetup_invalidation_email_body"
 msgstr "Defina la plantilla del cuerpo del correo electrónico que se enviará automáticamente a los contactos principales y a los responsables de laboratorio cuando se invalide una muestra. Los marcadores disponibles son: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
@@ -7217,13 +7631,13 @@ msgstr "Defina la plantilla del cuerpo del correo electrónico que se enviará a
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 #, fuzzy
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr "Especifique si es obligatorio indicar un motivo al invalidar una muestra. Si está activado, el marcador '$reason' en el cuerpo del correo de notificación de invalidación será reemplazado por el motivo introducido."
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr "Marque esta casilla si desea que sea obligatorio seleccionar como mínimo un análisis en el formulario de registro de muestra."
 
@@ -7241,36 +7655,46 @@ msgstr "Servicios de análisis que dependen del cálculo."
 #. where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #. Default: "<p>The formula you type here will be dynamically calculated be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators, + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #: senaite/core/content/calculation.py:291
+#, fuzzy
 msgid "description_calculation_formula"
-msgstr ""
+msgstr "<p>La fórmula que escriba aquí se calculará dinámicamente cuando se muestre un análisis que utilice este cálculo.</p><p>Para introducir un cálculo, use los operadores matemáticos estándar, + - * / ( ), y todas las palabras clave disponibles, tanto de otros Servicios de análisis como de los Campos provisionales aquí especificados, como variables. Enciérrelas entre corchetes [ ].</p><p>P. ej., el cálculo de la Dureza total, la suma de los iones de Calcio (ppm) y Magnesio (ppm) en el agua, se introduce como [Ca] + [Mg], donde Ca y Mg son las palabras clave de esos dos Servicios de análisis.</p>"
+
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
+#. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
+#: senaite/core/content/calculation.py:268
+#, fuzzy
+msgid "description_calculation_imports"
+msgstr "Si su fórmula necesita una función especial de una biblioteca externa de Python, puede importarla aquí. P. ej., si desea usar la función 'floor' del módulo 'math' de Python, añada 'math' al campo Módulo y 'floor' al campo de función. El equivalente en Python sería 'from math import floor'. En su cálculo podría usar entonces 'floor([Ca] + [Mg])'."
 
 #. should your calculation require them. The field title specified here will
 #. be used as column headers and field descriptors where the interim fields
 #. are displayed. If 'Apply wide' is enabled the field will be shown in a
 #. selection box on the top of the worksheet, allowing to apply a specific
 #. value to all the corresponding fields on the sheet."
-#. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
-#: senaite/core/content/calculation.py:268
-msgid "description_calculation_imports"
-msgstr ""
-
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
+#, fuzzy
 msgid "description_calculation_interims"
-msgstr ""
+msgstr "Defina campos provisionales como la masa del recipiente o los factores de dilución, en caso de que su cálculo los requiera. El título del campo aquí especificado se usará como encabezado de columna y descriptor de campo donde se muestren los campos provisionales. Si 'Aplicar de forma amplia' está habilitado, el campo se mostrará en un cuadro de selección en la parte superior de la hoja de trabajo, permitiendo aplicar un valor específico a todos los campos correspondientes de la hoja."
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
 #. Default: "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 #: senaite/core/content/calculation.py:321
+#, fuzzy
 msgid "description_calculation_test_params"
-msgstr ""
+msgstr "Para probar el cálculo, introduzca aquí los valores de todos los parámetros del cálculo. Esto incluye los campos provisionales definidos arriba, así como cualquier servicio del que dependa este cálculo para calcular los resultados."
 
 #. values."
 #. Default: "The result after the calculation has taken place with test values."
 #: senaite/core/content/calculation.py:345
+#, fuzzy
 msgid "description_calculation_test_result"
-msgstr ""
+msgstr "El resultado después de que el cálculo se haya realizado con valores de prueba."
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/analysiscategory.py:62
@@ -7278,22 +7702,22 @@ msgid "description_category_department"
 msgstr "Departamento responsable de esta categoría de análisis."
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr "Marque esta casilla si desea que las categorías de análisis siempre se muestren desplegadas en listados de análisis."
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr "Categorías de análisis que a mostrar cuando el usuario seleccione este cliente en el formulario de registro de muestras. Si no indica ninguna categoría, todas serán visibles."
 
 #. Default: "This value is reported at the bottom of all published results"
 #: senaite/core/content/laboratory.py:127
 msgid "description_confidence_level"
-msgstr ""
+msgstr "Este valor se indica al pie de todos los resultados publicados"
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr "Contactos en copia para nuevas muestras."
 
@@ -7400,15 +7824,30 @@ msgstr "Seleccione el departamento por defecto del contacto."
 msgid "description_labcontact_departments"
 msgstr "Indique los departamentos del laboratorio a los que pertenece este contacto."
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+#, fuzzy
+msgid "description_label_color"
+msgstr "Código de color hexadecimal utilizado para el chip (p. ej. #0d6efd). Déjelo vacío para el estilo predeterminado."
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+#, fuzzy
+msgid "description_label_title"
+msgstr "Cambiar el nombre de esta etiqueta reescribe el nombre almacenado en todo el contenido actualmente etiquetado. La cascada se ejecuta en la misma transacción que el guardado y puede tardar un momento en conjuntos de datos grandes."
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
-msgstr ""
+msgstr "Marque esta casilla si su laboratorio está acreditado"
 
 #. Default: "The Laboratory's web address"
 #: senaite/core/content/laboratory.py:101
 msgid "description_laboratory_lab_url"
-msgstr ""
+msgstr "La dirección web del laboratorio"
 
 #. Default: "Supervisor of the Lab"
 #: bika/lims/content/laboratory.py:78
@@ -7418,7 +7857,7 @@ msgstr "Seleccione el supervisor o persona encargada del correcto functionamient
 #. Default: "Supervisor of the Lab"
 #: senaite/core/content/laboratory.py:77
 msgid "description_laboratory_supervisor"
-msgstr ""
+msgstr "Supervisor del laboratorio"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/labproduct.py:89
@@ -7431,6 +7870,14 @@ msgstr "Proporcione el precio sin IVA"
 #, fuzzy
 msgid "description_labproduct_vat"
 msgstr "Proporcione el IVA en porcentaje que se añade al precio del producto"
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+#, fuzzy
+msgid "description_manage_viewlets"
+msgstr "Los gestores de viewlets y sus viewlets se muestran en su lugar, anidados y posicionados tal como aparecen en el sitio. Use los controles para ocultar, mostrar o reordenar cada viewlet."
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
@@ -7462,8 +7909,9 @@ msgstr "Los valores para las muestras de referencia son cero o 'blanco'"
 #. definition."
 #. Default: "Hazard categories that apply to samples of this reference definition."
 #: bika/lims/content/referencedefinition.py:106
+#, fuzzy
 msgid "description_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro que se aplican a las muestras de esta definición de referencia."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: bika/lims/content/referencedefinition.py:91
@@ -7485,8 +7933,9 @@ msgstr "Haga clic sobre las cabeceras de categorías de análisis (con fondo gri
 #. inherit from the reference definition."
 #. Default: "Hazard categories for this reference sample. Leave empty to inherit from the reference definition."
 #: bika/lims/content/referencesample.py:118
+#, fuzzy
 msgid "description_referencesample_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro para esta muestra de referencia. Déjelo vacío para heredar de la definición de referencia."
 
 #. Default: "Select the manufacturer for this sample"
 #: bika/lims/content/referencesample.py:136
@@ -7545,8 +7994,9 @@ msgstr "Enviar automáticamente los análisis al importar"
 #. batch is created in a single transaction (legacy behaviour)."
 #. Default: "When enabled, each sample created from the add form is committed in its own ZODB transaction with a per-sample retry on conflict. This reduces the chance that ID-counter or container contention aborts the whole batch on instances with many concurrent users. When disabled, the whole batch is created in a single transaction (legacy behaviour)."
 #: senaite/core/registry/schema.py:391
+#, fuzzy
 msgid "description_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Cuando está habilitado, cada muestra creada desde el formulario de creación se confirma en su propia transacción de ZODB con un reintento por muestra en caso de conflicto. Esto reduce la posibilidad de que la contención del contador de ID o del contenedor aborte todo el lote en instancias con muchos usuarios concurrentes. Cuando está deshabilitado, todo el lote se crea en una sola transacción (comportamiento heredado)."
 
 #. matching the source sample structure. Each partition will be created with
 #. the same configuration (sample type, container, preservation) and analyses
@@ -7586,12 +8036,12 @@ msgid "description_registry_worksheet_settings"
 msgstr "Configuración de la vista de hoja de trabajo"
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr "Muestras incluidas en el PDF"
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr "La muestra principal del PDF"
 
@@ -7633,7 +8083,7 @@ msgstr "Referencia a la muestra de la que se desvinculó esta partición."
 #. Default: "Reference to the source sample this sample was duplicated from"
 #: bika/lims/content/analysisrequest.py:1283
 msgid "description_sample_duplicated_from"
-msgstr ""
+msgstr "Referencia a la muestra de origen desde la que se duplicó esta muestra"
 
 #. Default: "Generated invoice for this sample"
 #: bika/lims/content/analysisrequest.py:1049
@@ -7828,8 +8278,9 @@ msgstr "El periodo durante el que las muestras sin conservar de este tipo pueden
 #. display the appropriate pictograms in reports and lists."
 #. Default: "Hazard categories that apply to samples of this type. Used to display the appropriate pictograms in reports and lists."
 #: senaite/core/content/sampletype.py:180
+#, fuzzy
 msgid "description_sampletype_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro que se aplican a las muestras de este tipo. Se utilizan para mostrar los pictogramas apropiados en los informes y las listas."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: senaite/core/content/sampletype.py:168
@@ -7855,7 +8306,7 @@ msgstr "Seleccione la base o matriz del tipo de muestra."
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 #, fuzzy
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr "Si esta opción está activada, la fecha de captura del resultado puede introducirse manualmente para los análisis"
@@ -7864,21 +8315,21 @@ msgstr "Si esta opción está activada, la fecha de captura del resultado puede 
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 #, fuzzy
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr "Cuando está activado, los usuarios pueden enviar resultados para análisis no asignados o no asignados a ellos. Cuando está desactivado, los usuarios solo pueden enviar resultados para análisis asignados a ellos mismos. Esta configuración no se aplica a los usuarios con rol de Responsable de laboratorio."
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 #, fuzzy
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr "Marque esta casilla si desea que los responsables de departamentos involucrados también reciban correos electrónicos en copia al publicar informes de resultados."
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 #, fuzzy
 msgid "description_senaitesetup_auto_log_off"
 msgstr "Número de minutos antes de que el usuario cierre sesión automáticamente. 0 desactiva el cierre de sesión automático"
@@ -7886,54 +8337,54 @@ msgstr "Número de minutos antes de que el usuario cierre sesión automáticamen
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 #, fuzzy
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr "Cuando está activado, la muestra se verifica automáticamente en cuanto se verifican todos los resultados. En caso contrario, los usuarios con privilegios suficientes deben verificar la muestra manualmente. Por defecto: activado"
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 #, fuzzy
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr "Agrupar los servicios de análisis por categoría en las tablas del LIMS, útil cuando la lista es larga"
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr "Agrupar los análisis por categorías dentro de la vista de muestras."
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr "Seleccione la moneda que usará el sitio para mostrar precios."
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr "Seleccione esto para activar el panel de control como página principal por defecto."
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 #, fuzzy
 msgid "description_senaitesetup_date_sampled_required"
 msgstr "Seleccione esto para que el campo Fecha de muestreo sea obligatorio al crear la muestra. Esta funcionalidad solo tiene efecto cuando el flujo de trabajo de muestreo no está activo"
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr "Separador decimal preferido para los informes."
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr "Seleccione el país que el sitio mostrará por defecto"
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 #, fuzzy
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr "Valor predeterminado del campo 'Número de muestras' cuando los usuarios hacen clic en 'AÑADIR' para crear nuevas muestras"
@@ -7941,26 +8392,26 @@ msgstr "Valor predeterminado del campo 'Número de muestras' cuando los usuarios
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 #, fuzzy
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr "Correo electrónico para usar como dirección 'De' en los correos de publicación de informes de resultados. Esta dirección reemplaza el valor establecido en la configuración de correo del portal."
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 #, fuzzy
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr "Si está activado, se mostrará un campo de texto libre junto a cada análisis en la vista de entrada de resultados"
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr "Especificaciones de análisis editadas directamente en la muestra."
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 #, fuzzy
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr "Seleccione esto para activar el flujo de trabajo de rechazo para las muestras. Se mostrará la opción 'Rechazar' en el menú de acciones."
@@ -7968,7 +8419,7 @@ msgstr "Seleccione esto para activar el flujo de trabajo de rechazo para las mue
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 #, fuzzy
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr "Los valores de resultados con al menos este número de dígitos significativos se muestran en notación científica usando la letra 'e' para indicar el exponente. La precisión puede configurarse en cada Servicio de análisis."
@@ -7976,7 +8427,7 @@ msgstr "Los valores de resultados con al menos este número de dígitos signific
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 #, fuzzy
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr "Permite que el usuario pueda efectuar la introducción directa de resultados justo después de crear la muestra. Esta funcionalidad es útil para por ejemplo la captura de resultados durante el muestreo."
@@ -7984,7 +8435,7 @@ msgstr "Permite que el usuario pueda efectuar la introducción directa de result
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 #, fuzzy
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr "Especifique si es obligatorio indicar un motivo al invalidar una muestra. Si está activado, el marcador '$reason' en el cuerpo del correo de notificación de invalidación será reemplazado por el motivo introducido."
@@ -7992,7 +8443,7 @@ msgstr "Especifique si es obligatorio indicar un motivo al invalidar una muestra
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 #, fuzzy
 msgid "description_senaitesetup_landing_page"
 msgstr "La página de inicio se muestra para usuarios no autenticados si el Panel de control no está seleccionado como página principal por defecto. Si no se selecciona ninguna página de inicio, se muestra la página de bienvenida predeterminada."
@@ -8000,7 +8451,7 @@ msgstr "La página de inicio se muestra para usuarios no autenticados si el Pane
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 #, fuzzy
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr "Número máximo de muestras que se pueden crear de acuerdo con el valor establecido para el campo 'Número de muestras' en el formulario de registro."
@@ -8008,7 +8459,7 @@ msgstr "Número máximo de muestras que se pueden crear de acuerdo con el valor 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 #, fuzzy
 msgid "description_senaitesetup_member_discount"
 msgstr "El porcentaje de descuento introducido aquí se aplica a los precios para los clientes marcados como 'miembros', normalmente miembros de cooperativas o asociados que merecen este descuento"
@@ -8016,7 +8467,7 @@ msgstr "El porcentaje de descuento introducido aquí se aplica a los precios par
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 #, fuzzy
 msgid "description_senaitesetup_minimum_results"
 msgstr "Usar pocos datos no tiene sentido estadístico. Establezca un número mínimo aceptable de resultados antes de que se calculen y representen las estadísticas de QC"
@@ -8024,7 +8475,7 @@ msgstr "Usar pocos datos no tiene sentido estadístico. Establezca un número m�
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 #, fuzzy
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr "Número de verificaciones requeridas antes de que un resultado se considere 'verificado'. Esta configuración puede sobreescribirse para cualquier análisis en la vista de edición del Servicio de análisis. Por defecto, 1"
@@ -8032,14 +8483,14 @@ msgstr "Número de verificaciones requeridas antes de que un resultado se consid
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 #, fuzzy
 msgid "description_senaitesetup_publication_email_text"
 msgstr "Texto por defecto del cuerpo del correo electrónico que debe utilizarse por defecto cuando al enviar informes de resultados a los destinatarios seleccionados. Puede utilizar las palabras reservadas siguientes: $client_name (nombre de cliente), $recipients (lista de recipientes), $lab_name (nombre del laboratorio), $lab_address (dirección física del laboratorio)."
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 #, fuzzy
 msgid "description_senaitesetup_rejection_reasons"
 msgstr "Introduzca los motivos de rechazo predefinidos que los usuarios pueden seleccionar al rechazar una muestra."
@@ -8048,50 +8499,51 @@ msgstr "Introduzca los motivos de rechazo predefinidos que los usuarios pueden s
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 #, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr "Cuando está activado, solo los responsables de laboratorio pueden crear y gestionar hojas de trabajo. Cuando está desactivado, también los analistas y recepcionistas pueden gestionarlas. Nota: Esta configuración se activa y bloquea automáticamente cuando el acceso a hojas de trabajo está restringido a los analistas asignados."
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 #, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr "Cuando está activado, los analistas solo pueden acceder a las hojas de trabajo que tienen asignadas. Cuando está desactivado, los analistas tienen acceso a todas las hojas de trabajo."
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr "Separador decimal preferido para los resultados"
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
+#, fuzzy
 msgid "description_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Si está habilitado, los usuarios con privilegios suficientes pueden crear una muestra hermana directamente a partir de una existente mediante la acción 'Duplicar' en el listado de muestras. Habilitado de forma predeterminada."
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr "Marque esta casilla si desea que sea obligatorio seleccionar como mínimo un análisis durante el registro de muestra."
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 #, fuzzy
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr "Seleccione las columnas que se mostrarán en los listados de análisis de muestras. El orden de selección determina el orden de visualización. Las columnas no seleccionadas se ocultan. Si no se selecciona ninguna, se muestran todas las columnas en el orden predeterminado."
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr "Formato de notación científica preferido para los informes"
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr "Formato de notación científica preferido para los resultados"
 
@@ -8100,14 +8552,14 @@ msgstr "Formato de notación científica preferido para los resultados"
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 #, fuzzy
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr "Si está activado, el usuario que envió un resultado también podrá verificarlo. Esta configuración solo tiene efecto para los usuarios con un rol que les permite verificar resultados (por defecto, administradores, responsables de laboratorio y verificadores). Por defecto, desactivado."
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 #, fuzzy
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr "Cuando está seleccionado, el nombre del laboratorio se mostrará en la página de inicio de sesión, encima de las credenciales de acceso."
@@ -8115,7 +8567,7 @@ msgstr "Cuando está seleccionado, el nombre del laboratorio se mostrará en la 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 #, fuzzy
 msgid "description_senaitesetup_show_partitions"
 msgstr "Seleccione para mostrar las particiones de muestra a los contactos de cliente. Si está desactivado, las particiones no se incluirán en los listados y no se mostrará ningún mensaje informativo con enlaces a la muestra principal a los contactos de cliente."
@@ -8124,21 +8576,21 @@ msgstr "Seleccione para mostrar las particiones de muestra a los contactos de cl
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 #, fuzzy
 msgid "description_senaitesetup_sidebar_folders"
 msgstr "Seleccione las carpetas de primer nivel que deben mostrarse en la navegación lateral. El orden de selección determina el orden de visualización en la barra lateral. Si no se selecciona ninguna, se muestran todas las carpetas en el orden predeterminado."
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 #, fuzzy
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr "Profundidad máxima del árbol de navegación lateral. El nivel 1 muestra solo las carpetas de primer nivel, el nivel 2 incluye sus elementos hijos, y así sucesivamente."
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 #, fuzzy
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr "Seleccione los tipos de contenido que deben excluirse de la navegación lateral. Si no se selecciona ninguno, se mostrarán todos los tipos de contenido."
@@ -8146,14 +8598,14 @@ msgstr "Seleccione los tipos de contenido que deben excluirse de la navegación 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 #, fuzzy
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr "Seleccione el tipo de verificación múltiple para el mismo usuario. Esta configuración puede activar o desactivar la verificación o verificación consecutiva más de una vez para el mismo usuario."
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 #, fuzzy
 msgid "description_senaitesetup_vat"
 msgstr "Introduzca el porcentaje de IVA, p.ej. 14.0. Este porcentaje se aplica en todo el sistema pero puede sobreescribirse en elementos individuales"
@@ -8162,7 +8614,7 @@ msgstr "Introduzca el porcentaje de IVA, p.ej. 14.0. Este porcentaje se aplica e
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 #, fuzzy
 msgid "description_senaitesetup_worksheet_layout"
 msgstr "Distribución preferida de la tabla de entrada de resultados en la vista de hoja de trabajo. La distribución clásica muestra las muestras en filas y los análisis en columnas. La distribución transpuesta muestra las muestras en columnas y los análisis en filas."
@@ -8170,7 +8622,7 @@ msgstr "Distribución preferida de la tabla de entrada de resultados en la vista
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 #, fuzzy
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr "Seleccione las columnas que se mostrarán en los listados de análisis de hojas de trabajo. El orden de selección determina el orden de visualización. Las columnas no seleccionadas se ocultan. Si no se selecciona ninguna, se muestran todas las columnas en el orden predeterminado."
@@ -8178,7 +8630,7 @@ msgstr "Seleccione las columnas que se mostrarán en los listados de análisis d
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 #, fuzzy
 msgid "description_setup_landingpage"
 msgstr "Página por defecto para usuarios anónimos o para usuarios autentificados cuando la vista principal con indicadores está desactivada. Si no selecciona ninguna página de inicio, el sistema mostrará la página de de bienvenida por defecto."
@@ -8300,47 +8752,51 @@ msgstr "El duplicado en la posición ${dup} referencia esta posición, por lo qu
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr ""
+msgstr "${days} días"
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr ""
+msgstr "${hours} horas"
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr ""
+msgstr "Días"
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr ""
+msgstr "Horas"
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr ""
+msgstr "Minutos"
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr ""
+msgstr "Segundos"
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr ""
+msgstr "${minutes} minutos"
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr ""
+msgstr "${seconds} segundos"
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
 msgstr "Contenido del archivo"
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
+msgstr "editado"
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8382,202 +8838,202 @@ msgstr "Particiones"
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/formula.py:121
 msgid "formula_validation_chain_error"
-msgstr ""
+msgstr "Error interno de la cadena de validación: ${error}"
 
 #. Default: "cryogenic / inert gas"
 #: senaite/core/vocabularies/hazard_categories.py:167
 msgid "hazard_ASPH01_common"
-msgstr ""
+msgstr "criogénico / gas inerte"
 
 #. Default: "Asphyxiating atmosphere"
 #: senaite/core/vocabularies/hazard_categories.py:165
 msgid "hazard_ASPH01_name"
-msgstr ""
+msgstr "Atmósfera asfixiante"
 
 #. Default: "infectious / biological"
 #: senaite/core/vocabularies/hazard_categories.py:104
 msgid "hazard_BIO01_common"
-msgstr ""
+msgstr "infeccioso / biológico"
 
 #. Default: "Biohazard"
 #: senaite/core/vocabularies/hazard_categories.py:103
 msgid "hazard_BIO01_name"
-msgstr ""
+msgstr "Riesgo biológico"
 
 #. Default: "freezing / cold storage"
 #: senaite/core/vocabularies/hazard_categories.py:158
 msgid "hazard_COLD01_common"
-msgstr ""
+msgstr "congelación / almacenamiento en frío"
 
 #. Default: "Low temperature"
 #: senaite/core/vocabularies/hazard_categories.py:157
 msgid "hazard_COLD01_name"
-msgstr ""
+msgstr "Baja temperatura"
 
 #. Default: "electric shock"
 #: senaite/core/vocabularies/hazard_categories.py:132
 msgid "hazard_ELEC01_common"
-msgstr ""
+msgstr "descarga eléctrica"
 
 #. Default: "Electricity"
 #: senaite/core/vocabularies/hazard_categories.py:131
 msgid "hazard_ELEC01_name"
-msgstr ""
+msgstr "Electricidad"
 
 #. Default: "explosive"
 #: senaite/core/vocabularies/hazard_categories.py:48
 msgid "hazard_GHS01_common"
-msgstr ""
+msgstr "explosivo"
 
 #. Default: "Explosive"
 #: senaite/core/vocabularies/hazard_categories.py:47
 msgid "hazard_GHS01_name"
-msgstr ""
+msgstr "Explosivo"
 
 #. Default: "flammable"
 #: senaite/core/vocabularies/hazard_categories.py:54
 msgid "hazard_GHS02_common"
-msgstr ""
+msgstr "inflamable"
 
 #. Default: "Flammable"
 #: senaite/core/vocabularies/hazard_categories.py:53
 msgid "hazard_GHS02_name"
-msgstr ""
+msgstr "Inflamable"
 
 #. Default: "oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:60
 msgid "hazard_GHS03_common"
-msgstr ""
+msgstr "oxidante"
 
 #. Default: "Oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:59
 msgid "hazard_GHS03_name"
-msgstr ""
+msgstr "Oxidante"
 
 #. Default: "pressurised gas"
 #: senaite/core/vocabularies/hazard_categories.py:66
 msgid "hazard_GHS04_common"
-msgstr ""
+msgstr "gas presurizado"
 
 #. Default: "Compressed gas"
 #: senaite/core/vocabularies/hazard_categories.py:65
 msgid "hazard_GHS04_name"
-msgstr ""
+msgstr "Gas comprimido"
 
 #. Default: "acid / caustic"
 #: senaite/core/vocabularies/hazard_categories.py:72
 msgid "hazard_GHS05_common"
-msgstr ""
+msgstr "ácido / cáustico"
 
 #. Default: "Corrosive"
 #: senaite/core/vocabularies/hazard_categories.py:71
 msgid "hazard_GHS05_name"
-msgstr ""
+msgstr "Corrosivo"
 
 #. Default: "poisonous"
 #: senaite/core/vocabularies/hazard_categories.py:78
 msgid "hazard_GHS06_common"
-msgstr ""
+msgstr "venenoso"
 
 #. Default: "Acute toxicity"
 #: senaite/core/vocabularies/hazard_categories.py:77
 msgid "hazard_GHS06_name"
-msgstr ""
+msgstr "Toxicidad aguda"
 
 #. Default: "harmful / irritant"
 #: senaite/core/vocabularies/hazard_categories.py:84
 msgid "hazard_GHS07_common"
-msgstr ""
+msgstr "nocivo / irritante"
 
 #. Default: "Health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:83
 msgid "hazard_GHS07_name"
-msgstr ""
+msgstr "Peligro para la salud"
 
 #. Default: "carcinogenic / mutagenic"
 #: senaite/core/vocabularies/hazard_categories.py:90
 msgid "hazard_GHS08_common"
-msgstr ""
+msgstr "cancerígeno / mutágeno"
 
 #. Default: "Serious health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:89
 msgid "hazard_GHS08_name"
-msgstr ""
+msgstr "Peligro grave para la salud"
 
 #. Default: "environmentally hazardous"
 #: senaite/core/vocabularies/hazard_categories.py:97
 msgid "hazard_GHS09_common"
-msgstr ""
+msgstr "peligroso para el medio ambiente"
 
 #. Default: "Environmental hazard"
 #: senaite/core/vocabularies/hazard_categories.py:96
 msgid "hazard_GHS09_name"
-msgstr ""
+msgstr "Peligro medioambiental"
 
 #. Default: "heated material"
 #: senaite/core/vocabularies/hazard_categories.py:145
 msgid "hazard_HOT01_common"
-msgstr ""
+msgstr "material caliente"
 
 #. Default: "Hot content"
 #: senaite/core/vocabularies/hazard_categories.py:144
 msgid "hazard_HOT01_name"
-msgstr ""
+msgstr "Contenido caliente"
 
 #. Default: "hot to touch"
 #: senaite/core/vocabularies/hazard_categories.py:139
 msgid "hazard_HSURF01_common"
-msgstr ""
+msgstr "caliente al tacto"
 
 #. Default: "Hot surface"
 #: senaite/core/vocabularies/hazard_categories.py:138
 msgid "hazard_HSURF01_name"
-msgstr ""
+msgstr "Superficie caliente"
 
 #. Default: "NMR / MRI"
 #: senaite/core/vocabularies/hazard_categories.py:125
 msgid "hazard_MAG01_common"
-msgstr ""
+msgstr "RMN / RM"
 
 #. Default: "Magnetic field"
 #: senaite/core/vocabularies/hazard_categories.py:124
 msgid "hazard_MAG01_name"
-msgstr ""
+msgstr "Campo magnético"
 
 #. Default: "UV / laser / RF"
 #: senaite/core/vocabularies/hazard_categories.py:118
 msgid "hazard_NIR01_common"
-msgstr ""
+msgstr "UV / láser / RF"
 
 #. Default: "Non-ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:117
 msgid "hazard_NIR01_name"
-msgstr ""
+msgstr "Radiación no ionizante"
 
 #. Default: "ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:112
 msgid "hazard_RAD01_common"
-msgstr ""
+msgstr "radiación ionizante"
 
 #. Default: "Radioactive"
 #: senaite/core/vocabularies/hazard_categories.py:111
 msgid "hazard_RAD01_name"
-msgstr ""
+msgstr "Radiactivo"
 
 #. Default: "autoclave / sterilisation"
 #: senaite/core/vocabularies/hazard_categories.py:151
 msgid "hazard_STEAM01_common"
-msgstr ""
+msgstr "autoclave / esterilización"
 
 #. Default: "Hot steam"
 #: senaite/core/vocabularies/hazard_categories.py:150
 msgid "hazard_STEAM01_name"
-msgstr ""
+msgstr "Vapor caliente"
 
 #. Default: "Hazardous"
 #: senaite/core/api/hazard.py:37
 msgid "hazard_warning_label"
-msgstr ""
+msgstr "Peligroso"
 
 #. Default: "Legacy Setup"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:16
@@ -8611,12 +9067,12 @@ msgstr "horas"
 #. Default: "'${function}' not found in module '${module}'"
 #: senaite/core/validators/imports.py:66
 msgid "importable_function_error"
-msgstr ""
+msgstr "'${function}' no se encontró en el módulo '${module}'"
 
 #. Default: "Could not import module '${module}'"
 #: senaite/core/validators/imports.py:49
 msgid "importable_module_error"
-msgstr ""
+msgstr "No se pudo importar el módulo '${module}'"
 
 #: bika/lims/browser/publish/templates/email.pt:189
 msgid "in"
@@ -8630,30 +9086,30 @@ msgstr "Exportador de instrumento no encontrado"
 #. Default: "Interim field ${row_num}: ${message}"
 #: senaite/core/validators/interimfields.py:299
 msgid "interim_field_error"
-msgstr ""
+msgstr "Campo provisional ${row_num}: ${message}"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/interimfields.py:278
 msgid "interims_validation_chain_error"
-msgstr ""
+msgstr "Error interno de la cadena de validación: ${error}"
 
 #. Default: "'${field_name}' contains invalid characters"
 #: senaite/core/validators/interimfields.py:68
 msgid "invalid_characters_validator_error"
-msgstr ""
+msgstr "'${field_name}' contiene caracteres no válidos"
 
 #. Default: "AnalysesServices not found for keywords: ${keywords}"
 #: senaite/core/validators/formula.py:92
 msgid "invalid_keyword_error"
-msgstr ""
+msgstr "No se encontraron Servicios de análisis para las palabras clave: ${keywords}"
 
 #. Default: "Invalid wildcards found: ${wildcards}"
 #: senaite/core/validators/formula.py:71
 msgid "invalid_wildcards_check_error"
-msgstr ""
+msgstr "Se encontraron comodines no válidos: ${wildcards}"
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr "Etiquetas"
 
@@ -8716,7 +9172,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr "Tiempo máximo de estabilidad"
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr "Criterio de ordenación"
 
@@ -8834,59 +9290,59 @@ msgid "label_batch_client"
 msgstr "Cliente"
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr "Permitir establecer la fecha de captura del resultado"
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr "Notificar responsables por correo electrónico al publicar resultados"
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr "Categorizar análisis de muestras"
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr "Fecha de muestreo obligatoria"
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr "Cuerpo del correo electrónico para notificaciones de publicación de muestras"
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr "Dirección 'De' para publicaciones"
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr "Entrada immediata de resultados"
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr "Cuerpo del correo electrónico para notificaciones de invalidación de muestras"
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr "Motivo de invalidación obligatorio"
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr "No permitir el registro de muestras sin análisis"
 
 #. Default: "DependentServices"
 #: senaite/core/content/calculation.py:352
 msgid "label_calculation_dependent_services"
-msgstr ""
+msgstr "Servicios dependientes"
 
 #. Default: "Dependent services"
 #: bika/lims/content/calculation.py:81
@@ -8896,52 +9352,52 @@ msgstr "Servicios dependientes"
 #. Default: "Calculation Formula"
 #: senaite/core/content/calculation.py:287
 msgid "label_calculation_formula"
-msgstr ""
+msgstr "Fórmula de cálculo"
 
 #. Default: "Function"
 #: senaite/core/content/calculation.py:185
 msgid "label_calculation_import_function_name"
-msgstr ""
+msgstr "Función"
 
 #. Default: "Module"
 #: senaite/core/content/calculation.py:179
 msgid "label_calculation_import_module_name"
-msgstr ""
+msgstr "Módulo"
 
 #. Default: "Additional Python Libraries"
 #: senaite/core/content/calculation.py:266
 msgid "label_calculation_imports"
-msgstr ""
+msgstr "Bibliotecas de Python adicionales"
 
 #. Default: "Calculation Interim Fields"
 #: senaite/core/content/calculation.py:243
 msgid "label_calculation_interims"
-msgstr ""
+msgstr "Campos provisionales del cálculo"
 
 #. Default: "Raw Test Result"
 #: senaite/core/content/calculation.py:336
 msgid "label_calculation_raw_test_keywords"
-msgstr ""
+msgstr "Resultado de prueba sin procesar"
 
 #. Default: "Keyword"
 #: senaite/core/content/calculation.py:198
 msgid "label_calculation_test_param_keyword"
-msgstr ""
+msgstr "Palabra clave"
 
 #. Default: "Value"
 #: senaite/core/content/calculation.py:207
 msgid "label_calculation_test_param_value"
-msgstr ""
+msgstr "Valor"
 
 #. Default: "Test Parameters"
 #: senaite/core/content/calculation.py:317
 msgid "label_calculation_test_params"
-msgstr ""
+msgstr "Parámetros de prueba"
 
 #. Default: "Test Result"
 #: senaite/core/content/calculation.py:343
 msgid "label_calculation_test_result"
-msgstr ""
+msgstr "Resultado de prueba"
 
 #. Default: "Department"
 #: bika/lims/content/analysiscategory.py:59
@@ -8949,12 +9405,12 @@ msgid "label_category_department"
 msgstr "Departamento"
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr "Categorías por defecto"
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr "Categorías disponibles"
 
@@ -8964,7 +9420,7 @@ msgid "label_confirm_password"
 msgstr "Confirmar contraseña"
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr "Contactos en copia"
 
@@ -9073,52 +9529,52 @@ msgstr "Realizada por"
 #. Default: "Allow empty"
 #: senaite/core/schema/interimfields.py:87
 msgid "label_interim_allow_empty"
-msgstr ""
+msgstr "Permitir vacío"
 
 #. Default: "Apply wide"
 #: senaite/core/schema/interimfields.py:127
 msgid "label_interim_apply_wide"
-msgstr ""
+msgstr "Aplicar de forma amplia"
 
 #. Default: "Choices"
 #: senaite/core/schema/interimfields.py:67
 msgid "label_interim_choices"
-msgstr ""
+msgstr "Opciones"
 
 #. Default: "Default value"
 #: senaite/core/schema/interimfields.py:57
 msgid "label_interim_default_value"
-msgstr ""
+msgstr "Valor predeterminado"
 
 #. Default: "Hidden"
 #: senaite/core/schema/interimfields.py:117
 msgid "label_interim_hidden"
-msgstr ""
+msgstr "Oculto"
 
 #. Default: "Keyword"
 #: senaite/core/schema/interimfields.py:37
 msgid "label_interim_keyword"
-msgstr ""
+msgstr "Palabra clave"
 
 #. Default: "Report"
 #: senaite/core/schema/interimfields.py:107
 msgid "label_interim_report"
-msgstr ""
+msgstr "Informe"
 
 #. Default: "Result type"
 #: senaite/core/schema/interimfields.py:76
 msgid "label_interim_result_type"
-msgstr ""
+msgstr "Tipo de resultado"
 
 #. Default: "Field title"
 #: senaite/core/schema/interimfields.py:47
 msgid "label_interim_title"
-msgstr ""
+msgstr "Título del campo"
 
 #. Default: "Unit"
 #: senaite/core/schema/interimfields.py:97
 msgid "label_interim_unit"
-msgstr ""
+msgstr "Unidad"
 
 #. Default: "Default Department"
 #: bika/lims/content/labcontact.py:86
@@ -9261,7 +9717,7 @@ msgid "label_powered_by_plone"
 msgstr "Plone y Python"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr "Preferencia de publicación"
 
@@ -9273,7 +9729,7 @@ msgstr "Blanco"
 #. Default: "Hazard categories"
 #: bika/lims/content/referencedefinition.py:104
 msgid "label_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro"
 
 #. Default: "Hazardous"
 #: bika/lims/content/referencedefinition.py:89
@@ -9288,7 +9744,7 @@ msgstr "Valores de referencia"
 #. Default: "Hazard categories"
 #: bika/lims/content/referencesample.py:116
 msgid "label_referencesample_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/referencesample.py:133
@@ -9353,7 +9809,7 @@ msgstr "Permitir pegado múltiple"
 #. Default: "Commit each sample in its own transaction"
 #: senaite/core/registry/schema.py:387
 msgid "label_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Confirmar cada muestra en su propia transacción"
 
 #. Default: "Copy sample structure with partitions"
 #: senaite/core/registry/schema.py:324
@@ -9386,12 +9842,12 @@ msgid "label_registry_worksheet_settings"
 msgstr "Hoja de trabajo"
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr "Muestras incluidas"
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr "Muestra principal"
 
@@ -9433,7 +9889,7 @@ msgstr "Muestra original"
 #. Default: "Duplicated from sample"
 #: bika/lims/content/analysisrequest.py:1280
 msgid "label_sample_duplicated_from"
-msgstr ""
+msgstr "Duplicada de la muestra"
 
 #. Default: "Invoice"
 #: bika/lims/content/analysisrequest.py:1046
@@ -9601,7 +10057,7 @@ msgid "label_sampletype_title"
 msgstr "Nombre"
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr "Guardar"
 
@@ -9611,12 +10067,12 @@ msgid "label_senaite"
 msgstr "SENAITE LIMS"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr "Valor máximo para el campo 'Número de muestras' en el formulario de registro de muestra"
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr "Página de bienvenida"
 
@@ -9675,6 +10131,23 @@ msgstr "Instrumento analítico"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
 msgstr "Método"
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr "Se añadieron ${count} etiqueta(s) a ${affected} muestra(s)"
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+#, fuzzy
+msgid "labels_changed"
+msgstr "Se aplicaron ${added} añadida(s) y ${removed} quitada(s) en ${affected} muestra(s)"
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
+msgstr "Se quitaron ${count} etiqueta(s) de ${affected} muestra(s)"
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
@@ -9929,42 +10402,42 @@ msgstr "Etiquetas de lote"
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/calculations/view.py:51
 msgid "listing_calculation_action_add"
-msgstr ""
+msgstr "Añadir"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/calculations/view.py:75
 msgid "listing_calculation_description"
-msgstr ""
+msgstr "Descripción"
 
 #. Default: "Formula"
 #: senaite/core/browser/controlpanel/calculations/view.py:82
 msgid "listing_calculation_formula"
-msgstr ""
+msgstr "Fórmula"
 
 #. Default: "Calculation"
 #: senaite/core/browser/controlpanel/calculations/view.py:68
 msgid "listing_calculation_title"
-msgstr ""
+msgstr "Cálculo"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/calculations/view.py:93
 msgid "listing_calculations_state_active"
-msgstr ""
+msgstr "Activo"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/calculations/view.py:111
 msgid "listing_calculations_state_all"
-msgstr ""
+msgstr "Todos"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/calculations/view.py:102
 msgid "listing_calculations_state_inactive"
-msgstr ""
+msgstr "Inactivo"
 
 #. Default: "Calculations"
 #: senaite/core/browser/controlpanel/calculations/view.py:58
 msgid "listing_calculations_title"
-msgstr ""
+msgstr "Cálculos"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/containertypes/view.py:51
@@ -10850,87 +11323,87 @@ msgid "listing_suppliers_title"
 msgstr "Proveedores"
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr "Añadir"
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr "Analista"
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr "Creado"
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr "Análisis de rutina"
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr "Análisis de QC"
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr "Muestras"
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr "Progreso"
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr "Estado"
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr "Plantilla"
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr "Hoja de trabajo"
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr "Activo"
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr "Todos"
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr "Mis hojas"
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr "Abierto"
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr "Por verificar"
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr "Verificado"
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr "Hojas de trabajo"
 
@@ -10983,6 +11456,11 @@ msgstr "Plantillas de hoja de trabajo"
 msgid "minutes"
 msgstr "minutos"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr "modificado"
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "mensual"
@@ -11005,22 +11483,22 @@ msgstr "El instrumento no tiene ninguna interfaz de datos seleccionada"
 #. Default: "Keyword '${duplicate}' duplicate found for a Analysis Service"
 #: senaite/core/validators/interimfields.py:97
 msgid "no_dup_service_keyword_validator_error"
-msgstr ""
+msgstr "Se encontró la palabra clave duplicada '${duplicate}' para un Servicio de análisis"
 
 #. Default: "'${duplicate}' duplicates found"
 #: senaite/core/validators/interimfields.py:83
 msgid "no_dups_values_validator_error"
-msgstr ""
+msgstr "Se encontraron duplicados de '${duplicate}'"
 
 #. Default: "Wildcards for  are not allowed: ${wildcards}"
 #: senaite/core/validators/formula.py:45
 msgid "no_wildcards__error"
-msgstr ""
+msgstr "No se permiten comodines para : ${wildcards}"
 
 #. Default: "'${field_name}' is required"
 #: senaite/core/validators/interimfields.py:54
 msgid "non_blank_validator_error"
-msgstr ""
+msgstr "'${field_name}' es obligatorio"
 
 #. view."
 #. Default: "Layout view '${view}' not found. Set '${default}' as layout view."
@@ -11034,13 +11512,21 @@ msgstr "Vista de distribución '${view}' no encontrada. Se establece '${default}
 msgid "num_of_positions_button_title"
 msgstr "Establecer"
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "de"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr "original"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "Resumen"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr "por listado"
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11119,6 +11605,11 @@ msgstr "Código de interfaz"
 msgid "this_sample_has_been_dispatched_by"
 msgstr "Esta muestra ha sido enviada el ${date} por ${actor} "
 
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
+msgstr "Esta muestra ha sido desechada por ${actor} el ${date}"
+
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
 #. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
@@ -11133,32 +11624,32 @@ msgstr "${H}:${M}"
 #. Default: "Accreditation"
 #: senaite/core/content/laboratory.py:170
 msgid "title_accreditation"
-msgstr ""
+msgstr "Acreditación"
 
 #. Default: "Accreditation Body Abbreviation"
 #: senaite/core/content/laboratory.py:149
 msgid "title_accreditation_body"
-msgstr ""
+msgstr "Abreviatura del organismo de acreditación"
 
 #. Default: "Accreditation Logo"
 #: senaite/core/content/laboratory.py:195
 msgid "title_accreditation_body_logo"
-msgstr ""
+msgstr "Logotipo de acreditación"
 
 #. Default: "Accreditation Body URL"
 #: senaite/core/content/laboratory.py:160
 msgid "title_accreditation_body_url"
-msgstr ""
+msgstr "URL del organismo de acreditación"
 
 #. Default: "Accreditation page header"
 #: senaite/core/content/laboratory.py:216
 msgid "title_accreditation_page_header"
-msgstr ""
+msgstr "Encabezado de la página de acreditación"
 
 #. Default: "Accreditation Reference"
 #: senaite/core/content/laboratory.py:182
 msgid "title_accreditation_reference"
-msgstr ""
+msgstr "Referencia de acreditación"
 
 #. Default: "Address"
 #: senaite/core/content/laboratory.py:88
@@ -11264,17 +11755,17 @@ msgstr "Este sitio fue construido usando el CMS/WCM de código abierto Plone."
 #. Default: "Description"
 #: senaite/core/content/calculation.py:228
 msgid "title_calculation_description"
-msgstr ""
+msgstr "Descripción"
 
 #. Default: "Name"
 #: senaite/core/content/calculation.py:220
 msgid "title_calculation_title"
-msgstr ""
+msgstr "Nombre"
 
 #. Default: "Confidence Level %"
 #: senaite/core/content/laboratory.py:123
 msgid "title_confidence_level"
-msgstr ""
+msgstr "Nivel de confianza %"
 
 #. Default: "Description"
 #: senaite/core/content/containertype.py:44
@@ -11351,25 +11842,30 @@ msgstr "Recepcionista"
 msgid "title_lab_manager_role"
 msgstr "Responsable"
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr "Color"
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr "Descripción"
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr "Nombre"
 
 #. Default: "Laboratory Accredited"
 #: senaite/core/content/laboratory.py:136
 msgid "title_laboratory_accredited"
-msgstr ""
+msgstr "Laboratorio acreditado"
 
 #. Default: "Lab URL"
 #: senaite/core/content/laboratory.py:98
 msgid "title_laboratory_lab_url"
-msgstr ""
+msgstr "URL del laboratorio"
 
 #. Default: "Description"
 #: senaite/core/content/labproduct.py:60
@@ -11445,6 +11941,11 @@ msgstr "Referencia"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
 msgstr "Tipo de análisis"
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
+msgstr "Gestionar viewlets"
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
@@ -11661,7 +12162,7 @@ msgstr "Periodo de conservación"
 #. Default: "Hazard categories"
 #: senaite/core/content/sampletype.py:178
 msgid "title_sampletype_hazard_categories"
-msgstr ""
+msgstr "Categorías de peligro"
 
 #. Default: "Hazardous"
 #: senaite/core/content/sampletype.py:166
@@ -11689,222 +12190,222 @@ msgid "title_samplingdeviation_title"
 msgstr "Nombre"
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr "Permitir establecer la fecha de captura del resultado"
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr "Permitir el envío de resultados para análisis no asignados"
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr "Notificar responsables por correo electrónico al publicar resultados"
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr "Cierre de sesión automático"
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr "Verificación automática de muestras"
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr "Categorizar servicios de análisis"
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr "Categorizar análisis de muestras"
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr "Moneda"
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr "Usar el panel de control como página principal por defecto"
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr "Fecha de muestreo obligatoria"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr "Separador decimal por defecto"
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr "País"
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr "Número de muestras por defecto a añadir."
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr "Dirección 'De' para publicaciones"
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr "Añadir campo de observaciones a todos los análisis"
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr "Activar especificaciones de muestra"
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr "Activar el flujo de trabajo de rechazo"
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr "Umbral de formato exponencial"
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr "Motivo de invalidación obligatorio"
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr "Página de inicio"
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr "Descuento de miembro %"
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr "Número mínimo de resultados para los cálculos de estadísticas de QC"
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr "Número de verificaciones requeridas"
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr "Cuerpo del correo electrónico para notificaciones de publicación de muestras"
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr "Motivos de rechazo"
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr "Restringir la gestión de hojas de trabajo a los responsables de laboratorio"
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr "Restringir el acceso a la hoja de trabajo a los analistas asignados"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr "Separador decimal por defecto"
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Permitir la duplicación de muestras"
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr "No permitir el registro de muestras sin análisis"
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr "Columnas de análisis en la vista de muestra"
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr "Formato de notación científica por defecto para informes"
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr "Formato de notación científica por defecto para resultados"
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr "Permitir la autoverificación de resultados"
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr "Mostrar el nombre del laboratorio en la página de inicio de sesión"
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr "Mostrar particiones de muestra a los clientes"
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr "Incluir y mostrar información de precios"
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr "Carpetas de navegación lateral"
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr "Profundidad de navegación lateral"
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr "Tipos de portal omitidos en la navegación lateral"
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr "Tipo de verificación múltiple"
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr "IVA %"
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr "Distribución por defecto en la vista de hoja de trabajo"
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr "Columnas de análisis en la vista de hoja de trabajo"
 
@@ -12163,7 +12664,7 @@ msgstr "El ID de la muestra de referencia no es válido. Asegúrese de que solo 
 msgid "validator_uloq_above_ulod"
 msgstr "El Límite superior de cuantificación (ULOQ) no puede ser superior al Límite superior de detección (ULOD)."
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "verificación(es) pendiente(s)"
 
@@ -12206,7 +12707,7 @@ msgstr "{sid} resultado para '{analysis_keyword}:{interim_keyword}': '{value}'"
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr "{sid} resultado para '{keyword}': '{result}'"
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr "{} (Caducado)"
 

--- a/src/senaite/core/locales/es_419/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_419/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Latin America) (https://app.transifex.com/senaite/teams/87045/es_419/)\n"

--- a/src/senaite/core/locales/es_419/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_419/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Latin America) (https://app.transifex.com/senaite/teams/87045/es_419/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/es_419/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_419/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Spanish (Latin America) (https://app.transifex.com/senaite/teams/87045/es_419/)\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: es_419\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -29,6 +29,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} archivos adjuntos con un tamaño total de ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -54,6 +55,7 @@ msgid "%s has no '%s' column."
 msgstr "%s no tiene la columna '%s'."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Back"
@@ -123,6 +125,10 @@ msgstr "*** Esto es un correo electrónico generado automáticamente, por favor 
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -140,7 +146,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Bienvenido a SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -198,7 +204,7 @@ msgid "Account Type"
 msgstr "Tipo de cuenta"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -243,21 +249,21 @@ msgstr "Activado"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Activo"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Actor"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Añadir"
 
@@ -285,15 +291,19 @@ msgstr "Añadir duplicado"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Añadir un campo de comentarios a todos los análisis"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -306,8 +316,11 @@ msgstr "Añadir nuevo archivo adjunto"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Añadir uno o más archivos adjuntos con información adicional sobre la muestra o para añadir especificaciones sobre la solicitud."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Añadir comentarios"
 
@@ -371,13 +384,21 @@ msgstr "Se muestran todos los análisis acreditados."
 msgid "All Analyses of Service"
 msgstr "Todas las analíticas del servicio de análisis"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Todos los análisis asignados"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Permitir ingreso manual de límite de detección"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -395,11 +416,11 @@ msgstr "Permitir que un mismo usuario pueda verificar múltiples veces"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Permitir que un mismo usuario pueda verificar múltiples veces, pero no consecutivamente"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Permitir verificación de resultados por el mismo usuario"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -428,15 +449,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Analizado por"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Análisis"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Análisis solicitados"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -505,7 +542,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Especificaciones de análisis que son editados directamente en la Muestra."
 
@@ -542,7 +579,7 @@ msgstr "Debe indicar un analista."
 msgid "Any"
 msgstr "Sin definir"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -553,6 +590,10 @@ msgstr "Aplicar cambios"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Aplicar plantilla"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -566,19 +607,15 @@ msgstr "Número de lote"
 msgid "Assign"
 msgstr "Asignar"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Con análisis asignados"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Asignado a: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Pendiente de asignación"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -592,7 +629,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -680,11 +717,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr "Registro de importaciones automáticas"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Partición automática en la recepción"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Auto-recibir muestras"
 
@@ -692,15 +733,15 @@ msgstr "Auto-recibir muestras"
 msgid "Autofill"
 msgstr "Auto-rellenado"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Cierre de sesión automático"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -751,7 +792,7 @@ msgstr "Caso"
 msgid "Batch Book"
 msgstr "Libro de lotes"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID del caso"
 
@@ -781,6 +822,10 @@ msgstr "Tenga en cuenta que los rangos provistos en el archivo de hoja de cálcu
 msgid "Bearing"
 msgstr "Retraso"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Dirección de facturación"
@@ -801,7 +846,7 @@ msgstr "Marca"
 msgid "Bulk Discount"
 msgstr "Descuento por volumen"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Descuento por volumen aplicable"
@@ -819,19 +864,19 @@ msgstr "Teléfono del trabajo"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -839,12 +884,12 @@ msgstr ""
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "Correos electrónicos en copia"
 
@@ -900,23 +945,23 @@ msgstr "Calibraciones"
 msgid "Calibrator"
 msgstr "Calibrador"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Puede verificar, aunque sea el mismo usuario que ha introducido los resultados"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Se puede verificar, pero ya fue verificado por el usuario actual"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -936,15 +981,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "No se puede verificar, ultima verificación realizada por el usuario actual"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "No se puede verificar, los resultados fueron enviados por el usuario actual"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "No se puede verificar, ya fue verificado por el usuario actual"
 
@@ -970,7 +1015,7 @@ msgstr "Contenido del Catálogo Dexterity en múltiples catálogos"
 msgid "Catalogue Number"
 msgstr "Número de catálogo"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Categorizar los servicios de análisis"
 
@@ -1002,11 +1047,11 @@ msgid "Changes Saved"
 msgstr "Cambios guardados."
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Cambios guardados."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Los cambios se propagarán a particiones"
 
@@ -1043,31 +1088,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Seleccione un tipo de verificación múltiple para el mismo usuario."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1080,20 +1125,34 @@ msgstr "Ciudad"
 msgid "Classic"
 msgstr "Clásico"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Clic para desplegar esta categoría"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Institución de referencia"
@@ -1105,7 +1164,7 @@ msgstr "ID Lote de Cliente"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID de Institución de Referencia"
 
@@ -1117,7 +1176,7 @@ msgstr "Página de inicio del cliente"
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Pedido de cliente"
 
@@ -1127,7 +1186,7 @@ msgstr "Pedido de cliente"
 msgid "Client Order Number"
 msgstr "Número de pedido de cliente"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Ref. del cliente"
 
@@ -1136,7 +1195,7 @@ msgstr "Ref. del cliente"
 msgid "Client Reference"
 msgstr "Referencia del cliente"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "ID de muestra del cliente"
 
@@ -1229,7 +1288,7 @@ msgstr "Comentarios"
 msgid "Comments or results interpretation"
 msgstr "Comentarios o interpretación de resultados"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "ID comercial"
@@ -1267,6 +1326,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1285,7 +1348,7 @@ msgstr "Confirme la contraseña"
 msgid "Considerations"
 msgstr "Consideraciones"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contacto"
@@ -1329,7 +1392,7 @@ msgstr "Recipientes de muestras"
 msgid "Contents of the file {}"
 msgstr "Contenido del archivo {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1362,15 +1425,15 @@ msgstr "Copiar servicio de análisis"
 msgid "Copy from"
 msgstr "Copiar desde"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Copiar a nuevo"
 
@@ -1380,6 +1443,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1398,11 +1465,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1415,7 +1482,7 @@ msgstr "País"
 msgid "Create Invoice PDF"
 msgstr "Crear Factura en PDF"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Crear Particiones"
 
@@ -1423,7 +1490,7 @@ msgstr "Crear Particiones"
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1435,7 +1502,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr "Crear un nuevo usuario"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1465,7 +1532,7 @@ msgid "Created {} partitions: {}"
 msgstr "Creadas {} particiones: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Creado por"
 
@@ -1474,7 +1541,7 @@ msgstr "Creado por"
 msgid "Criteria"
 msgstr "Criterios"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1482,13 +1549,21 @@ msgstr "Moneda"
 msgid "Current"
 msgstr "En curso"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Separador decimal personalizado"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "Límite de Detección"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1535,23 +1610,23 @@ msgstr "Fecha modificada"
 msgid "Date Opened"
 msgstr "Fecha de apertura"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Fecha de conservación"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Fecha de impresión"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Fecha de publicación"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Fecha de recepción"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Fecha de registro"
 
@@ -1563,11 +1638,11 @@ msgstr "Fecha de petición"
 msgid "Date Sample Received"
 msgstr "Fecha de recepción"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Fecha de muestreo"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Fecha de verificación"
 
@@ -1609,7 +1684,7 @@ msgstr "Fecha del certificado de calibración"
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1632,11 +1707,11 @@ msgstr "Desactivado hasta la próxima calibración"
 msgid "Deactivate"
 msgstr "Desactivar"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Separador decimal a utilizar en los informes de este Cliente."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1648,7 +1723,7 @@ msgstr "Recipiente por defecto"
 msgid "Default Department"
 msgstr "Departamento predeterminado"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Direcciones de correo electrónico a las que se enviará una copia de los informes de resultados para este cliente"
 
@@ -1660,7 +1735,7 @@ msgstr "Instrumento predeterminado"
 msgid "Default Method"
 msgstr "Método predeterminado"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1668,20 +1743,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Método de conservación por defecto"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Número predeterminado de muestras a ser añadidas"
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Separador decimal predeterminado"
 
@@ -1693,7 +1768,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr "Etiqueta grande predeterminada"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Orientación predeterminada en la vista de hojas de trabajo"
 
@@ -1725,15 +1800,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Periodo de retención por defecto de la muestra"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Formato de notación científica para los informes por defecto"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Formato de notación científica para los resultados por defecto"
 
@@ -1745,7 +1820,7 @@ msgstr "Etiqueta pequeña predeterminada"
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Tiempo requerido predeterminado para el procesado de análisis."
 
@@ -1754,7 +1829,7 @@ msgstr "Tiempo requerido predeterminado para el procesado de análisis."
 msgid "Default value"
 msgstr "Valor por defecto"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "Número predeterminado de muestras a mostrar en el formulario de creación"
 
@@ -1778,7 +1853,7 @@ msgstr "Precisión al convertir el resultado a notación exponencial. Valor pred
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Persona que realizará el muestreo en la fecha programada"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1790,8 +1865,17 @@ msgstr "Etiquetas predeterminadas para éste tipo de muestra"
 msgid "Degrees"
 msgstr "Grados"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1820,9 +1904,9 @@ msgstr "Departamentos"
 msgid "Dependent Analyses"
 msgstr "Análisis dependientes"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Descripción"
 
@@ -1869,7 +1953,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr "Desactivar la verificación múltiple para el mismo usuario"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Descuento"
@@ -1887,7 +1975,7 @@ msgstr "Enviar"
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Enviado"
@@ -1912,15 +2000,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr "Mostrar el selector de límites de detección"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Eliminar"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminados"
 
@@ -1990,11 +2086,15 @@ msgstr "Descargar PDF"
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Pendientes"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
@@ -2011,7 +2111,7 @@ msgstr "Duplicado"
 msgid "Duplicate Analysis"
 msgstr "Análisis duplicados"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2059,6 +2159,7 @@ msgstr "P.ej., ENAC, Applus, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Editar"
@@ -2073,21 +2174,21 @@ msgstr "Elevación"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Correo electrónico"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Dirección de correo electrónico"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2095,27 +2196,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "Registro de correo electrónico"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "Cuerpo del correo electrónico para enviar notificaciones de Invalidación"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2128,16 +2229,20 @@ msgstr "Correo electrónico cancelado"
 msgid "Email notification"
 msgstr "Notificación por correo electrónico"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "Notificar por correo electrónico el rechazo de muestras"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2148,27 +2253,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Activar el uso de múltiples equipos analíticos en hojas de trabajo."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Activar la funcionalidad de protocolos de conservación de muestras"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "Activar las especificaciones para muestras"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "Activar la funcionalidad de muestreo"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "Activar la funcionalidad de planificación periódica de muestreos"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2176,9 +2281,17 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr "Activar el flujo de muestreo para la muestra creada"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "Activar la funcionalidad de seguimiento de impresión de informes de resultados"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2201,7 +2314,7 @@ msgstr "Introduzca su dirección de correo electrónico. Es necesaria en caso de
 msgid "Enter discount percentage value"
 msgstr "Introducir el porcentaje de descuento"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2214,7 +2327,7 @@ msgstr "Introducir un porcentaje, p.ej. 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Introducir un porcentaje, p.ej. 14.0. Este porcentaje solo se aplicará al perfil de muestras y sobrescribirá el impuesto definido por defecto."
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Introducir un porcentaje, p.ej. 14.0. Este porcentaje se aplicará a todo el sistema, pero podrá ser sobrescrito individualmente para cada elemento."
 
@@ -2238,7 +2351,7 @@ msgstr "Introducir los detalles de cada uno de los servicios de análisis a copi
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Introducir los detalles de las acreditaciones de servicios del laboratorio aquí. Los campos disponibles son los siguientes: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference <br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2250,15 +2363,15 @@ msgstr "Condiciones ambientales"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Evolución de análisis"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Evolución de muestras"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Evolución de hojas de trabajo"
 
@@ -2270,7 +2383,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Excluir de la factura"
 
@@ -2280,7 +2393,7 @@ msgstr "Excluir de la factura"
 msgid "Expected Result"
 msgstr "Resultado esperado"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Fecha esperada de muestreo"
 
@@ -2306,7 +2419,7 @@ msgstr "Fecha de caducidad"
 msgid "Exponential format precision"
 msgstr "Precisión en formato exponencial"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Límite del formato exponencial"
 
@@ -2314,7 +2427,7 @@ msgstr "Límite del formato exponencial"
 msgid "Export"
 msgstr "Exportar"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "No se ha podido cargar la etiqueta"
 
@@ -2401,7 +2514,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "Tamaño del archivo"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2415,6 +2528,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2431,11 +2556,11 @@ msgstr "Primer nombre"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Valor numérico entre 0.0 y 1000.0 que indica el orden de los elementos. Los elementos duplicados se ordenan alfabéticamente."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Configuración de formatos"
 
@@ -2458,13 +2583,17 @@ msgstr "Viernes"
 msgid "From"
 msgstr "Desde"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Nombre completo"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Nombre completo"
 
@@ -2472,7 +2601,7 @@ msgstr "Nombre completo"
 msgid "Function"
 msgstr "Función"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Muestra con fecha de asignación futura"
 
@@ -2505,7 +2634,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Título de cortesía, como p.ej. Sr., Sra. o Dr."
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Agrupar los servicios de análisis por categorías. Esto es útil cuando la lista de servicios de análisis es demasiado larga"
 
@@ -2519,7 +2648,7 @@ msgid "Hazardous"
 msgstr "Peligroso"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Oculto"
@@ -2532,8 +2661,20 @@ msgstr "Campo Oculto"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2557,7 +2698,7 @@ msgstr "IBAN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2565,7 +2706,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr "Valores del servidor de IDs"
 
@@ -2585,15 +2726,15 @@ msgstr "Si está marcado, se mostrará una lista de selección junto al campo de
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Si está marcado, el instrumento no estará disponible hasta que se realice una calibración válida. Esta casilla de verificación se desactivará automáticamente."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Si está marcado, se mostrará un campo de texto libre cerca de cada análisis en la vista de entrada de resultados"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Si está marcado, el usuario que introduzco el resultado para un análisis también podrá verificarlo. Esta configuración solo tiene efecto para aquellos usuarios con un rol que les permite verificar los resultados (por defecto, gerentes, labmanagers y verificadores). La opción establecida aquí tiene prioridad sobre la opción establecida en \"Configuración general\""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Si está marcado, el usuario que introdució el resultado también podrá verificarlo. Esta configuración solo tiene efecto para los usuarios con un rol que les permite verificar los resultados (por defecto, gerentes, labmanagers y verificadores). Esta configuración puede anularse para una vista de edición de Análisis en un Servicio de Análisis determinada. Por defecto, está deshabilitado."
 
@@ -2601,7 +2742,7 @@ msgstr "Si está marcado, el usuario que introdució el resultado también podr�
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Si está marcado, el nombre del análisis se mostrará en cursiva."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "Si está marcado, este análisis y sus resultados no se mostrarán por defecto en los informes. Esta configuración también puede modificarse en perfiles de análisis y en muestras"
 
@@ -2641,7 +2782,7 @@ msgstr "Si está marcado, los reponsables del laboratorio no podrán asignar el 
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "Si tu fórmula necesita una función especial de una biblioteca Python externa, puedes importarla aquí. P.ej. si desea usar la función 'floor' del módulo 'math' de Python, agregue 'math' al campo Módulo y 'floor' al campo de función. El equivalente en Python sería 'from math import floor'. En tu cálculo, podrás usar 'floor ([Ca] + [Mg])'."
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2672,11 +2813,11 @@ msgstr "Procedimiento de calibración en el laboratorio"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Inactivo"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Incluir y mostrar información de precios"
 
@@ -2873,7 +3014,7 @@ msgid "Internal Certificate"
 msgstr "Certificado de calibración interno"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "Uso interno"
 
@@ -2894,13 +3035,13 @@ msgstr ""
 msgid "Interval"
 msgstr "Intervalo"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Inválido"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2963,15 +3104,15 @@ msgstr "Facturar a"
 msgid "Invoice {} created"
 msgstr "Factura {} creada"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "No se ha especificado fecha de fin para el lote de facturación"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "No se ha especificado fecha de inicio para el lote de facturación"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "Lote de facturación sin título"
 
@@ -2983,7 +3124,7 @@ msgstr "Cargo"
 msgid "Job title"
 msgstr "Cargo"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2995,9 +3136,9 @@ msgstr "Clave"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Palabra clave"
 
@@ -3013,6 +3154,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Palabras clave"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3057,8 +3202,8 @@ msgstr "Productos del laboratorio"
 msgid "Lab URL"
 msgstr "URL del laboratorio"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Etiqueta"
@@ -3067,7 +3212,7 @@ msgstr "Etiqueta"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3075,13 +3220,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3094,7 +3239,7 @@ msgstr "Laboratorio"
 msgid "Laboratory Accredited"
 msgstr "Laboratorio acreditado"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Días laborables del Laboratorio"
 
@@ -3106,7 +3251,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Etiqueta grande"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3118,11 +3263,11 @@ msgstr "Últimos registros de importación automática"
 msgid "Last Login Time"
 msgstr "Último registro de inicio de sesión"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Con retraso"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Análisis con retraso"
 
@@ -3168,15 +3313,15 @@ msgstr "Linkar usuario"
 msgid "Link an existing User"
 msgstr "Linka un usuario existente"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3200,7 +3345,7 @@ msgstr "Documento de la certificación"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3228,6 +3373,14 @@ msgstr "Tipo de Ubicación"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Ubicación donde se archiva el conjunto de documentos"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3291,7 +3444,7 @@ msgstr "Hombre"
 msgid "Manage Analyses"
 msgstr "Administrar análisis"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "Configurar los campos del formulario"
 
@@ -3315,7 +3468,7 @@ msgstr "Configurar los campos del formulario para Muestras"
 msgid "Manage linked User"
 msgstr "Administrar usuario vinculado"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3339,7 +3492,7 @@ msgstr "Correo del responsable"
 msgid "Manager Phone"
 msgstr "Teléfono del responsable"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Manual"
 
@@ -3368,7 +3521,7 @@ msgstr "Fabricantes"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "Marque la muestra solo para uso interno. Esto significa que solo es accesible para el personal del laboratorio y no para los clientes."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3383,7 +3536,7 @@ msgstr "Tiempo máximo"
 msgid "Max operator"
 msgstr "Operador max"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3418,15 +3571,15 @@ msgid "Member Discount"
 msgstr "Descuento para miembros"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "% de descuento para clientes habituales"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Aplicar descuento de cliente habitual"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Miembro registrado y vinculado al contacto actual."
 
@@ -3434,7 +3587,7 @@ msgstr "Miembro registrado y vinculado al contacto actual."
 msgid "Message sent to {}, "
 msgstr "Mensaje enviado a {},"
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3465,7 +3618,7 @@ msgstr "Inicial de Segundo Nombre"
 msgid "Middle name"
 msgstr "Segundo nombre"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3476,7 +3629,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr "Operador min"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3494,7 +3647,7 @@ msgstr "Tamaño mínimo de 5 caracteres"
 msgid "Minimum Volume"
 msgstr "Volumen mínimo"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Número mínimo de resultados para los cálculos estadísticos de QC"
 
@@ -3525,6 +3678,10 @@ msgstr "Módulo"
 msgid "Monday"
 msgstr "Lunes"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3538,11 +3695,11 @@ msgstr "Comportamiento de Catálogo múltiple para contenidos de Dexterity"
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "Tipo de verificación múltiple"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Se requiere verificación múltiple"
 
@@ -3578,13 +3735,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "Código Cuenta Cliente (IBAN/CCC/BIC)"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nombre"
 
@@ -3595,6 +3756,10 @@ msgstr ""
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
 msgstr "Los nuevos rangos no se aplicarán ni a los análisis nuevos ni a los actuales. Vuelva a asignar la especificación si desea aplicar los últimos cambios."
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
@@ -3637,6 +3802,10 @@ msgstr ""
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "No hay ninguna acción definida"
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3684,6 +3853,10 @@ msgstr "No se han realizado cambios"
 msgid "No changes made."
 msgstr "Sin cambios."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "No se ha indicado fecha"
@@ -3728,6 +3901,16 @@ msgstr "No ha seleccionado ningún elemento"
 msgid "No items selected."
 msgstr "No ha seleccionado ningún elemento."
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "No se han creado ítems nuevos."
@@ -3735,6 +3918,10 @@ msgstr "No se han creado ítems nuevos."
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "No se ha creado ninguna partición"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3751,6 +3938,10 @@ msgstr "Ninguna muestra fue rechazada"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Sin flujo de trabajo de muestreo"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3778,7 +3969,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Ninguno"
 
@@ -3794,11 +3985,11 @@ msgstr ""
 msgid "Not defined"
 msgstr "Sin definir"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "No establecido"
@@ -3819,7 +4010,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "Nota: También puede arrastrar y soltar las filas de archivos adjuntos para cambiar el orden en que aparecen en el informe."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3831,7 +4022,7 @@ msgstr "Número de columnas"
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Número de análisis"
 
@@ -3847,16 +4038,16 @@ msgstr "Número de copias"
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Número de verificaciones necesarias"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Número de verificaciones requeridas antes de que un resultado determinado se considere 'verificado'. Esta configuración se puede anular para una vista de edición de análisis en un servicio de análisis. Por defecto, 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Número de verificaciones necesarias de diferentes usuarios antes de que un resultado determinado para este análisis se considere como 'verificado'. La opción establecida aquí tiene prioridad sobre la opción establecida en la Configuración general."
 
@@ -3866,6 +4057,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3884,11 +4079,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "Solo se consideran los días laborables de laboratorio para el cálculo del tiempo de respuesta del análisis."
 
@@ -3896,13 +4091,13 @@ msgstr "Solo se consideran los días laborables de laboratorio para el cálculo 
 msgid "Only to empty or zero fields"
 msgstr "Solo campos sin valor o con valor cero"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Abierto"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3910,9 +4105,17 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Open Source Web based Laboratory Information Management System"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "Abra el formulario de correo electrónico para enviar los informes seleccionados a los destinatarios. Esto también publicará las muestras contenidas de los informes después de que el correo electrónico se haya enviado correctamente."
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3939,7 +4142,7 @@ msgstr "Otras razones"
 msgid "Other reasons:"
 msgstr "Otras razones:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Otro estado"
 
@@ -3961,11 +4164,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4062,11 +4265,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Seleccione un usuario de la lista"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4079,6 +4282,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4098,12 +4302,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Punto de muestreo"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4142,31 +4350,31 @@ msgstr "Precisión en el número de decimales"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Precisión como el número de dígitos significativos en función del valor de la incertidumbre. La posición decimal viene determinada por el primer número distinto de cero del valor de la incertidumbre. En esa posición, el sistema redondea el valor de la incertidumbre y del resultado. Por ejemplo, para un resultado de 5.243 y un valor de incertidumbre de 0.22, el sistema formatea el resultado como 5.2 ±0.2. Cuando el resultado no está dentro de ningún rango de incertidumbre especificado, el sistema trunca el resultado en función de la precisión decimal fija indicada."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Marcador decimal preferida para informes."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Marca decimal preferida para los resultados"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "Diseño de la vista de entada de resultados. El diseño clásico muestra las muestras en filas y los análisis en columnas. El diseño transpuesto muestra las muestras en columnas y los análisis en filas."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Formato de notación científica para informes"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Formato de notación científica para los resultados"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4199,7 +4407,7 @@ msgstr ""
 msgid "Preserve"
 msgstr "Preservar"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Conservador"
 
@@ -4216,11 +4424,11 @@ msgstr "Preventivo"
 msgid "Preventive maintenance procedure"
 msgstr "Procedimiento de mantenimiento preventivo"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "Previsualizar"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4248,7 +4456,7 @@ msgstr "Lista de precios"
 msgid "Pricelists"
 msgstr "Listas de precios"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4257,7 +4465,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "Muestra Primaria"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4279,11 +4487,11 @@ msgstr "Fecha de impresión:"
 msgid "Print pricelist"
 msgstr "Imprimir la lista de precios"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Imprimir pegatinas"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Impreso"
 
@@ -4296,7 +4504,7 @@ msgstr "Impreso en"
 msgid "Priority"
 msgstr "Prioridad"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Perfil"
 
@@ -4320,7 +4528,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Progreso"
 
@@ -4329,7 +4537,7 @@ msgstr "Progreso"
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "ID de protocolo"
 
@@ -4337,7 +4545,7 @@ msgstr "ID de protocolo"
 msgid "Province"
 msgstr "Provincia"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4346,8 +4554,12 @@ msgstr ""
 msgid "Publish"
 msgstr "Publicar"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Publicado"
@@ -4363,6 +4575,10 @@ msgstr "Fecha de publicación"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Resultados publicados"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4384,6 +4600,14 @@ msgstr "Resultados QC"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "ID Muestra QC"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4409,7 +4633,7 @@ msgstr "Introduzca de nuevo la clave. Asegúrese que las claves coinciden."
 msgid "Reasons for rejection"
 msgstr "Motivos de rechazo"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Reasignar"
 
@@ -4421,30 +4645,34 @@ msgstr "Disponible"
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Recibir"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Recibida"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Pendiente de recepción"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Destinatarios"
 
@@ -4495,11 +4723,15 @@ msgstr "Valores de referencia"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Los valores para las muestras de referencia son cero o 'blanco'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registro"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4525,9 +4757,9 @@ msgstr "Rechazar análisis"
 msgid "Reject samples"
 msgstr "Rechazar muestras"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Rechazado"
 
@@ -4543,7 +4775,7 @@ msgstr "Muestras rechazadas"
 msgid "Rejected {} samples: {}"
 msgstr "Rechazadas {} muestras: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4604,8 +4836,16 @@ msgstr "IP Remoto"
 msgid "Remove"
 msgstr "Eliminar"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4641,11 +4881,11 @@ msgstr "ID de informe"
 msgid "Report identification number"
 msgstr "Número de identificación de informe"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4657,7 +4897,7 @@ msgstr "Cargar informe"
 msgid "Republish"
 msgstr "Volver a publicar"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "Republicado después de la última impresión"
 
@@ -4666,7 +4906,7 @@ msgstr "Republicado después de la última impresión"
 msgid "Request ID"
 msgstr "ID de la solicitud"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Solicitar nuevos análisis"
 
@@ -4682,8 +4922,20 @@ msgstr "Volumen necesario"
 msgid "Reset"
 msgstr "Reset"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4691,15 +4943,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr "Responsables"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4724,15 +4977,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Resultado en el límite del rango"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "El resultado está fuera de rango"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr "El rango de resultados es diferente de la especificación: {}"
 
@@ -4740,7 +4993,7 @@ msgstr "El rango de resultados es diferente de la especificación: {}"
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Los resultados con al menos este número de dígitos significativos se muestran en notación científica con la letra 'e' para indicar el exponente. La precisión se puede configurar en los servicios de análisis individuales."
 
@@ -4756,16 +5009,20 @@ msgstr "Resultados"
 msgid "Results Interpretation"
 msgstr "Interpretación de resultados"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Los resultados han sido descartados"
 
@@ -4773,7 +5030,7 @@ msgstr "Los resultados han sido descartados"
 msgid "Results interpretation"
 msgstr "Interpretación de resultados"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Resultados pendientes"
 
@@ -4797,7 +5054,7 @@ msgstr "Prueba repetida"
 msgid "Retract"
 msgstr "Retirar"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4833,6 +5090,10 @@ msgstr "Restablecer"
 msgid "Routine Analyses"
 msgstr "Análisis rutinarios"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4858,6 +5119,7 @@ msgstr "SENAITE LIMS front-page"
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4867,7 +5129,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr "SENAITE LIMS front-page"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "Servidor SMTP desconectado. Creación de usuario abortada."
 
@@ -4881,7 +5143,7 @@ msgstr "Tratamiento"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Muestra"
 
@@ -4918,7 +5180,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "ID de muestra"
 
@@ -4938,7 +5200,7 @@ msgstr "Soporte de la muestra"
 msgid "Sample Partitions"
 msgstr "Particiones de muestras"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4965,7 +5227,7 @@ msgid "Sample Templates"
 msgstr "Plantillas de muestras"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Tipo de muestra"
@@ -5026,7 +5288,7 @@ msgstr "Tipo de muestra"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Muestreado por"
 
@@ -5038,8 +5300,8 @@ msgstr "Muestreador para el muestreo programado"
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Muestras"
@@ -5056,6 +5318,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5065,7 +5339,23 @@ msgstr "Las muestras de este tipo deben ser tratadas como peligrosas"
 msgid "Samples rejection reporting form"
 msgstr "Formulario de informe de rechazo de muestras"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5073,7 +5363,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Fecha prevista de muestreo"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Diferencias entre el muestreo previsto y el realizado"
@@ -5086,7 +5376,7 @@ msgstr "Diferencias entre el muestreo previsto y el realizado"
 msgid "Sampling Frequency"
 msgstr "Frecuencia de muestreo"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "Muestreo programado"
 
@@ -5094,14 +5384,23 @@ msgstr "Muestreo programado"
 msgid "Saturday"
 msgstr "Sábado"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Guardar"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5116,7 +5415,7 @@ msgstr "Tarea programada"
 msgid "Schedule sampling"
 msgstr "Programar el muestreo"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Muestreo programado"
@@ -5133,6 +5432,10 @@ msgstr "Nombre científico"
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5141,7 +5444,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Segundos"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5231,11 +5534,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Seleccionar la plantilla"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "País a mostrar por defecto"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Seleccione la moneda que se debe utilizar al mostrar los importes."
 
@@ -5247,11 +5550,11 @@ msgstr "Seleccionar el recipiente por defecto que debe ser utilizado para este s
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Seleccione la página de inicio predeterminada. Se muestra cuando un usuario de Cliente inicia la sesión en el sistema, o cuando se selecciona un cliente de la lista de carpetas del cliente."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5259,31 +5562,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr "Seleccione los tipos que este ID se usa para identificar."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "Seleccione para activar el envío automático de notificaciones por correo electrónico al cliente cuando una muestra sea rechazada"
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "Seleccione para activar el tablero de control como página inicial predeterminada."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Seleccione esta casilla para activar el flujo de trabajo de los pasos para la recogida de muestras."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Seleccione para permitir que un Coordinador de Muestreo programe un muestreo. Esta funcionalidad solo tiene efecto cuando el 'Flujo de trabajo de muestreo' está activo."
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "Seleccione recibir las muestras automáticamente cuando sea creado por el personal del laboratorio y el flujo de trabajo de muestreo esté desactivado. Las muestras creadas por los contactos del cliente no se recibirán automáticamente"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5295,7 +5606,7 @@ msgstr "Seleccione qué análisis desea incluir a la hoja de trabajo"
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Autoverificación de resultados"
 
@@ -5307,11 +5618,11 @@ msgstr "Enviar"
 msgid "Send Analysis Reports via Email"
 msgstr "Enviar informes de análisis por correo electrónico"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5333,7 +5644,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Recipiente por separado"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5347,7 +5658,7 @@ msgstr "Nº de serie"
 msgid "Service"
 msgstr "Servicio"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "El servicio no puede ser deseleccionado. Por favor, haga clic en el botón de información para más detalles."
 
@@ -5375,7 +5686,7 @@ msgstr "Establezca el flujo de trabajo de rechazo de muestra y las razones"
 msgid "Set the maintenance task as closed."
 msgstr "Asignar la tarea de mantenimiento como cerrada"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5423,28 +5734,40 @@ msgstr "¿Deben excluirse los análisis de la factura?"
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5467,11 +5790,11 @@ msgstr "Código del lugar"
 msgid "Site Description"
 msgstr "Descripción del lugar"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5492,7 +5815,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Etiqueta pequeña"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5509,6 +5832,14 @@ msgstr "Algunos servicios de análisis utilizan instrumentos sin calibración vi
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Clave de ordenación"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5534,7 +5865,7 @@ msgstr "Los rangos de especificación han cambiado desde que fueron asignados"
 msgid "Specifications"
 msgstr "Especificaciones"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5542,7 +5873,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Especifique el tamaño de la hoja de trabajo, por ejemplo, correspondiente al tamaño de la bandeja de un instrumento específico. Luego seleccione un 'tipo' de Análisis por posición de la Hoja de trabajo. Cuando se seleccionen muestras de QC, seleccione también qué Muestra de Referencia se debe usar. Si se selecciona un análisis duplicado, indique en qué posición de la muestra debería ser un duplicado de"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5559,17 +5890,17 @@ msgstr "Fecha de inicio"
 msgid "Start date must be before End Date"
 msgstr "La fecha de inicio debe ser anterior a la fecha de finalización"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Estado"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Estado"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Etiqueta"
@@ -5578,7 +5909,11 @@ msgstr "Etiqueta"
 msgid "Stickers preview"
 msgstr "Previsualización de etiquetas"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Ubicación de almacenamiento"
@@ -5618,7 +5953,11 @@ msgstr "Tramitar"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "Enviado y verificado por el mismo usuario: {}"
 
@@ -5626,7 +5965,7 @@ msgstr "Enviado y verificado por el mismo usuario: {}"
 msgid "Submitter"
 msgstr "Remitente"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotal"
@@ -5668,7 +6007,7 @@ msgstr "Cambiar al tablero de control"
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "Por defecto del sistema"
 
@@ -5694,7 +6033,7 @@ msgstr "Impuestos"
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descripción técnica e instrucciones para los analistas"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5776,7 +6115,7 @@ msgstr "La fecha en que se preservó la muestra"
 msgid "The date when the sample was received"
 msgstr "La fecha en que se recibió la muestra"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Se usará la tipo de separador decimal seleccionado en la configuración general del sistema."
 
@@ -5784,7 +6123,7 @@ msgstr "Se usará la tipo de separador decimal seleccionado en la configuración
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "El porcentaje de descuento solo se aplicará a clientes que estén etiquetados como 'clientes habituales'. Normalmente, se trata de miembros que forman parte de una cooperativa, asociados o clientes con contrato de mantenimiento."
 
@@ -5812,7 +6151,11 @@ msgstr "Se han creado las particiones siguientes:"
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5820,11 +6163,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Altura o profundidad del muestreo"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5861,11 +6204,11 @@ msgstr "Volumen mínimo de muestra necesario para efectuar el análisis (por eje
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "El número de días antes que caduque la muestras sin que pueda ser analizada más. Esta propiedad puede ser sobreescrita individualmente para cada tipo de muestra desde la página de configuración de tipos de muestras."
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Duración en minutos de la sesión de usuario en el sistema. Si desea desactivar la expulsión automática de usuarios, introduzca el valor 0."
 
@@ -5905,7 +6248,7 @@ msgstr "Código de referencia que la entidad de acreditación ha concedido al la
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "El resultado del cálculo ha sido obtenido a partir de los valores de la prueba. Es necesario guardar para que el cálculo se realize."
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5929,11 +6272,11 @@ msgstr "La muestra es un conjunto de sub-muestras"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Número de serie que identifica inequívocamente al equipo"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "Identificación del protocolo analítico del servicio."
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "La identificación comercial del servicio para fines contables."
 
@@ -5985,11 +6328,11 @@ msgstr "Esta es una Muestra Secundaria de"
 msgid "This is a detached partition from Sample"
 msgstr "Esta es una partición separada de la Muestra"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "Este es el tiempo máximo predeterminado permitido para realizar análisis. Solo se usa para análisis en los que el servicio de análisis no especifica un tiempo de respuesta. Solo se consideran los días laborables de laboratorio."
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6013,11 +6356,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6049,8 +6392,8 @@ msgstr "Fecha"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Consejo. Los documentos adjuntos no se cargarán a menos que estén presentes en la instancia."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Título"
@@ -6077,34 +6420,42 @@ msgstr "Nombre del lugar"
 msgid "To"
 msgstr "A"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Por conservar"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Por muestrear"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Se mostrará debajo de cada sección de Categoría de Análisis en los informes de resultados."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Por preservar"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "Pendiente de impresión"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Por muestrear"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Pendiente de verificación"
@@ -6117,7 +6468,7 @@ msgstr "Para probar el cálculo, puedes introducir valores aquí para todos los 
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6139,7 +6490,7 @@ msgid "Tuesday"
 msgstr "Martes"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Tipo"
@@ -6164,6 +6515,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6172,7 +6527,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6184,6 +6539,7 @@ msgstr "No se puede cargar la plantilla"
 msgid "Unassign"
 msgstr "Desasignar"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sin asignar"
@@ -6216,9 +6572,13 @@ msgstr "IBAN del país desconocido %s"
 msgid "Unlink User"
 msgstr "Desvincular usuario"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
 msgstr "Usuario desvinculado"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6234,13 +6594,17 @@ msgstr "Formato de archivo no válido: ${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr "Formato de archivo no válido: ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "Sin asignar"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Actualizar archivos adjuntos"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6250,7 +6614,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Cargar una firma digitalizada para que sea imprimida en los informes de resultados. Las dimensiones idóneas son 250 píxels de ancho por 150 píxels de alto."
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6258,7 +6622,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Utilizar el precio del perfil de análisis"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Use el tablero de control como página inicial predeterminada."
 
@@ -6296,7 +6660,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "Usuario vinculado a este contacto"
 
@@ -6304,15 +6668,15 @@ msgstr "Usuario vinculado a este contacto"
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "El uso de un número bajo de puntos de datos suele conllevar que los resultados del cálculo estadístico no tengan sentido. Establezca un número mínimo aceptable de resultados antes que se ejecuten los cálculos estadísticos de Control de Calidad (QC)"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6320,7 +6684,7 @@ msgstr "IVA"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "% IVA"
 
@@ -6567,8 +6931,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Los valores ingresados aquí anularan los establecidos en los campos de la sección de Cálculo Provisional"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verificadas"
@@ -6577,11 +6941,19 @@ msgstr "Verificadas"
 msgid "Verified By"
 msgstr "Verificado por"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Verificar"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6595,6 +6967,14 @@ msgstr "Detalle"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6630,6 +7010,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "Miércoles"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Semanas para expirar"
@@ -6642,19 +7026,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6705,10 +7089,18 @@ msgstr "Plantillas para hojas de trabajo"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Hojas de trabajo"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6717,6 +7109,10 @@ msgstr ""
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Longitud de IBAN incorrecta por%s: %s corto por %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6800,6 +7196,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6904,8 +7304,17 @@ msgstr "días"
 msgid "deactivate"
 msgstr "desactivar"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6970,7 +7379,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7137,46 +7546,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7188,19 +7597,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7221,16 +7630,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7255,12 +7669,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7270,7 +7684,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7373,6 +7787,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7402,6 +7829,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7548,12 +7982,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7806,7 +8240,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7814,163 +8248,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7978,47 +8412,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8027,20 +8461,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8048,32 +8482,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8081,21 +8515,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8251,6 +8685,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8563,7 +9001,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8624,7 +9062,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8740,52 +9178,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8855,12 +9293,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8870,7 +9308,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9166,7 +9604,7 @@ msgid "label_powered_by_plone"
 msgstr "Plone y Python"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9291,12 +9729,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9506,7 +9944,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9516,12 +9954,12 @@ msgid "label_senaite"
 msgstr "SENAITE LIMS"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9579,6 +10017,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10755,87 +11209,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10888,6 +11342,11 @@ msgstr ""
 msgid "minutes"
 msgstr "minutos"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "mensual"
@@ -10938,13 +11397,21 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "de"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "Resumen"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11021,6 +11488,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11255,13 +11727,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11348,6 +11825,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11593,222 +12075,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12062,7 +12544,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "Verificación(es) pendiente(s)"
 
@@ -12105,7 +12587,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/es_419/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_419/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Spanish (Latin America) (https://app.transifex.com/senaite/teams/87045/es_419/)\n"

--- a/src/senaite/core/locales/es_AR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_AR/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Argentina) (https://app.transifex.com/senaite/teams/87045/es_AR/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/es_AR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_AR/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Argentina) (https://app.transifex.com/senaite/teams/87045/es_AR/)\n"

--- a/src/senaite/core/locales/es_AR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_AR/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Spanish (Argentina) (https://app.transifex.com/senaite/teams/87045/es_AR/)\n"

--- a/src/senaite/core/locales/es_AR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_AR/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Spanish (Argentina) (https://app.transifex.com/senaite/teams/87045/es_AR/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: es_AR\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Activo"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Añadir"
 
@@ -284,15 +290,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -551,6 +588,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -565,18 +606,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr "Lote"
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Identificador de Lote"
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -800,7 +845,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr "Teléfono Empresarial"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Cambios guardados."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Cliente"
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Identificador de Cliente"
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1126,7 +1185,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1135,7 +1194,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1228,7 +1287,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1328,7 +1391,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "País"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1473,7 +1540,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1481,12 +1548,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Descripción"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Correo electrónico"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Dirección de correo electrónico"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Nombre completo"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Nombre completo"
 
@@ -2471,7 +2600,7 @@ msgstr "Nombre completo"
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Inactivo"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr "Masculino"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nombre"
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr "Provincia"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotal"
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Título"
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr "IVA"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6576,10 +6940,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,9 +7088,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/es_MX/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_MX/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Mexico) (https://app.transifex.com/senaite/teams/87045/es_MX/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/es_MX/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_MX/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Mexico) (https://app.transifex.com/senaite/teams/87045/es_MX/)\n"

--- a/src/senaite/core/locales/es_MX/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_MX/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Mexico) (https://app.transifex.com/senaite/teams/87045/es_MX/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: es_MX\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/es_MX/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_MX/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Mexico) (https://app.transifex.com/senaite/teams/87045/es_MX/)\n"

--- a/src/senaite/core/locales/es_PE/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_PE/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Peru) (https://app.transifex.com/senaite/teams/87045/es_PE/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/es_PE/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_PE/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Peru) (https://app.transifex.com/senaite/teams/87045/es_PE/)\n"

--- a/src/senaite/core/locales/es_PE/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_PE/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Spanish (Peru) (https://app.transifex.com/senaite/teams/87045/es_PE/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: es_PE\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Tipo de cuenta"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Activos"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Añadir"
 
@@ -284,15 +290,19 @@ msgstr "Añadir duplicado"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Agregar un campo de observaciones a todos los análisis"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr "Se muestran todos los análisis acreditados."
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Todos los análisis asignados"
 
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
+
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Análisis"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr "Cualquier"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr ""
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Aplicar plantilla"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,19 +606,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Asignado"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Asignado a: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr ""
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Cierre de sesión automático"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr "Lote"
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID Lote"
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Retraso"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Dirección de facturación"
@@ -800,7 +845,7 @@ msgstr "Marca"
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Descuento por volumen aplicable"
@@ -818,19 +863,19 @@ msgstr "Teléfono del negocio"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC Correos"
 
@@ -899,23 +944,23 @@ msgstr "Calibraciones"
 msgid "Calibrator"
 msgstr "Calibrador"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Número de catálogo"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr "Ciudad"
 msgid "Classic"
 msgstr "Clásico"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Cliente"
@@ -1104,7 +1163,7 @@ msgstr "ID Lote de Cliente"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID del cliente"
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Pedido de cliente"
 
@@ -1126,7 +1185,7 @@ msgstr "Pedido de cliente"
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Ref. del cliente"
 
@@ -1135,7 +1194,7 @@ msgstr "Ref. del cliente"
 msgid "Client Reference"
 msgstr "Referencia del cliente"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "ID de muestra del cliente"
 
@@ -1228,7 +1287,7 @@ msgstr "Comentarios"
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Confirme la contraseña"
 msgid "Considerations"
 msgstr "Consideraciones"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contacto"
@@ -1328,7 +1391,7 @@ msgstr "Contenedores de muestras"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr "Copiar desde"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "País"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Creador"
 
@@ -1473,7 +1540,7 @@ msgstr "Creador"
 msgid "Criteria"
 msgstr "Criterios"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Moneda"
 
@@ -1481,12 +1548,20 @@ msgstr "Moneda"
 msgid "Current"
 msgstr "En curso"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Fecha de apertura"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Fecha de conservación"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Fecha de publicación"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Fecha de recepción"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr "Fecha de petición"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Fecha de muestreo"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr "Contenidor por defecto"
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Método de conservación por defecto"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Periodo de retención por defecto de la muestra"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Valor por defecto"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Grados"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Análisis dependientes"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Descripción"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Enviado"
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminados"
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Vencimiento"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
@@ -2010,7 +2110,7 @@ msgstr "Duplicado"
 msgid "Duplicate Analysis"
 msgstr "Análisis duplicados"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr "P.ej., ENAC, Applus, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr "Elevación"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Dirección de correo electrónico"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr "Introduzca su dirección de correo electrónico. Es necesaria en caso de
 msgid "Enter discount percentage value"
 msgstr "Introducir el porcentaje de descuento"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr "Introducir un porcentaje, p.ej. 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Introducir un porcentaje, p.ej. 14.0. Este porcentaje se aplicará a todo el sistema, pero podrá ser sobreescrito individualmente para cada elemento."
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Excluir de la factura"
 
@@ -2279,7 +2392,7 @@ msgstr "Excluir de la factura"
 msgid "Expected Result"
 msgstr "Resultado esperado"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr "Fecha de caducidad"
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr "Exportar"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr "Primer nombre"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr "Desde"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Nombre completo"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Muestra con fecha de asignación futura"
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Título de cortesía, como p.ej. Sr., Sra. o Dr."
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr "Peligroso"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr "Campo Oculto"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr "Procedimiento de calibración en el laboratorio"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr "Cargo"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr "Clave"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Palabra clave"
 
@@ -3012,6 +3153,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Palabras clave"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3056,8 +3201,8 @@ msgstr "Productos del laboratorio"
 msgid "Lab URL"
 msgstr "URL del laboratorio"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Etiqueta"
@@ -3066,7 +3211,7 @@ msgstr "Etiqueta"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr "Laboratorio"
 msgid "Laboratory Accredited"
 msgstr "Laboratorio acreditado"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Etiqueta grande"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Con retraso"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Análisis con retraso"
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr "Hombre"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr "Correo del responsable"
 msgid "Manager Phone"
 msgstr "Teléfono del responsable"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr "Fabricantes"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr "Tiempo máximo"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "% de descuento para clientes habituales"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Aplicar descuento de cliente habitual"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr "Tamaño mínimo de 5 caracteres"
 msgid "Minimum Volume"
 msgstr "Volumen mínimo"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Número mínimo de resultados para los cálculos estadísticos de QC"
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nombre"
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Ninguno"
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Abierto"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Punto de muestreo"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr "Precisión en el número de decimales"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Conservador"
 
@@ -4215,11 +4423,11 @@ msgstr "Preventivo"
 msgid "Preventive maintenance procedure"
 msgstr "Procedimiento de mantenimiento preventivo"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr "Lista de precios"
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr "Fecha de impresión:"
 msgid "Print pricelist"
 msgstr "Imprimir la lista de precios"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Perfil"
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Publicado"
@@ -4362,6 +4574,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Resultados publicados"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr "Introduzca de nuevo la clave. Asegúrese que las claves coinciden."
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Reasignar"
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Recibir"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Recibida"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr "Valores de referencia"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Los valores para las muestras de referencia son cero o 'blanco'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registro"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr "Análisis rechazado"
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "ID de la solicitud"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Solicitar nuevos análisis"
 
@@ -4681,8 +4921,20 @@ msgstr "Volumen necesario"
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "El resultado está fuera de rango"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr "Prueba repetida"
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr "Tratamiento"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Muestra"
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "ID de muestra"
 
@@ -4937,7 +5199,7 @@ msgstr "Soporte de la muestra"
 msgid "Sample Partitions"
 msgstr "Particiones de muestras"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Tipo de muestra"
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Muestreador"
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Muestras"
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr "Las muestras de este tipo deben ser tratadas como peligrosas"
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Fecha de muestreo"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Desviación en el muestreo"
@@ -5085,7 +5375,7 @@ msgstr "Desviaciones en el muestreo"
 msgid "Sampling Frequency"
 msgstr "Frecuencia de muestreo"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Guardar"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr "Tarea programada"
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Segundos"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Seleccionar la plantilla"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Seleccione la moneda que se debe utilizar al mostrar los importes."
 
@@ -5246,11 +5549,11 @@ msgstr "Seleccionar el contenedor por defecto que debe utilizarse para este serv
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Seleccione esta casilla para activar el flujo de trabajo de los pasos para la recogida de muestras."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr "Seleccione qué análisis desea incluir a la hoja de trabajo"
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Contenedor separado"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr "Nº de serie"
 msgid "Service"
 msgstr "Servicio"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr "Asignar la tarea de mantenimiento como cerrada"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Etiqueta pequeña"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "Especificaciones"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Estado"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Estado"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Etiqueta"
@@ -5577,7 +5908,11 @@ msgstr "Etiqueta"
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr "Tramitar"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotal"
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descripción técnica e instrucciones para los analistas"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "El porcentaje de descuento solo se aplicará a clientes que estén etiquetados como 'clientes habituales'."
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Altura o profundidad del muestreo"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr "Volumen mínimo de muestra necesario para efectuar el análisis (por eje
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "El número de días antes que caduque la muestras sin que pueda ser analizada más. Esta propiedad puede ser sobreescrita individualmente para cada tipo de muestra desde la página de configuración de tipos de muestras."
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "El número de minutos de duración de la sesión de usuario en el sistema. Si desea desactivar la expulsión automática de usuarios, introduzca el valor 0."
 
@@ -5904,7 +6247,7 @@ msgstr "Código de referencia que la entidad de acreditación ha concedido al la
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Número de serie que identifica inequívocamente al equipo"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Título"
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr "A"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Por conservar"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Por muestrear"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Pendiente de verificación"
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Tipo"
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sin asignar"
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Cargar una firma digitalizada para que sea imprimida en los informes de resultados. Las dimensiones idóneas son 250 píxels de ancho por 150 píxels de alto."
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "El uso de un número bajo de puntos de datos suele conllevar que los resultados del cálculo estadístico no tengan sentido. Estableced un número mínimo aceptable de resultados antes que se ejecuten los cálculos estadísticos de Control de Calidad (QC)"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr "IVA"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "% IVA"
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Los valores ingresados aquí anularan los establecidos en los campos de la sección de Cálculo Provisional"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verificado"
@@ -6576,10 +6940,18 @@ msgstr "Verificado"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,10 +7088,18 @@ msgstr "Plantillas para hojas de trabajo"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Hojas de trabajo"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "desactivar"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/es_PE/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_PE/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Spanish (Peru) (https://app.transifex.com/senaite/teams/87045/es_PE/)\n"

--- a/src/senaite/core/locales/es_UY/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_UY/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Uruguay) (https://app.transifex.com/senaite/teams/87045/es_UY/)\n"

--- a/src/senaite/core/locales/es_UY/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/es_UY/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Uruguay) (https://app.transifex.com/senaite/teams/87045/es_UY/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/es_UY/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_UY/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Uruguay) (https://app.transifex.com/senaite/teams/87045/es_UY/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: es_UY\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/es_UY/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es_UY/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Uruguay) (https://app.transifex.com/senaite/teams/87045/es_UY/)\n"

--- a/src/senaite/core/locales/fa/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fa/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Persian (https://app.transifex.com/senaite/teams/87045/fa/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/fa/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fa/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Persian (https://app.transifex.com/senaite/teams/87045/fa/)\n"

--- a/src/senaite/core/locales/fa/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fa/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Persian (https://app.transifex.com/senaite/teams/87045/fa/)\n"

--- a/src/senaite/core/locales/fa/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fa/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Persian (https://app.transifex.com/senaite/teams/87045/fa/)\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fa\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -29,6 +29,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "تعداد ${amount}  پیوست با اندازه کلی ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -54,6 +55,7 @@ msgid "%s has no '%s' column."
 msgstr "%s ستون '%s' را ندارد"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -123,6 +125,10 @@ msgstr "*** این یک ایمیل به صورت خودکار تولید می ش
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -140,7 +146,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> به Senaite خوش آمدید"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -198,7 +204,7 @@ msgid "Account Type"
 msgstr "نوع حساب"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -243,21 +249,21 @@ msgstr "فعال کردن"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "فعال"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "بازیگر"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "افزودن"
 
@@ -285,15 +291,19 @@ msgstr "همانند سازی"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "به تمام تجزیه و تحلیل ها ، یک بخش اظهارات اضافه کنید"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -306,8 +316,11 @@ msgstr "پیوست جدید اضافه کنید"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "برای توصیف نمونه در این نمونه یا مشخص کردن درخواست خود ، یک یا چند پیوست اضافه کنید."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "اظهارات اضافه کنید"
 
@@ -371,13 +384,21 @@ msgstr "همه خدمات تجزیه و تحلیل معتبر در اینجا ذ
 msgid "All Analyses of Service"
 msgstr "تمام تجزیه و تحلیل خدمات"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "همه تجزیه و تحلیل اختصاص داده شده است"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "اجازه دستیابی دستی محدود کردن ورودی"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -395,11 +416,11 @@ msgstr "به همان کاربر اجازه دهید چندین بار تأیی�
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "به همان کاربر اجازه دهید چندین بار تأیید کند ، اما نه به صورت متوالی"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "اجاره دهید تایید نتایج توسط خود شخص فعال شود."
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -428,15 +449,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "تحلیل شده توسط"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "آزمونها"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "درخواست آزمون"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -505,7 +542,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "مشخصات آزمون که مستقیماً بر روی نمونه اعمال می شوند. "
 
@@ -542,7 +579,7 @@ msgstr "باید آزمونگر مشخص شود."
 msgid "Any"
 msgstr "هر"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -553,6 +590,10 @@ msgstr "اعمال"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "اعمال الگو"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -566,19 +607,15 @@ msgstr ""
 msgid "Assign"
 msgstr "تخصیص دادن"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "تخصیص داده شده"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "تخصیص داده شده به : ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "وظیفه در حال انتظار"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -592,7 +629,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -680,11 +717,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr "درونریزی خودکار گزارش‌ها"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "دریافت نمونه خودکار"
 
@@ -692,15 +733,15 @@ msgstr "دریافت نمونه خودکار"
 msgid "Autofill"
 msgstr "پرکردن خودکار"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "خروج خودکار"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -751,7 +792,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr "دفترچه دسته‌بندی"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -781,6 +822,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "آدرس صورتحساب"
@@ -801,7 +846,7 @@ msgstr "نام تجاری"
 msgid "Bulk Discount"
 msgstr "تخفیف عمده"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "تخفیف عمده اعمال شده"
@@ -819,19 +864,19 @@ msgstr "تلفن محل کار"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -839,12 +884,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "رونوشت ایمیلها"
 
@@ -900,23 +945,23 @@ msgstr "کالیبراسیون‌ها"
 msgid "Calibrator"
 msgstr "کالیبره گر"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "می‌تواند تایید شود، ولی توسط کاربر کنونی ثبت شده"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "می‌تواند تایید شود، ولی قبلا توسط کاربر کنونی تایید شده"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "لغو"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "لغو شده"
 
@@ -936,15 +981,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -970,7 +1015,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "شماره کاتالوگ"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1002,11 +1047,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1043,31 +1088,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1080,12 +1125,26 @@ msgstr ""
 msgid "Classic"
 msgstr "کلاسیک"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1093,7 +1152,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1105,7 +1164,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1117,7 +1176,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "سفارش مشتری"
 
@@ -1127,7 +1186,7 @@ msgstr "سفارش مشتری"
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1136,7 +1195,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "شناسه نمونه مشتری"
 
@@ -1229,7 +1288,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1267,6 +1326,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1285,7 +1348,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "مخاطب"
@@ -1329,7 +1392,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1362,15 +1425,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1380,6 +1443,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1398,11 +1465,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1415,7 +1482,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr "ساخت PDF فاکتور"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1423,7 +1490,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1435,7 +1502,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1465,7 +1532,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1474,7 +1541,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1482,12 +1549,20 @@ msgstr ""
 msgid "Current"
 msgstr "جاری"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1535,23 +1610,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "تاریخ افتتاح"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "تاریخ انتشار"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "تاریخ دریافت"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1563,11 +1638,11 @@ msgstr "تاریخ درخواست"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "تاریخ نمونه برداری"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1609,7 +1684,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1632,11 +1707,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1648,7 +1723,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1660,7 +1735,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1668,20 +1743,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1693,7 +1768,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1725,15 +1800,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "دوره پیش فرض نگهداری نمونه"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1745,7 +1820,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1754,7 +1829,7 @@ msgstr ""
 msgid "Default value"
 msgstr "مقدار پیش فرض"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1778,7 +1853,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1790,8 +1865,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "درجه ها"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1820,9 +1904,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "آزمونهای وابسته"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "شرح"
 
@@ -1869,7 +1953,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1887,7 +1975,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "ارسال شده"
@@ -1912,15 +2000,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "آماده"
 
@@ -1990,11 +2086,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "مقرر"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "موعد مقرر"
@@ -2011,7 +2111,7 @@ msgstr "تکرار"
 msgid "Duplicate Analysis"
 msgstr "آزمایش تکراری"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2059,6 +2159,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "ویرایش"
@@ -2073,21 +2174,21 @@ msgstr "ترفیع"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "پست الکترونیک"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "آدرس پست الکترونیک"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2095,27 +2196,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2128,16 +2229,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2148,27 +2253,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2176,8 +2281,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2201,7 +2314,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr "میزان تخفیف را وارد کنید"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2214,7 +2327,7 @@ msgstr "ارزش را به درصد وارد شود"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2238,7 +2351,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2250,15 +2363,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2270,7 +2383,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "حذف از فاکتور"
 
@@ -2280,7 +2393,7 @@ msgstr "حذف از فاکتور"
 msgid "Expected Result"
 msgstr "نتیجه مورد انتظار"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2306,7 +2419,7 @@ msgstr "تاریخ انقضا"
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2314,7 +2427,7 @@ msgstr ""
 msgid "Export"
 msgstr "برون‌ریزی"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2401,7 +2514,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2415,6 +2528,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2431,11 +2556,11 @@ msgstr "نام"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2458,13 +2583,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "نام کامل"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2472,7 +2601,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2505,7 +2634,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "عنوان افراد مانند آقا، خانم، دکتر، غیره"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2519,7 +2648,7 @@ msgid "Hazardous"
 msgstr "خطرناک"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2532,8 +2661,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2557,7 +2698,7 @@ msgstr ""
 msgid "ID"
 msgstr "شناسه"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2565,7 +2706,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2585,15 +2726,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2601,7 +2742,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2641,7 +2782,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2672,11 +2813,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2873,7 +3014,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2894,13 +3035,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2963,15 +3104,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2983,7 +3124,7 @@ msgstr ""
 msgid "Job title"
 msgstr "عنوان شغلی"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2995,9 +3136,9 @@ msgstr "کلید"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "کلید واژه"
 
@@ -3013,6 +3154,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "کلید واژه ها"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3057,8 +3202,8 @@ msgstr "محصولات آزمایشگاه"
 msgid "Lab URL"
 msgstr "آدرس سایت آزمایشگاه"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3067,7 +3212,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3075,13 +3220,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3094,7 +3239,7 @@ msgstr "آزمایشگاه"
 msgid "Laboratory Accredited"
 msgstr "آزمایشگاه همکار"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3106,7 +3251,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "برچسب بزرگ"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3118,11 +3263,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "اخیر"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "آخرین آزمونها"
 
@@ -3168,15 +3313,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3200,7 +3345,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3227,6 +3372,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3291,7 +3444,7 @@ msgstr "مرد"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3315,7 +3468,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3339,7 +3492,7 @@ msgstr "ایمیل مدیر"
 msgid "Manager Phone"
 msgstr "تلفن مدیر"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3368,7 +3521,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3383,7 +3536,7 @@ msgstr "حداکثر زمان"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3418,15 +3571,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "٪ تخفیف عضو"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "تخفیف اعمال شده عضو"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3434,7 +3587,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3465,7 +3618,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3476,7 +3629,7 @@ msgstr "حداقل"
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3494,7 +3647,7 @@ msgstr "حداقل ۵ کاراکتر"
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3525,6 +3678,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3538,11 +3695,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3578,13 +3735,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "نام"
 
@@ -3594,6 +3755,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3636,6 +3801,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3684,6 +3853,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3728,12 +3901,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3750,6 +3937,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3778,7 +3969,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "هیچکدام"
 
@@ -3794,11 +3985,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3819,7 +4010,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3831,7 +4022,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3847,16 +4038,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3866,6 +4057,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3884,11 +4079,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3896,13 +4091,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "باز کردن"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3910,8 +4105,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3939,7 +4142,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3961,11 +4164,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4062,11 +4265,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4079,6 +4282,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4098,12 +4302,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Point of Capture"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4142,31 +4350,31 @@ msgstr "دقت بر اساس ارقام اعشاری"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4199,7 +4407,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4216,11 +4424,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4248,7 +4456,7 @@ msgstr "لیست قیمت برای"
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4257,7 +4465,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4279,11 +4487,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr "چاپ لیست قیمت"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4296,7 +4504,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "پروفایل"
 
@@ -4320,7 +4528,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4329,7 +4537,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4337,7 +4545,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4346,8 +4554,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "منتشر شده"
@@ -4363,6 +4575,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "انتشار نتایج"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4383,6 +4599,14 @@ msgstr "نتایج کنترل کیفیت"
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4409,7 +4633,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4421,30 +4645,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "دریافت"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "دریافت شده"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4495,11 +4723,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr "مقادیر نمونه مرجع صفر یا blank می باشد"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "ثبت نام"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4525,9 +4757,9 @@ msgstr "رد کردن آزمایش"
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4543,7 +4775,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4604,8 +4836,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4641,11 +4881,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4657,7 +4897,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4666,7 +4906,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "شناسه درخواست"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "درخواست آزمونهای جدید"
 
@@ -4682,8 +4922,20 @@ msgstr "حجم لازم"
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4691,15 +4943,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4724,15 +4977,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "نتیجه خارج از محدوده مجاز"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4740,7 +4993,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4756,16 +5009,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4773,7 +5030,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4797,7 +5054,7 @@ msgstr "Retested"
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4833,6 +5090,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4858,6 +5119,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4867,7 +5129,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4881,7 +5143,7 @@ msgstr "سلام و تهنیت"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "نمونه"
 
@@ -4918,7 +5180,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "شناسه نمونه"
 
@@ -4938,7 +5200,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4965,7 +5227,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "نوع نمونه"
@@ -5026,7 +5288,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5038,8 +5300,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "نمونه ها"
@@ -5056,6 +5318,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5065,7 +5339,23 @@ msgstr "نمونه های این نوع باید خطرناک تلقی شوند"
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5073,7 +5363,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "تاریخ نمونه برداری"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5086,7 +5376,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr "تناوب نمونه برداری"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5094,14 +5384,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "ذخیره کردن"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5116,7 +5415,7 @@ msgstr "برنامه"
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5133,6 +5432,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5141,7 +5444,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "ثانیه"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5231,11 +5534,11 @@ msgstr ""
 msgid "Select template"
 msgstr "انتخاب الگو"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5247,11 +5550,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5259,31 +5562,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5295,7 +5606,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5307,11 +5618,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5333,7 +5644,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5347,7 +5658,7 @@ msgstr "شماره سریال"
 msgid "Service"
 msgstr "خدمات"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5375,7 +5686,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5423,28 +5734,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5467,11 +5790,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5492,7 +5815,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "برچسب کوچک"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5508,6 +5831,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5534,7 +5865,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5542,7 +5873,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5559,17 +5890,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "State"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "وضعیت"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "برچسب"
@@ -5578,7 +5909,11 @@ msgstr "برچسب"
 msgid "Stickers preview"
 msgstr "پیشنمایش استیکر"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5618,7 +5953,11 @@ msgstr "ارائه"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5626,7 +5965,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "جمع کل"
@@ -5668,7 +6007,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5694,7 +6033,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5776,7 +6115,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5784,7 +6123,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5812,7 +6151,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5820,11 +6163,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5861,11 +6204,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5905,7 +6248,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5929,11 +6272,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5985,11 +6328,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6013,11 +6356,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6049,8 +6392,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "عنوان"
@@ -6077,34 +6420,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "باید تایید شود"
@@ -6117,7 +6468,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "جمع"
 
@@ -6139,7 +6490,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "نوع"
@@ -6164,6 +6515,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6172,7 +6527,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6184,6 +6539,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6216,8 +6572,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6234,12 +6594,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6250,7 +6614,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6258,7 +6622,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6296,7 +6660,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6304,15 +6668,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6320,7 +6684,7 @@ msgstr "مالیات ارزش افزوده"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6567,8 +6931,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "مقادیری را می توان در اینجا وارد کرد که پیش فرض های مشخص شده در فیلدهای موقت محاسبه را لغو کند"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "تایید شده"
@@ -6577,11 +6941,19 @@ msgstr "تایید شده"
 msgid "Verified By"
 msgstr "تایید شده توسط"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "تایید"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6595,6 +6967,14 @@ msgstr "مشاهده"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6630,6 +7010,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "چهارشنبه"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "هفته تا پایان اعتبار"
@@ -6642,19 +7026,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6705,10 +7089,18 @@ msgstr "الگوهای کاربرگ"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "کاربرگ ها"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6716,6 +7108,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6800,6 +7196,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6904,8 +7304,17 @@ msgstr "روز"
 msgid "deactivate"
 msgstr "غیرفعال"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6970,7 +7379,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7137,46 +7546,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7188,19 +7597,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7221,16 +7630,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7255,12 +7669,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7270,7 +7684,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7373,6 +7787,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7402,6 +7829,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7548,12 +7982,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7806,7 +8240,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7814,163 +8248,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7978,47 +8412,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8027,20 +8461,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8048,32 +8482,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8081,21 +8515,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8251,6 +8685,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8563,7 +9001,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8624,7 +9062,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8740,52 +9178,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8855,12 +9293,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8870,7 +9308,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9166,7 +9604,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9291,12 +9729,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9506,7 +9944,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9516,12 +9954,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9579,6 +10017,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10755,87 +11209,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10888,6 +11342,11 @@ msgstr ""
 msgid "minutes"
 msgstr "دقیقه"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "ماهانه"
@@ -10938,13 +11397,21 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "از"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "بررسی اجمالی"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11021,6 +11488,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11255,13 +11727,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11348,6 +11825,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11593,222 +12075,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12062,7 +12544,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "درحال انتظار جهت تایید"
 
@@ -12105,7 +12587,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/fa_IR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fa_IR/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Persian (Iran) (https://app.transifex.com/senaite/teams/87045/fa_IR/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/fa_IR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fa_IR/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Persian (Iran) (https://app.transifex.com/senaite/teams/87045/fa_IR/)\n"

--- a/src/senaite/core/locales/fa_IR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fa_IR/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Persian (Iran) (https://app.transifex.com/senaite/teams/87045/fa_IR/)\n"

--- a/src/senaite/core/locales/fa_IR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fa_IR/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Persian (Iran) (https://app.transifex.com/senaite/teams/87045/fa_IR/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fa_IR\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/fi/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fi/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Finnish (https://app.transifex.com/senaite/teams/87045/fi/)\n"

--- a/src/senaite/core/locales/fi/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fi/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Finnish (https://app.transifex.com/senaite/teams/87045/fi/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/fi/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fi/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Finnish (https://app.transifex.com/senaite/teams/87045/fi/)\n"

--- a/src/senaite/core/locales/fi/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fi/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Finnish (https://app.transifex.com/senaite/teams/87045/fi/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fi\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Asiakastyyppi"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Lisää"
 
@@ -284,15 +290,19 @@ msgstr "Lisää kopio"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -551,6 +588,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -565,18 +606,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -800,7 +845,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr "Työpuhelin"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC sähköposti"
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Peruutettu"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Luettelonumero"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr ""
 msgid "Classic"
 msgstr "Klassinen"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Asiakastilaus"
 
@@ -1126,7 +1185,7 @@ msgstr "Asiakastilaus"
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Asiakas viite"
 
@@ -1135,7 +1194,7 @@ msgstr "Asiakas viite"
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1228,7 +1287,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Vahvista salasana"
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kontaktihenkilö"
@@ -1328,7 +1391,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1473,7 +1540,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1481,12 +1548,20 @@ msgstr ""
 msgid "Current"
 msgstr "Nykyinen"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Avauspäivämäärä"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Julkaisupäivämäärä"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Vastaanottopäivämäärä"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr "Tiedustelupäivämäärä"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Näytteenotto pvm"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Oletusarvo"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Astetta"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Toimitettu"
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Lähetetty"
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Voimassaolepvm"
@@ -2010,7 +2110,7 @@ msgstr "Kopio"
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Sähköposti"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Sähköpostiosoite"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr "Oletustulos"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr "Etunimi"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Koko nimi"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr "Vaarallinen"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr "Tehtävänimike"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr "Avain"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr "Laboratorio"
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6576,10 +6940,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,9 +7088,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/fr/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fr/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: French (https://app.transifex.com/senaite/teams/87045/fr/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/fr/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fr/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: French (https://app.transifex.com/senaite/teams/87045/fr/)\n"

--- a/src/senaite/core/locales/fr/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fr/LC_MESSAGES/senaite.core.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Alexandre S, 2026\n"
 "Language-Team: French (https://app.transifex.com/senaite/teams/87045/fr/)\n"
@@ -22,7 +22,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fr\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr " <p>Le serveur d'ID fournis une liste séquentielle d'IDs pour differents objets comme les Échantillons, les Worksheets etc, basé sur un format spécifique défini pour chaque type d'objet.</p><p>Le format de séquence est construit en utilisant une syntaxe similaire à Python : en utilisant des préfixes variables prédéfinis par type de contenu, et un compteur numérique incrémental parcourant la séquence 'seq' et utilisant le nombre de chiffres défini comme par exemple '03d' pour une séquence allant de 001 à 999.</p><p>Les préfixes alphanumériques sont inclus dans l'ID final. Par exemple WS pour les Worksheet donnera via la séquence WS-{seq:03d} la liste d'ID suivante : WS-001, WS-002, WS-003 etc.</p><p>Pour un mix d'identifiants séquentiels utilisant des chiffres et des lettres, le mot-clef {alpha} peut être utilisé. Par exemple WS-{alpha:2a3d} donnera des identifiants comme WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Les variables utilisables sont :<table><tr><th style='width:150px'>Type de contenu</th><th>Variables</th></tr><tr><td>ID Client</td><td>{clientId}</td></tr><tr><td>Année</td><td>{year}</td></tr><tr><td>ID Échantillon</td><td>{sampleId}</td></tr><tr><td>Type d'échantillon</td><td>{sampleType}</td></tr><tr><td>Date d'échantillonage prévue</td><td>{samplingDate}</td></tr><tr><td>Date d'échantillonage effective</td><td>{dateSampled}</td></tr></table></p><p>Paramètres de configuration:<ul><li>format:<ul><li>une chaine de caractères python utilisant des variables prédéfinies comme sampleId, clientId, sampleType.</li><li> La variable 'seq' doit être en fin de chaine.</li></ul></li><li>Type de séquence : [generated|counter]</li><li>contexte : si le type de conpteur fourni des informations de contexte à la fonction de comptage</li><li>type de fonction de comptage : [backreference|contained]</li><li>reference de comptage : tout paramètre de la fonction de comptage</li><li>préfixe: préfixe par défaut si aucun n'est fourni dans la chaine de caractère de format</li><li>longueur de découpage : nombre de parties à inclure dans le préfixe</li></ul></p>"
 
@@ -31,6 +31,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} pièce(s) jointe(s) d'une taille totale de ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -56,6 +57,7 @@ msgid "%s has no '%s' column."
 msgstr "%s n'a pas de colonne '%s'."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Retour"
@@ -125,6 +127,10 @@ msgstr "*** Ce message  a été généré automatiquement. Merci de ne pas y ré
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr "... Sélectionner un appareil ..."
@@ -142,7 +148,7 @@ msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Aller vers la configura
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Bienvenue dans SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -200,7 +206,7 @@ msgid "Account Type"
 msgstr "Type de compte"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr "Comptabilité"
 
@@ -245,21 +251,21 @@ msgstr "Activer"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Actif"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Utilisateur actif"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Ajouter"
 
@@ -287,15 +293,19 @@ msgstr "Ajouter un duplicat"
 msgid "Add Samples"
 msgstr "Ajouter des échantillons"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Ajoute un champ de commentaires à toutes les analyses"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "Ajouter des règles de CCS  personnalisées pour le logo (ex. height:15px; width:150px;)"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "Ajouter une étiquettes sélectionnable par défaut"
 
@@ -308,8 +318,11 @@ msgstr "Ajouter une nouvelle pièce jointe"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Ajouter une ou plusieurs pièce(s) jointe(s) à votre demande pour décrire plus spécifiquement votre échantillon."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Ajouter une remarque"
 
@@ -373,13 +386,21 @@ msgstr "Tous les services d'analyse accrédités sont listés ici."
 msgid "All Analyses of Service"
 msgstr "Toutes les analyses du service"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Toutes les analyses  assignées"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Permet de saisir manuellement la limite de détection"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -397,11 +418,11 @@ msgstr "Permet au même utilisateur de vérifier plusieurs fois"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Permet au même utilisateur de vérifier plusieurs fois, mais non consécutives"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Permet l'auto-vérification des résultats"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr "Permettre la publication de résultats pour les analyses non assignées"
 
@@ -430,15 +451,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Analysé par"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analyses"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Analyses demandées"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -507,7 +544,7 @@ msgstr "Conditions d'analyse"
 msgid "Analysis conditions updated: {}"
 msgstr "Conditions d'analyse mises à jour : {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Spécifications analytiques éditées directement au niveau de l'échantillon."
 
@@ -544,7 +581,7 @@ msgstr "L'analyste doit être spécifié."
 msgid "Any"
 msgstr "Tous"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "Apparence"
 
@@ -555,6 +592,10 @@ msgstr "Appliquer"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Appliquer le modèle"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -568,19 +609,15 @@ msgstr "Numéro d'équipement"
 msgid "Assign"
 msgstr "Assigner"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Affecté"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Assigné à : ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Attribution en attente"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -594,7 +631,7 @@ msgstr "Associer un échantillon"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr "Etiquettes associées"
 
@@ -682,11 +719,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr "Journaux des imports automatiques"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Partitionner automatiquement à la réception"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Réceptionner automatique des échantillons"
 
@@ -694,15 +735,15 @@ msgstr "Réceptionner automatique des échantillons"
 msgid "Autofill"
 msgstr "Autocomplétion"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Déconnexion automatiqueDéconnexion automatique"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -753,7 +794,7 @@ msgstr "Lot"
 msgid "Batch Book"
 msgstr "Recueil de lots"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Lot ID"
 
@@ -783,6 +824,10 @@ msgstr "Attention, les domaines limites indiqués dans la feuille de calcul prov
 msgid "Bearing"
 msgstr "Direction"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "adresse de facturation"
@@ -803,7 +848,7 @@ msgstr "marque"
 msgid "Bulk Discount"
 msgstr "Rabais de quantité"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Remise sur la quantité"
@@ -821,19 +866,19 @@ msgstr "téléphone professionnel"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -841,12 +886,12 @@ msgstr ""
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "Emails CC"
 
@@ -902,23 +947,23 @@ msgstr "Calibrations"
 msgid "Calibrator"
 msgstr "Métrologue"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Vérification possible malgré la saisie par l'utilisateur actif"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Vérification possible, mais l'utilisateur actif a déjà procédé à la vérification précédente"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Annuler"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Annulé"
 
@@ -938,15 +983,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "Vérification impossible, l'utilisateur actif ayant déjà procédé à la vérification précédente"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "Vérification impossible, résultat soumis par l'utilisateur actif"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "Vérification impossible, l'utilisateur actif ayant procédé à la vérification précédente"
 
@@ -972,7 +1017,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Référence catalogue"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Classe les services analytiques"
 
@@ -1004,11 +1049,11 @@ msgid "Changes Saved"
 msgstr "Modifications sauvegardées"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Modifications sauvegardées."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Les changements seront déployés vers les partitions"
 
@@ -1045,31 +1090,31 @@ msgstr ""
 msgid "Choices"
 msgstr "Choix"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Choisir la manière dont un même utilisateur peut procéder à des vérifications multiples. Ce paramètre permet d'activer et de désactiver les possibilités de vérifier consécutivement ou plusieurs fois un résultat pour un même utilisateur."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1082,20 +1127,34 @@ msgstr "Ville"
 msgid "Classic"
 msgstr "Classique"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Cliquer pour développer cette catégorie"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Client"
@@ -1107,7 +1166,7 @@ msgstr "ID du lot du client"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Identifiant"
 
@@ -1119,7 +1178,7 @@ msgstr "Page d'accueil du client"
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Commande du client"
 
@@ -1129,7 +1188,7 @@ msgstr "Commande du client"
 msgid "Client Order Number"
 msgstr "Numéro de commande du client"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Réf client"
 
@@ -1138,7 +1197,7 @@ msgstr "Réf client"
 msgid "Client Reference"
 msgstr "Référence client"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID client"
 
@@ -1231,7 +1290,7 @@ msgstr "Commentaires"
 msgid "Comments or results interpretation"
 msgstr "Commentaires ou interprétation des résultats"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "ID commercial"
@@ -1269,6 +1328,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1287,7 +1350,7 @@ msgstr "Confirmer le mot de passe"
 msgid "Considerations"
 msgstr "Considérations"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contact"
@@ -1331,7 +1394,7 @@ msgstr "Contenants"
 msgid "Contents of the file {}"
 msgstr "Contenus du fichier {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1364,15 +1427,15 @@ msgstr "Copier les analyses"
 msgid "Copy from"
 msgstr "Copier de "
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Copier dans un  nouveau"
 
@@ -1382,6 +1445,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1400,11 +1467,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1417,7 +1484,7 @@ msgstr "Pays"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Créer une partition"
 
@@ -1425,7 +1492,7 @@ msgstr "Créer une partition"
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1437,7 +1504,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr "Créer un nouvel utilisateur"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1467,7 +1534,7 @@ msgid "Created {} partitions: {}"
 msgstr "Partitions {} créée {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Créateur"
 
@@ -1476,7 +1543,7 @@ msgstr "Créateur"
 msgid "Criteria"
 msgstr "Critère"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Devise"
 
@@ -1484,13 +1551,21 @@ msgstr "Devise"
 msgid "Current"
 msgstr "Actuel"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Signe décimal personnalisé"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "LD"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1537,23 +1612,23 @@ msgstr "Date de modification"
 msgid "Date Opened"
 msgstr "Date d'ouverture"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Date de conservation"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Date d'impression"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Date de publication"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Date de réception"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Date d'enregistrement"
 
@@ -1565,11 +1640,11 @@ msgstr "Date de la demande"
 msgid "Date Sample Received"
 msgstr "Date de réception de l'échantillon"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Date d'échantillonnage"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Vérifié le"
 
@@ -1611,7 +1686,7 @@ msgstr "Date de délivrance du certificat"
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1634,11 +1709,11 @@ msgstr "Désactiver jusqu'au prochain étalonnage"
 msgid "Deactivate"
 msgstr "Désactivé"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "signe décimal à utiliser dans les rapports pour ce client"
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1650,7 +1725,7 @@ msgstr "conteneur par défaut"
 msgid "Default Department"
 msgstr "Département par défaut"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Adresses e-mail du client, utilisées par défaut pour l’envoi de résultats publiés"
 
@@ -1662,7 +1737,7 @@ msgstr "Equipement par défaut"
 msgid "Default Method"
 msgstr "Méthode par défaut"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1670,20 +1745,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Conservation par défaut"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Nombre d'échantillons à ajouter par défaut."
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Signe décimal par défaut"
 
@@ -1695,7 +1770,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr "Grande étiquette par défaut"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Mise en page par défaut des feuilles de travail"
 
@@ -1727,15 +1802,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Période par défaut de rétention de l'échantillon"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Formattage par défaut des notations scientifiques pour les rapports"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Formattage par défaut des notations scientifiques pour les résultats"
 
@@ -1747,7 +1822,7 @@ msgstr "Petite étiquette par défaut"
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Délai d'exécution par défaut pour les analyses."
 
@@ -1756,7 +1831,7 @@ msgstr "Délai d'exécution par défaut pour les analyses."
 msgid "Default value"
 msgstr "Valeur par défaut"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "Valeur par défaut du nombre d'échantillon lorsque l'utilisateur clique sur le bouton \"Ajouter\" pour créer de nouveaux échantillons"
 
@@ -1780,7 +1855,7 @@ msgstr "Définit la précision lors de conversions de valeurs en notation expone
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Définir le préleveur prévu pour l'échantillonnage à la date planifiée"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1792,8 +1867,17 @@ msgstr "Définir l'étiquette à utiliser pour ce type d'échantillon."
 msgid "Degrees"
 msgstr "Degrés"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1822,9 +1906,9 @@ msgstr "Départements"
 msgid "Dependent Analyses"
 msgstr "Analyses dépendantes"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Description"
 
@@ -1871,7 +1955,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr "Désactiver les vérifications multiples pour le même utilisateur"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Rabais"
@@ -1889,7 +1977,7 @@ msgstr "Répartir"
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Réparti"
@@ -1914,15 +2002,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr "Affiche un sélecteur de limite de détection"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Éliminer"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminé"
 
@@ -1992,11 +2088,15 @@ msgstr "Télécharger le PDF"
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Dû"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Echéance"
@@ -2013,7 +2113,7 @@ msgstr "Réplicat"
 msgid "Duplicate Analysis"
 msgstr "Dupliquer une analyse"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2061,6 +2161,7 @@ msgstr "Ex. SANAS, APLAC, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2075,21 +2176,21 @@ msgstr "Hauteur"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Adresse mail"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2097,27 +2198,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "Journal d'e-mail"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "Corps de message pour les notifications d'invalidation d'échantillon"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr "Corps de message pour les notifications de rejet d'échantillon"
 
@@ -2130,16 +2231,20 @@ msgstr "E-mail annulé"
 msgid "Email notification"
 msgstr "Notification par E-mail"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "Envoyer une notification par e-mail lorsqu'un échantillon est rejeté"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2150,27 +2255,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Activer l'utilisation multiple des équipements dans les feuilles de travail"
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Activer la conservation des échantillons"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "Activer les spécifications d'échantillon"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "Activer l'échantillonage"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "Activer la planification de l'échantillonnage"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2178,9 +2283,17 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr "Activer le flux de travail pour l'échantillon créé"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "Activer le flux de travail d'impression des rapports de résultats"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2203,7 +2316,7 @@ msgstr "Entrer une adresse email. C'est nécessaire en cas de perte du mot de pa
 msgid "Enter discount percentage value"
 msgstr "Saisir le taux de remise"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2216,7 +2329,7 @@ msgstr "Saisir un pourcentage  ex: 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Saisir un pourcentage, par exemple 14,0. Ce pourcentage s'applique uniquement au profil d'analyse et remplace la TVA système "
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Saisir un pourcentage  (ex : 14.0). Ce pourcentage est appliqué à l'ensemble du système mais peut être écrasé sur des éléments individuels."
 
@@ -2240,7 +2353,7 @@ msgstr "Entrer le détail de chacune des analyses que vous voulez copier"
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Entrez ici le détail des accréditations de votre laboratoire. Les champs suivants sont disponibles : lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference <br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2252,15 +2365,15 @@ msgstr "Conditions environnementales"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "État d'avancement des analyses"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "État d'avancement des échantillons"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "État d'avancement des feuilles de travail"
 
@@ -2272,7 +2385,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Exclu de la facture"
 
@@ -2282,7 +2395,7 @@ msgstr "Exclu de la facture"
 msgid "Expected Result"
 msgstr "Résultat attendu"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Date d’échantillonnage attendue"
 
@@ -2308,7 +2421,7 @@ msgstr "Date d'expiration"
 msgid "Exponential format precision"
 msgstr "Précision pour le format exponentiel"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "sensibilité pour le format exponentiel"
 
@@ -2316,7 +2429,7 @@ msgstr "sensibilité pour le format exponentiel"
 msgid "Export"
 msgstr "Exportation"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "Chargement de l'étiquette impossible"
 
@@ -2403,7 +2516,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "Taille du fichier"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2417,6 +2530,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2433,11 +2558,11 @@ msgstr "Prénom"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Valeur flottante comprise entre 0.0 et 1000.0 indiquant l'ordre de tri. Les valeurs en double sont classées par ordre alphabétique."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Configuration de formatage"
 
@@ -2460,13 +2585,17 @@ msgstr "Vendredi"
 msgid "From"
 msgstr "De"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Nom complet"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Fullname"
 
@@ -2474,7 +2603,7 @@ msgstr "Fullname"
 msgid "Function"
 msgstr "Fonction"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Echantillons futurs"
 
@@ -2507,7 +2636,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Civilité (Mme, M., Dr...)"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Groupe les analyses par catégorie dans les tables du LIMS : utile si la liste est longue"
 
@@ -2521,7 +2650,7 @@ msgid "Hazardous"
 msgstr "Dangereux"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Caché"
@@ -2534,8 +2663,20 @@ msgstr "Champ caché"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2559,7 +2700,7 @@ msgstr "IBAN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2567,7 +2708,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2587,15 +2728,15 @@ msgstr "Si coché, une liste de sélection sera affichée à coté du champ de r
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Si coché, l'équipement sera indisponible jusqu'au prochain étalonnage correct. Cette case à cocher est automatiquement décochée."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Si activé, un champ de texte libre sera affiché à proximité de chaque analyse dans la vue d'entrée des résultats"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Si cette option est activée, un utilisateur ayant soumis un résultat pourra également le vérifier. Ce paramètrage ne prend effet que pour les utilisateurs avec un rôle de vérificateur (par défaut, gestionnaires, responsables de laboratoire et vérificateurs). L'option sélectionnée ici est prioritaire sur cette même option gérée au niveau du paramétrage Bika."
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Si cette option est activée, un utilisateur ayant soumis un résultat pourra également le vérifier. Ce paramètrage ne prend effet que pour les utilisateurs avec un rôle de vérificateur (par défaut, gestionnaires, responsables de laboratoire et vérificateurs). Ce paramètre peut être supplanté dans la page d'édition de chaque service analytique. Par défaut, désactivée."
 
@@ -2603,7 +2744,7 @@ msgstr "Si cette option est activée, un utilisateur ayant soumis un résultat p
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Si activé, le nom de l'analyse sera écrit en italique."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "Si cette option est activée, l'analyse et son résultat associé ne seront pas affichés dans les rapports. Ce paramètrage peut être supplanté dans les propriétés du profil analytique et/ou de l'échantillon."
 
@@ -2643,7 +2784,7 @@ msgstr "Si elle n'est pas cochée, les responsables de laboratoire ne pourront p
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "Si la formule nécessite une fonction spéciale issue d'une bibliothèque Python externe, vous pouvez l'importer ici. Par exemple, si vous souhaitez utiliser la fonction 'floor' du module Python 'math', ajoutez 'math' dans le champ Module et 'floor' dans le champ Fonction. L'équivalent en Python serait 'from math import floor'. Vous pouvez l'utiliser comme suit dans votre expression: 'floor([Ca]+[Mg])'."
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2674,11 +2815,11 @@ msgstr "Procédure d'étalonnage interne"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Inactif"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Inclus et affiche les informations tarifaires"
 
@@ -2875,7 +3016,7 @@ msgid "Internal Certificate"
 msgstr "Certificat interne"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "Usage interne"
 
@@ -2896,13 +3037,13 @@ msgstr ""
 msgid "Interval"
 msgstr "Intervalle"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Invalide"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2965,15 +3106,15 @@ msgstr "Adresse de facturation"
 msgid "Invoice {} created"
 msgstr "Facture {} créée"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "Le lot de facturation n'a pas de date de fin"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "Le lot de facturation n'a pas de date de début"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "Le lot de facturation n'a pas de titre"
 
@@ -2985,7 +3126,7 @@ msgstr "Profession"
 msgid "Job title"
 msgstr "Profession"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2997,9 +3138,9 @@ msgstr "Clé"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Mot clé"
 
@@ -3015,6 +3156,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Mots clé"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3059,8 +3204,8 @@ msgstr "Produits du labo"
 msgid "Lab URL"
 msgstr "URL du laboratoire"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Libellé"
@@ -3069,7 +3214,7 @@ msgstr "Libellé"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3077,13 +3222,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3096,7 +3241,7 @@ msgstr "Laboratoire"
 msgid "Laboratory Accredited"
 msgstr "Laboratoire accrédité"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Jours de travail du laboratoire"
 
@@ -3108,7 +3253,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Grande étiquette"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3120,11 +3265,11 @@ msgstr "Derniers journaux d'importation automatique"
 msgid "Last Login Time"
 msgstr "Dernier accès"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "En retard"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Analyses en retard"
 
@@ -3170,15 +3315,15 @@ msgstr "Associer un utilisateur"
 msgid "Link an existing User"
 msgstr "Associer un utilisateur existant"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3202,7 +3347,7 @@ msgstr "Charger le certificat ici"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3230,6 +3375,14 @@ msgstr "Type d'emplacement"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Emplacement de conservation de la documentation"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3293,7 +3446,7 @@ msgstr "Mâle"
 msgid "Manage Analyses"
 msgstr "Gérer les analyses"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "Gérer les champs du formulaire"
 
@@ -3317,7 +3470,7 @@ msgstr "Gérer les champs du formulaire d'échantillon"
 msgid "Manage linked User"
 msgstr "Gérer les utilisateurs associés"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3341,7 +3494,7 @@ msgstr "E-mail du gestionnaire"
 msgid "Manager Phone"
 msgstr "Téléphone du gestionnaire"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Manuel"
 
@@ -3370,7 +3523,7 @@ msgstr "Fabricants"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "Réserve l'échantillon pour un usage interne. Il ne pourra être accessible que par le personnel du laboratoire et non pour les clients."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3385,7 +3538,7 @@ msgstr "Temps max"
 msgid "Max operator"
 msgstr "Opérateur Max"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3420,15 +3573,15 @@ msgid "Member Discount"
 msgstr "Rabais de membre"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Remise membre %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Application de la remise membre"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Membre enregistré et associé au contact actif."
 
@@ -3436,7 +3589,7 @@ msgstr "Membre enregistré et associé au contact actif."
 msgid "Message sent to {}, "
 msgstr "Message envoyé à {},"
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3467,7 +3620,7 @@ msgstr "Initiale du deuxième prénom"
 msgid "Middle name"
 msgstr "Deuxième prénom"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3478,7 +3631,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr "Opérateur Min"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3496,7 +3649,7 @@ msgstr "5 caractères minimum"
 msgid "Minimum Volume"
 msgstr "Volume minimal"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Nombre minimal de résultat pour le calcul des statistiques de QC"
 
@@ -3527,6 +3680,10 @@ msgstr "Module"
 msgid "Monday"
 msgstr "Lundi"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3540,11 +3697,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Vérification multiple requise"
 
@@ -3580,13 +3737,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "RIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nom"
 
@@ -3596,6 +3757,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3639,6 +3804,10 @@ msgstr ""
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "Aucune action définie."
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3686,6 +3855,10 @@ msgstr "Aucun changement effectué"
 msgid "No changes made."
 msgstr "Aucun changement effectué."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "Aucune date renseignée"
@@ -3730,6 +3903,16 @@ msgstr "Pas d'articles sélectionnés"
 msgid "No items selected."
 msgstr "Aucun élément sélectionné."
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "Aucun nouvel élément créé"
@@ -3737,6 +3920,10 @@ msgstr "Aucun nouvel élément créé"
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "Aucune partition créée"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3753,6 +3940,10 @@ msgstr "Aucun échantillon rejeté"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Aucun flux de travail d'échantillonnage"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3780,7 +3971,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Aucun"
 
@@ -3796,11 +3987,11 @@ msgstr ""
 msgid "Not defined"
 msgstr "Non défini"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Non défini"
@@ -3821,7 +4012,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3833,7 +4024,7 @@ msgstr "Num colonne"
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Nombre d'analyses"
 
@@ -3849,16 +4040,16 @@ msgstr "Nombre de copies"
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Nombre de vérifications requises"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Nombre de vérification nécessaire pour qu'un résultat donné soit considéré comme 'vérifié'. Ce paramètrage peut être supplanté dans la page d'édition de chaque service analytique. Par défaut, 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3868,6 +4059,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3886,11 +4081,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "Seul les jour de travail du laboratoire sont considérés pour le calcul du temps d'analyse."
 
@@ -3898,13 +4093,13 @@ msgstr "Seul les jour de travail du laboratoire sont considérés pour le calcul
 msgid "Only to empty or zero fields"
 msgstr "Champs à valeur vide ou zéro"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Ouvert"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3912,8 +4107,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Application web d'un système de gestion de l'information du laboratoire open source"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3941,7 +4144,7 @@ msgstr "Autres raisons"
 msgid "Other reasons:"
 msgstr "Autres raisons:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3963,11 +4166,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4064,11 +4267,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Veuillez sélectionner un utilisateur de la liste"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4081,6 +4284,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4100,12 +4304,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Point de saisie"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4144,31 +4352,31 @@ msgstr "Précision, comme nombre de décimales"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Précision comme le nombre de décimales significatives en accord avec l'incertitude. La position décimale sera donnée par le premier chiffre différent de zéro dans l'incertitude, à la position que le système  arrondira au-dessus l'incertitude et le résultat. Par exemple, pour un résultat de 5.243 et une incertitude de 0.22, le système affichera 5.2+/-0.2. S'il n'y a pas de plage d'incertitude pour le résultat, le système utilisera la précision spécifiée."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Marqueur décimal préféré pour les rapports"
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Marqueur décimal préféré pour les résultats"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "Mise en page préférée dans la table de saisie des résultats dans l'affichage de feuille de travail. La mise en page Classique affiche les échantillons en lignes et les analyses en colonnes. La mise en page Transposée affiche les échantillons en colonnes et les analyses en lignes."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Format de notation scientifique préféré pour les rapports"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Format de notation scientifique préféré pour les résultats"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4201,7 +4409,7 @@ msgstr ""
 msgid "Preserve"
 msgstr "Conserver"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Personne ayant stocké"
 
@@ -4218,11 +4426,11 @@ msgstr "Préventif"
 msgid "Preventive maintenance procedure"
 msgstr "Procédure de maintenance préventive"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "Prévisualisation"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4250,7 +4458,7 @@ msgstr "Liste de prix pour"
 msgid "Pricelists"
 msgstr "Tarifs"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4259,7 +4467,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "Échantillon principal"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4281,11 +4489,11 @@ msgstr "Date d'impression"
 msgid "Print pricelist"
 msgstr "impression liste de prix"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Imprimer des étiquettes"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Imprimé"
 
@@ -4298,7 +4506,7 @@ msgstr "Date d'impression"
 msgid "Priority"
 msgstr "Priorité"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Profil"
 
@@ -4322,7 +4530,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4331,7 +4539,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "ID du protocole"
 
@@ -4339,7 +4547,7 @@ msgstr "ID du protocole"
 msgid "Province"
 msgstr "Province"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4348,8 +4556,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Publié"
@@ -4365,6 +4577,10 @@ msgstr "Date de publication"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Résultats publiés"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4386,6 +4602,14 @@ msgstr ""
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "ID échantillon QC"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4411,7 +4635,7 @@ msgstr "Saisissez de nouveau le mot de passe. Assurez-vous que les mots de passe
 msgid "Reasons for rejection"
 msgstr "Motifs de rejet"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Réassigné"
 
@@ -4423,30 +4647,34 @@ msgstr "Position réattribuable"
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Reçoit"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Reçu"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Réception en attente"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Récipients"
 
@@ -4497,11 +4725,15 @@ msgstr "Valeurs de référence"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Les valeurs des échantillons de référence sont nulles ou vides"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Enregistrer"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4527,9 +4759,9 @@ msgstr "Rejeter l'analyse"
 msgid "Reject samples"
 msgstr "Rejeter des échantillons"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Rejeté"
 
@@ -4545,7 +4777,7 @@ msgstr "Échantillon rejeté"
 msgid "Rejected {} samples: {}"
 msgstr "Échantillons rejeté {}: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4606,8 +4838,16 @@ msgstr ""
 msgid "Remove"
 msgstr "Retirer"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4643,11 +4883,11 @@ msgstr "ID du rapport"
 msgid "Report identification number"
 msgstr "Numéro d'identification du rapport"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4659,7 +4899,7 @@ msgstr "Importation du rapport"
 msgid "Republish"
 msgstr "Republier"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4668,7 +4908,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "ID demande"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Demander de nouvelles analyses"
 
@@ -4684,8 +4924,20 @@ msgstr "Volume requis"
 msgid "Reset"
 msgstr "Réinitialiser"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4693,15 +4945,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4726,15 +4979,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Résultat dans la plage haute"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Résultat hors intervalle"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4742,7 +4995,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Les valeurs de résultat avec au moins ce nombre de décimales significatives sont affichés en notation scientifique utilisant la lettre 'e' pour indiquer l'exposant. La précision peut-être configurée dans les analyses individuelles"
 
@@ -4758,16 +5011,20 @@ msgstr "Résultats"
 msgid "Results Interpretation"
 msgstr "Interprétation des résultats"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Les résultats ont été retirés"
 
@@ -4775,7 +5032,7 @@ msgstr "Les résultats ont été retirés"
 msgid "Results interpretation"
 msgstr "Interprétation des résultats"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Résultats en attente"
 
@@ -4799,7 +5056,7 @@ msgstr "Retesté"
 msgid "Retract"
 msgstr "Retirer"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4835,6 +5092,10 @@ msgstr "Revenir en arrière"
 msgid "Routine Analyses"
 msgstr "Analyses de routine"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4860,6 +5121,7 @@ msgstr "Page d'accueil SENAITE LIMS"
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4869,7 +5131,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr "Page d'accueil SENAITE"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4883,7 +5145,7 @@ msgstr "Salutation"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Échantillon"
 
@@ -4920,7 +5182,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "ID échantillon"
 
@@ -4940,7 +5202,7 @@ msgstr "Matrice d'échantillons"
 msgid "Sample Partitions"
 msgstr "Répartition d'échantillon"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4967,7 +5229,7 @@ msgid "Sample Templates"
 msgstr "Modèles d'échantillon"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Type d'échantillon"
@@ -5028,7 +5290,7 @@ msgstr "Type d'échantillon"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Préleveur"
 
@@ -5040,8 +5302,8 @@ msgstr "Préleveur pour échantillonnage planifié"
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Échantillons"
@@ -5058,6 +5320,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5067,7 +5341,23 @@ msgstr "Les échantillons de ce type doivent être traités comme dangereux"
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5075,7 +5365,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Date d'échantillonnage"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Écart d'échantillonnage"
@@ -5088,7 +5378,7 @@ msgstr "Écarts d'échantillonnage"
 msgid "Sampling Frequency"
 msgstr "Fréquence d'échantillonnage"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "Échantillonnage programmé"
 
@@ -5096,14 +5386,23 @@ msgstr "Échantillonnage programmé"
 msgid "Saturday"
 msgstr "Samedi"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Sauver"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5118,7 +5417,7 @@ msgstr "Planification"
 msgid "Schedule sampling"
 msgstr "Programme d’échantillonnage"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Échantillonnage programmé"
@@ -5135,6 +5434,10 @@ msgstr "Nom scientifique"
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5143,7 +5446,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "secondes"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5233,11 +5536,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Sélectionnez le modèle"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Sélectionnez le pays dans lequel le site sera affiché par défaut"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Sélectionnez la devise que le site va utiliser pour afficher les tarifs."
 
@@ -5249,11 +5552,11 @@ msgstr "Sélectionnez le récipient par défaut à utiliser pour cette analyse. 
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Sélectionnez la page d'accueil par défaut. Ceci est utilisé lorsque un utilisateur \"Client\" se connecte au système ou lorsque un client est sélectionné dans le dossier contenant la liste des clients"
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5261,31 +5564,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Sélectionner pour activer les étapes du flux de travail de collecte d'échantillon."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Sélectionner pour autoriser le coordinateur de prélèvement à planifier un échantillonnage. Cette fonctionnalité ne prend effet uniquement si le flux de travail pour l'échantillonnage est activé."
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "Sélectionner pour réceptionner automatiquement les échantillons lorsque ceux-ci sont créés par le personnel du laboratoire et que le flux de travail d’échantillonnage est désactivé. Les échantillons reçus au travers les personnes de contact des clients ne seront pas réceptionnés automatiquement."
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5297,7 +5608,7 @@ msgstr "Sélectionnez quelles analyses devraient être inclues dans la feuille d
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Auto-vérification des résultats"
 
@@ -5309,11 +5620,11 @@ msgstr "Envoyer"
 msgid "Send Analysis Reports via Email"
 msgstr "Envoyer les rapports d'analyse par e-mail"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5335,7 +5646,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Contenants distincts"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5349,7 +5660,7 @@ msgstr "N° de série"
 msgid "Service"
 msgstr "Service"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5377,7 +5688,7 @@ msgstr "Configurer le flux de travail de rejet d'échantillon et les raisons du 
 msgid "Set the maintenance task as closed."
 msgstr "Définir la tâche de maintenance comme terminée."
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5425,28 +5736,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5469,11 +5792,11 @@ msgstr "Code du site"
 msgid "Site Description"
 msgstr "Description du site"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5494,7 +5817,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Petite étiquette"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5511,6 +5834,14 @@ msgstr "Des analyses nécessitent des équipements hors calibration ou obsolète
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Clé de tri"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5536,7 +5867,7 @@ msgstr "Les domaine limites des spécifications ont été modifiés depuis leur 
 msgid "Specifications"
 msgstr "Spécifications"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5544,7 +5875,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5561,17 +5892,17 @@ msgstr "Date de début"
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "État"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Statut"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Etiquette"
@@ -5580,7 +5911,11 @@ msgstr "Etiquette"
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Lieu de stockage "
@@ -5620,7 +5955,11 @@ msgstr "Soumettre"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5628,7 +5967,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Sous-total"
@@ -5670,7 +6009,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5696,7 +6035,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr "Description technique et instructions destinées aux analystes"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5778,7 +6117,7 @@ msgstr "Date de conservation de l'échantillon"
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Le marqueur décimal sélectionné lors du paramétrage de Bika LIMS sera utilisé."
 
@@ -5786,7 +6125,7 @@ msgstr "Le marqueur décimal sélectionné lors du paramétrage de Bika LIMS ser
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "Le pourcentage de remise entré ici s'applique aux tarifs des clients marqués comme 'membres', normalement partenaires ou associés méritant cette remise."
 
@@ -5814,7 +6153,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5822,11 +6165,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "La hauteur ou profondeur à laquelle l'échantillon a été pris en charge"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5863,11 +6206,11 @@ msgstr "Le volume minimal d'échantillon requis pour l'analyse e.g. '10 ml' ou '
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Le nombre de jours avant qu'un échantillon expire et ne puisse plus être analysé. Ce paramétrage peut être écrasé par celui du type d'échantillon individuel."
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Le nombre de minutes avant qu'un utilisateur soit automatiquement déconnecté. 0 désactive la déconnexion automatique."
 
@@ -5907,7 +6250,7 @@ msgstr "Code de référence délivré au laboratoire par l'organisme d'accrédit
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5931,11 +6274,11 @@ msgstr "L'échantillon est composé d'un mélange de sous-échantillons"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Le numéro de série qui identifie de façon unique l'instrument"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "L'ID du protocole analytique du service"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "L'ID commercial du service pour les opérations comptables"
 
@@ -5987,11 +6330,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6015,11 +6358,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6051,8 +6394,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Astuce. Documents joints ne seront pas chargés à moins qu'il soient présents dans l'instance."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Titre"
@@ -6079,34 +6422,42 @@ msgstr "Nom du site"
 msgid "To"
 msgstr "Jusqu'à"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "A conserver"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "A échantillonner"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Pour être affiché en dessous de chaque section \"catégorie d'analyses\" sur les comptes rendus"
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "A conserver"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "A vérifier"
@@ -6119,7 +6470,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6141,7 +6492,7 @@ msgid "Tuesday"
 msgstr "Mardi"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Type"
@@ -6166,6 +6517,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6174,7 +6529,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6186,6 +6541,7 @@ msgstr "Impossible de charger le modèle"
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Non assigné"
@@ -6218,8 +6574,12 @@ msgstr "Le pays de l'IBAN est inconnu %s"
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6236,12 +6596,16 @@ msgstr "Format de fichier non reconnu ${file_format}"
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6252,7 +6616,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Uploadez une signature qui sera utilisée à l'impression des rapports de résultats d'analyse. La taille idéale est de 250 pixels de large par 150 de haut."
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6260,7 +6624,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Utiliser le prix du profil de l'analyse"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Utiliser le tableau de bord comme page d’accueil"
 
@@ -6298,7 +6662,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "Utilisateur associé à ce contact"
 
@@ -6306,15 +6670,15 @@ msgstr "Utilisateur associé à ce contact"
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "L'utilisation de trop peu de points ne permet pas de donner un sens aux statistiques. Paramétrez un nombre minimal acceptable de résultats avant que les statistiques de QC soient calculées et représentées."
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6322,7 +6686,7 @@ msgstr "Taxes"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "Taxes %"
 
@@ -6569,8 +6933,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Les valeurs rentrées ici remplaceront celles par défaut spécifiées dans les champs de calcul provisoires"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Vérifié"
@@ -6579,11 +6943,19 @@ msgstr "Vérifié"
 msgid "Verified By"
 msgstr "Vérifier par"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Vérifier"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6597,6 +6969,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6632,6 +7012,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "Mercredi"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Semaines avant expiration"
@@ -6644,19 +7028,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr "Bienvenue sur SENAITE"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6707,10 +7091,18 @@ msgstr "Modèles de feuille de travail"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Feuilles de travail"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6719,6 +7111,10 @@ msgstr ""
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Longueur d'IBAN incorrecte par %s: %s raccourci par %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6802,6 +7198,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6906,8 +7306,17 @@ msgstr "jours"
 msgid "deactivate"
 msgstr "desactiver"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6972,7 +7381,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7139,46 +7548,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7190,19 +7599,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7223,16 +7632,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7257,12 +7671,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7272,7 +7686,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7375,6 +7789,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7404,6 +7831,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7550,12 +7984,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7808,7 +8242,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7816,163 +8250,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7980,47 +8414,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8029,20 +8463,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8050,32 +8484,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8083,21 +8517,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8253,6 +8687,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8565,7 +9003,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8626,7 +9064,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8742,52 +9180,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8857,12 +9295,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8872,7 +9310,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9168,7 +9606,7 @@ msgid "label_powered_by_plone"
 msgstr "label_powered_by_plone "
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9293,12 +9731,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9508,7 +9946,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9518,12 +9956,12 @@ msgid "label_senaite"
 msgstr "label_senaite"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9581,6 +10019,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10757,87 +11211,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10890,6 +11344,11 @@ msgstr ""
 msgid "minutes"
 msgstr "minutes"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "mensuel"
@@ -10940,13 +11399,21 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "de"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "vue d'ensemble"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11023,6 +11490,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11257,13 +11729,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11350,6 +11827,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11595,222 +12077,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12064,7 +12546,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "vérification(s) en attente"
 
@@ -12107,7 +12589,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/fr/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fr/LC_MESSAGES/senaite.core.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Alexandre S, 2026\n"
 "Language-Team: French (https://app.transifex.com/senaite/teams/87045/fr/)\n"

--- a/src/senaite/core/locales/fr_FR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fr_FR/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: French (France) (https://app.transifex.com/senaite/teams/87045/fr_FR/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/fr_FR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/fr_FR/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: French (France) (https://app.transifex.com/senaite/teams/87045/fr_FR/)\n"

--- a/src/senaite/core/locales/fr_FR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fr_FR/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Alexandre S, 2026\n"
 "Language-Team: French (France) (https://app.transifex.com/senaite/teams/87045/fr_FR/)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fr_FR\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -27,6 +27,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -52,6 +53,7 @@ msgid "%s has no '%s' column."
 msgstr "%s n'a pas de colonne '%s'."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Retour"
@@ -121,6 +123,10 @@ msgstr "*** Ce message  a été généré automatiquement. Merci de ne pas y ré
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -138,7 +144,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -196,7 +202,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -241,21 +247,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -283,15 +289,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -304,8 +314,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -369,12 +382,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -393,11 +414,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -426,14 +447,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -503,7 +540,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -540,7 +577,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -550,6 +587,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -564,18 +605,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -590,7 +627,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -678,11 +715,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -690,15 +731,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -749,7 +790,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -779,6 +820,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -799,7 +844,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -817,19 +862,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -837,12 +882,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -898,23 +943,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -934,15 +979,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -968,7 +1013,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1000,11 +1045,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1041,31 +1086,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1078,12 +1123,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1091,7 +1150,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1103,7 +1162,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1115,7 +1174,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1125,7 +1184,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1134,7 +1193,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1227,7 +1286,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1265,6 +1324,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1283,7 +1346,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1327,7 +1390,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1360,15 +1423,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1378,6 +1441,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1396,11 +1463,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1413,7 +1480,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1421,7 +1488,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1433,7 +1500,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1463,7 +1530,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1472,7 +1539,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1480,12 +1547,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1533,23 +1608,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1561,11 +1636,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1607,7 +1682,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1630,11 +1705,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1646,7 +1721,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1658,7 +1733,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1666,20 +1741,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1691,7 +1766,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1723,15 +1798,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1743,7 +1818,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1752,7 +1827,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1776,7 +1851,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1788,8 +1863,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1818,9 +1902,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1867,7 +1951,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1885,7 +1973,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1910,15 +1998,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1988,11 +2084,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2009,7 +2109,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2057,6 +2157,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2071,21 +2172,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2093,27 +2194,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2126,16 +2227,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2146,27 +2251,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2174,8 +2279,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2199,7 +2312,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2212,7 +2325,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2236,7 +2349,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2248,15 +2361,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2268,7 +2381,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2278,7 +2391,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2304,7 +2417,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2312,7 +2425,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2399,7 +2512,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2413,6 +2526,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2429,11 +2554,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2456,13 +2581,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2470,7 +2599,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2503,7 +2632,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2517,7 +2646,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2530,8 +2659,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2555,7 +2696,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2563,7 +2704,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2583,15 +2724,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2599,7 +2740,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2639,7 +2780,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2670,11 +2811,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2871,7 +3012,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2892,13 +3033,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2961,15 +3102,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2981,7 +3122,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2993,9 +3134,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3010,6 +3151,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3055,8 +3200,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3065,7 +3210,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3073,13 +3218,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3092,7 +3237,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3104,7 +3249,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3116,11 +3261,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3166,15 +3311,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3198,7 +3343,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3225,6 +3370,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3289,7 +3442,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3313,7 +3466,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3337,7 +3490,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3366,7 +3519,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3381,7 +3534,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3416,15 +3569,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3432,7 +3585,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3463,7 +3616,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3474,7 +3627,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3492,7 +3645,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3523,6 +3676,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3536,11 +3693,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3576,13 +3733,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3592,6 +3753,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3634,6 +3799,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3682,6 +3851,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3726,12 +3899,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3748,6 +3935,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3776,7 +3967,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3792,11 +3983,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3817,7 +4008,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3829,7 +4020,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3845,16 +4036,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3864,6 +4055,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3882,11 +4077,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3894,13 +4089,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3908,8 +4103,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3937,7 +4140,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3959,11 +4162,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4060,11 +4263,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4077,6 +4280,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4096,12 +4300,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4140,31 +4348,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4197,7 +4405,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4214,11 +4422,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4246,7 +4454,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4255,7 +4463,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4277,11 +4485,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4294,7 +4502,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4318,7 +4526,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4327,7 +4535,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4335,7 +4543,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4344,8 +4552,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4360,6 +4572,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4381,6 +4597,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4407,7 +4631,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4419,30 +4643,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4493,11 +4721,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4523,9 +4755,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4541,7 +4773,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4602,8 +4834,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4639,11 +4879,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4655,7 +4895,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4664,7 +4904,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4680,8 +4920,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4689,15 +4941,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4722,15 +4975,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4738,7 +4991,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4754,16 +5007,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4771,7 +5028,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4795,7 +5052,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4831,6 +5088,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4856,6 +5117,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4865,7 +5127,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4879,7 +5141,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4916,7 +5178,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4936,7 +5198,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4963,7 +5225,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5024,7 +5286,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5036,8 +5298,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5054,6 +5316,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5063,7 +5337,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5071,7 +5361,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5084,7 +5374,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5092,14 +5382,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5114,7 +5413,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5131,6 +5430,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5139,7 +5442,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5229,11 +5532,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5245,11 +5548,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5257,31 +5560,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5293,7 +5604,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5305,11 +5616,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5331,7 +5642,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5345,7 +5656,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5373,7 +5684,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5421,28 +5732,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5465,11 +5788,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5490,7 +5813,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5506,6 +5829,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5532,7 +5863,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5540,7 +5871,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5557,17 +5888,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5576,7 +5907,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5616,7 +5951,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5624,7 +5963,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5666,7 +6005,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5692,7 +6031,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5774,7 +6113,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5782,7 +6121,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5810,7 +6149,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5818,11 +6161,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5859,11 +6202,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5903,7 +6246,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5927,11 +6270,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5983,11 +6326,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6011,11 +6354,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6047,8 +6390,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6075,34 +6418,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6115,7 +6466,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6137,7 +6488,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6162,6 +6513,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6170,7 +6525,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6182,6 +6537,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6214,8 +6570,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6232,12 +6592,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6248,7 +6612,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6256,7 +6620,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6294,7 +6658,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6302,15 +6666,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6318,7 +6682,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6565,8 +6929,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6575,10 +6939,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6593,6 +6965,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6628,6 +7008,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6640,19 +7024,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6703,9 +7087,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6714,6 +7106,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6798,6 +7194,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6902,8 +7302,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6968,7 +7377,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7135,46 +7544,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7186,19 +7595,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7219,16 +7628,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7253,12 +7667,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7268,7 +7682,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7371,6 +7785,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7400,6 +7827,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7546,12 +7980,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7804,7 +8238,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7812,163 +8246,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7976,47 +8410,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8025,20 +8459,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8046,32 +8480,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8079,21 +8513,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8249,6 +8683,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8561,7 +8999,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8622,7 +9060,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8738,52 +9176,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8853,12 +9291,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8868,7 +9306,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9164,7 +9602,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9289,12 +9727,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9504,7 +9942,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9514,12 +9952,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9577,6 +10015,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10753,87 +11207,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10886,6 +11340,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10936,12 +11395,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11019,6 +11486,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11253,13 +11725,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11346,6 +11823,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11591,222 +12073,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12060,7 +12542,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12103,7 +12585,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/fr_FR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/fr_FR/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Alexandre S, 2026\n"
 "Language-Team: French (France) (https://app.transifex.com/senaite/teams/87045/fr_FR/)\n"

--- a/src/senaite/core/locales/hi/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hi/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hindi (https://app.transifex.com/senaite/teams/87045/hi/)\n"

--- a/src/senaite/core/locales/hi/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hi/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hindi (https://app.transifex.com/senaite/teams/87045/hi/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/hi/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hi/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Hindi (https://app.transifex.com/senaite/teams/87045/hi/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: hi\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "खाते का प्रकार"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -284,15 +290,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -551,6 +588,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -565,18 +606,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -800,7 +845,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1126,7 +1185,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1135,7 +1194,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1228,7 +1287,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1328,7 +1391,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1473,7 +1540,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1481,12 +1548,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6576,10 +6940,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,9 +7088,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/hi/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hi/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Hindi (https://app.transifex.com/senaite/teams/87045/hi/)\n"

--- a/src/senaite/core/locales/hr/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hr/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Croatian (https://app.transifex.com/senaite/teams/87045/hr/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/hr/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hr/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Croatian (https://app.transifex.com/senaite/teams/87045/hr/)\n"

--- a/src/senaite/core/locales/hr/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hr/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Croatian (https://app.transifex.com/senaite/teams/87045/hr/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: hr\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/hr/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hr/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Croatian (https://app.transifex.com/senaite/teams/87045/hr/)\n"

--- a/src/senaite/core/locales/hr_BA/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hr_BA/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Croatian (Bosnia and Herzegovina) (https://app.transifex.com/senaite/teams/87045/hr_BA/)\n"

--- a/src/senaite/core/locales/hr_BA/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hr_BA/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Croatian (Bosnia and Herzegovina) (https://app.transifex.com/senaite/teams/87045/hr_BA/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/hr_BA/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hr_BA/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Croatian (Bosnia and Herzegovina) (https://app.transifex.com/senaite/teams/87045/hr_BA/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: hr_BA\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/hr_BA/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hr_BA/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Croatian (Bosnia and Herzegovina) (https://app.transifex.com/senaite/teams/87045/hr_BA/)\n"

--- a/src/senaite/core/locales/hu/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hu/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hungarian (https://app.transifex.com/senaite/teams/87045/hu/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/hu/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hu/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hungarian (https://app.transifex.com/senaite/teams/87045/hu/)\n"

--- a/src/senaite/core/locales/hu/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hu/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Hungarian (https://app.transifex.com/senaite/teams/87045/hu/)\n"

--- a/src/senaite/core/locales/hu/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hu/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Hungarian (https://app.transifex.com/senaite/teams/87045/hu/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: hu\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr "%s -nek nincs '%s' oszlopa."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Bankszámla típusa"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr "Aktivál"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Működő"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Hozzáadás"
 
@@ -284,15 +290,19 @@ msgstr "Másolat hozzáadása"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Megjegyzés mező hozzáadás minden vizsgálathoz"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,13 +383,21 @@ msgstr "Az összes akkreditált vizsgálati szolgáltatás listája"
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Az összes vizsgálat hozzárendelve"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Kézi érzékelés határ bevitele megengedett"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Vizsgálatok"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr "bármely"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr "Alkalmaz"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Sablon alkalmazása"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,19 +606,15 @@ msgstr "Műszer nyilvántartási szám"
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Kijelölt/hozzárendelt"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "${worksheet_id} munkanaplóhoz rendelve"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr ""
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr "Automatikus kitöltés"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr "Köteg"
 msgid "Batch Book"
 msgstr "Köteg könyv/napló"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Köteg ID"
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Fontosság"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Számlázási cím"
@@ -800,7 +845,7 @@ msgstr "Védjegy"
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Csoportos kedvezmény alkalmazás"
@@ -818,19 +863,19 @@ msgstr "Üzleti telefon"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -899,23 +944,23 @@ msgstr "Hitelesítések"
 msgid "Calibrator"
 msgstr "Hitelesítő"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Mégse"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Visszavont"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Katalógus szám"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Vizsgálat szolgáltatások osztályozása"
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr "Város"
 msgid "Classic"
 msgstr "Klasszikus"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Ügyfél"
@@ -1104,7 +1163,7 @@ msgstr "Ügyfél köteg ID"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Ügyfél ID"
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Ügyfél rendelés"
 
@@ -1126,7 +1185,7 @@ msgstr "Ügyfél rendelés"
 msgid "Client Order Number"
 msgstr "Ügyfél rendelés szám"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Ügyfél hiv."
 
@@ -1135,7 +1194,7 @@ msgstr "Ügyfél hiv."
 msgid "Client Reference"
 msgstr "Ügyfél hivatkozás"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Ügyfél SID"
 
@@ -1228,7 +1287,7 @@ msgstr "Megjegyzések"
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "Kereskedelmi ID"
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Jelszó jóváhagyás"
 msgid "Considerations"
 msgstr "Megfontolások"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kapcsolat"
@@ -1328,7 +1391,7 @@ msgstr "Tárolók"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr "Vizsgálat szolgáltatás másolás"
 msgid "Copy from"
 msgstr "Másol innen"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Új másolat létrehozás"
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "Ország"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Létrehozó"
 
@@ -1473,7 +1540,7 @@ msgstr "Létrehozó"
 msgid "Criteria"
 msgstr "Követelmény"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Pénznem"
 
@@ -1481,13 +1548,21 @@ msgstr "Pénznem"
 msgid "Current"
 msgstr "Jelenlegi"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Felhasználó által meghatározott tizedes pont"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "DL"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Megnyitás kelte"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Megőrzés kelte"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Kiadás kelte"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Átvétel kelte"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr "Igényelt dátum"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Mintavétel kelte"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr "A következő hitelesítés ellenőrzésig deaktiválás"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr "Alapértelmezett tároló"
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr "Alapértelmezett műszer"
 msgid "Default Method"
 msgstr "Alapértelmezett módszer"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Alapértelmezett megőrzés"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Alapértelmezett tizedes pont"
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Alapértelmezett adatmegőrzési időszak"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Alapértelmezett érték"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Fok(ozat)ok"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Függő vizsgálatok"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Leírás"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Feladva"
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Leszállítva"
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Esedékesség"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Esedékesség kelte"
@@ -2010,7 +2110,7 @@ msgstr "Másolat"
 msgid "Duplicate Analysis"
 msgstr "Másolat vizsgálat"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Szerkeszt"
@@ -2072,21 +2173,21 @@ msgstr "Emelés"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Email cím"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr "Írja be az engedmény százalék értékét"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Számlából  kizár"
 
@@ -2279,7 +2392,7 @@ msgstr "Számlából  kizár"
 msgid "Expected Result"
 msgstr "Várt eredmény"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr "Lejárat kelte"
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr "Export"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr "Keresztnév"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr "Tól"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Teljes név"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Üdvözlő cím, mint Úr, Asszony, Dr"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr "Kockázatos"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Rejtett"
@@ -2531,8 +2660,20 @@ msgstr "Rejtett mező"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Ha bejelöli, az eszköz nem lesz elérhető amíg a követjező hitelesítés ellenőrzés meg nem történik. Ekkor ez a bejelölés automatikusan megszűnik."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr "Laboron belüli hitelesítő eljárás"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Nem működő"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr "Belső tanúsítvány"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Érvénytelen"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr "Foglalkozás"
 msgid "Job title"
 msgstr "Foglalkozás"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr "Kulcs"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Kulcsszó"
 
@@ -3012,6 +3153,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Kulcsszavak"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3056,8 +3201,8 @@ msgstr "Labor termékek"
 msgid "Lab URL"
 msgstr "Labor URL"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Címke"
@@ -3066,7 +3211,7 @@ msgstr "Címke"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr "Laboratórium"
 msgid "Laboratory Accredited"
 msgstr "Akkreditált laboratórium"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Nagy címke"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr "A tanúsítvány dokumentumot itt töltse fel"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr "Hely típus"
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr "Vezető telefon"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Tagsági kedvezmény alkalmazás"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr "Második keresztnév"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr "Legkevesebb mennyiség"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Név"
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Nyitott"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr "Megelőző karbantartási eljárás"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr "Árlista ehhez:"
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr "Árlista nyomtatás"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr "Sürgősség"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4362,6 +4574,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Közzétett eredmények"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4382,6 +4598,14 @@ msgstr "QC eredmények"
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Újra osztás"
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Érkezett"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Átvétel függőben"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr "Referencia vizsgálat"
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Eredmények függőben"
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr "Minta mátrix"
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Mintavevő"
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr "Az ilyen típusú mintákat kockázatosnak kell kezelni"
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Mintavétel kelte"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Mintavételi eltérés"
@@ -5085,7 +5375,7 @@ msgstr "Mintavételi eltérések"
 msgid "Sampling Frequency"
 msgstr "Mintavétel gyakoriság"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr "Ütemezés"
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr "Tudományos neve"
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Válasszon sablont"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr "Jelölje, hogy mely vizsgálatok legyenek a munkalapon"
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr "Sorozatszám"
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr "Hely kód"
 msgid "Site Description"
 msgstr "Hely leírás"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Kis címke"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5508,6 +5831,14 @@ msgstr ""
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Rendező kulcs"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr "Kezdő időpont"
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Megye"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Címke"
@@ -5577,7 +5908,11 @@ msgstr "Címke"
 msgid "Stickers preview"
 msgstr "Címke előnézet"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5667,7 +6006,7 @@ msgstr "Váltson műszerfalra"
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr "A legkevesebb minta mennyiség, ami szükséges a vizsgálathoz, pl. '10
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr "Az akkreditáló testület által a labornak kiadott hivatkozási szám.
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "A sorozatszám az eszköz egyedi azonosítója"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Cím"
@@ -6076,34 +6419,42 @@ msgstr "A hely neve"
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Megőrzendő"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Mintavételezendő"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Az eredmény jelentés minden vizsgálat kategória szakaszában megjelenítődik."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Megőrzendő"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Mintavételezendő"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Ellenőrzendő"
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr "Ismeretlen IBAN ország %s"
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr "Ismeretlen fájl formátum ${file_format}"
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Töltse fel a szkennelt aláírást, amit a nyomtatott vizsgálati jelentésekben kell használni. Az ideális mérte 250 pixel széles és 150 pixel magas."
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Használja a műszerfalat főoldalként"
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr "Áfa"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "Áfa %"
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Ellenőrzött"
@@ -6576,10 +6940,18 @@ msgstr "Ellenőrzött"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr "Megtekintés"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,10 +7088,18 @@ msgstr "Munkalap sablonok"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Munkalap"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "hatástalanít"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "Ellenőrzés(ek) függőben"
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/hu_HU/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hu_HU/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hungarian (Hungary) (https://app.transifex.com/senaite/teams/87045/hu_HU/)\n"

--- a/src/senaite/core/locales/hu_HU/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hu_HU/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hungarian (Hungary) (https://app.transifex.com/senaite/teams/87045/hu_HU/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/hu_HU/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hu_HU/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hungarian (Hungary) (https://app.transifex.com/senaite/teams/87045/hu_HU/)\n"

--- a/src/senaite/core/locales/hu_HU/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hu_HU/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hungarian (Hungary) (https://app.transifex.com/senaite/teams/87045/hu_HU/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: hu_HU\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/hy/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hy/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Armenian (https://app.transifex.com/senaite/teams/87045/hy/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/hy/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/hy/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Armenian (https://app.transifex.com/senaite/teams/87045/hy/)\n"

--- a/src/senaite/core/locales/hy/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hy/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Armenian (https://app.transifex.com/senaite/teams/87045/hy/)\n"

--- a/src/senaite/core/locales/hy/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/hy/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Armenian (https://app.transifex.com/senaite/teams/87045/hy/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: hy\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/id/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/id/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Indonesian (https://app.transifex.com/senaite/teams/87045/id/)\n"

--- a/src/senaite/core/locales/id/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/id/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Indonesian (https://app.transifex.com/senaite/teams/87045/id/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/id/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/id/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Indonesian (https://app.transifex.com/senaite/teams/87045/id/)\n"

--- a/src/senaite/core/locales/id/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/id/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Indonesian (https://app.transifex.com/senaite/teams/87045/id/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: id\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -284,15 +290,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -551,6 +588,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -565,18 +606,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -800,7 +845,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1126,7 +1185,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1135,7 +1194,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1228,7 +1287,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1328,7 +1391,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1473,7 +1540,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1481,12 +1548,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6576,10 +6940,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,9 +7088,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/it/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/it/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Italian (https://app.transifex.com/senaite/teams/87045/it/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/it/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/it/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Italian (https://app.transifex.com/senaite/teams/87045/it/)\n"

--- a/src/senaite/core/locales/it/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/it/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: giulio morelli, 2025\n"
 "Language-Team: Italian (https://app.transifex.com/senaite/teams/87045/it/)\n"

--- a/src/senaite/core/locales/it/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/it/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: giulio morelli, 2025\n"
 "Language-Team: Italian (https://app.transifex.com/senaite/teams/87045/it/)\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: it\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -29,6 +29,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -54,6 +55,7 @@ msgid "%s has no '%s' column."
 msgstr "%s ha n. '%s' colonne."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -123,6 +125,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -140,7 +146,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -198,7 +204,7 @@ msgid "Account Type"
 msgstr "Tipo Account"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -243,21 +249,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Attivo"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Aggiungi"
 
@@ -285,15 +291,19 @@ msgstr "Aggiungi duplicato"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Aggiungi un campo note a tutte le analisi"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -306,8 +316,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -371,13 +384,21 @@ msgstr "Di seguito sono elencati tutti i servizi di analisi accreditati."
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Tutte le analisi assegnate"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Permetti inserimento Limite Rilevamento Manuale"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -395,11 +416,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -428,14 +449,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analisi"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -505,7 +542,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -542,7 +579,7 @@ msgstr "Deve essere specificato l'Analista."
 msgid "Any"
 msgstr "Qualunque"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -553,6 +590,10 @@ msgstr "Applica"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Applica il template"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -566,19 +607,15 @@ msgstr "Bene Numero"
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Assegnato"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Assegnato a: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr ""
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -592,7 +629,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -680,11 +717,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -692,15 +733,15 @@ msgstr ""
 msgid "Autofill"
 msgstr "Riempimento automatico"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Disconnessione automatica"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -751,7 +792,7 @@ msgstr "Batch"
 msgid "Batch Book"
 msgstr "Libro Batch"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID Batch"
 
@@ -781,6 +822,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Posizione"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Indirizzo fatturazione"
@@ -801,7 +846,7 @@ msgstr "Marca"
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Scontistica grandi quantità applicata"
@@ -819,19 +864,19 @@ msgstr "Telefono Ufficio"
 msgid "Business address"
 msgstr "Indirizzo Commerciale"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -839,12 +884,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC Emails"
 
@@ -900,23 +945,23 @@ msgstr "Calibrazioni"
 msgid "Calibrator"
 msgstr "Calibratore"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Cancellato"
 
@@ -936,15 +981,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -970,7 +1015,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Numero di Catalogo"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Categorie servizi di analisi"
 
@@ -1002,11 +1047,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1043,31 +1088,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1080,12 +1125,26 @@ msgstr "Città"
 msgid "Classic"
 msgstr "Classico"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1093,7 +1152,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Cliente"
@@ -1105,7 +1164,7 @@ msgstr "ID Batch Cliente"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID Cliente"
 
@@ -1117,7 +1176,7 @@ msgstr "Pagina Destinazione Cliente"
 msgid "Client Name"
 msgstr "Nome Cliente"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Ordine Cliente"
 
@@ -1127,7 +1186,7 @@ msgstr "Ordine Cliente"
 msgid "Client Order Number"
 msgstr "Numero Ordine Cliente"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Rif. Cliente"
 
@@ -1136,7 +1195,7 @@ msgstr "Rif. Cliente"
 msgid "Client Reference"
 msgstr "Riferimento Cliente"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID Cliente"
 
@@ -1229,7 +1288,7 @@ msgstr "Commenti"
 msgid "Comments or results interpretation"
 msgstr "Commenti o interpretazione risultati"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "ID Commerciale"
@@ -1267,6 +1326,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1285,7 +1348,7 @@ msgstr "Conferma password"
 msgid "Considerations"
 msgstr "Considerazioni"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contatto"
@@ -1329,7 +1392,7 @@ msgstr "Contenitori"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1362,15 +1425,15 @@ msgstr "Copia servizi di analisi"
 msgid "Copy from"
 msgstr "Copia da"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Copia su nuovo"
 
@@ -1380,6 +1443,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1398,11 +1465,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1415,7 +1482,7 @@ msgstr "Nazione"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1423,7 +1490,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1435,7 +1502,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1465,7 +1532,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Creatore"
 
@@ -1474,7 +1541,7 @@ msgstr "Creatore"
 msgid "Criteria"
 msgstr "Criterio"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Valuta"
 
@@ -1482,13 +1549,21 @@ msgstr "Valuta"
 msgid "Current"
 msgstr "Attuale"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Separatore decimale personalizzato"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "DL"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1535,23 +1610,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Data di apertura"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Data Conservato"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Data di pubblicazione"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Data di ricezione"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1563,11 +1638,11 @@ msgstr "Data di richiesta"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Data di campionamento"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1609,7 +1684,7 @@ msgstr "Data in cui il certificato di calibrazione è stato concesso"
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1632,11 +1707,11 @@ msgstr "Disattivare fino al prossimo test di calibrazione"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Il separatore decimale da utilizzare nei reports da questo Cliente."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1648,7 +1723,7 @@ msgstr "Contenitore Predefinito"
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1660,7 +1735,7 @@ msgstr "Strumento Predefinito"
 msgid "Default Method"
 msgstr "Metodo Predefinito"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1668,20 +1743,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Conservazione Predefinita"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Separatore decimale predefinito"
 
@@ -1693,7 +1768,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1725,15 +1800,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Periodo di default di conservazione del campione"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Notazione scientifica predefinita per reports"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Notazione scientifica predefinita per risultati"
 
@@ -1745,7 +1820,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1754,7 +1829,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Valore predefinito"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1778,7 +1853,7 @@ msgstr "Definisci la precisione nella conversione dei valori in notazione espone
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1790,8 +1865,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Gradi"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1820,9 +1904,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Analisi Dipendente"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Descrizione"
 
@@ -1869,7 +1953,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1887,7 +1975,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Spediti"
@@ -1912,15 +2000,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr "Mostra un selettore del limite di rilevabilità (DL)"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminato"
 
@@ -1990,11 +2086,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Scadenza"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Data di scadenza"
@@ -2011,7 +2111,7 @@ msgstr "Duplicato"
 msgid "Duplicate Analysis"
 msgstr "Duplicare Analisi"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2059,6 +2159,7 @@ msgstr "Es. SANAS, APLAC, ecc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2073,21 +2174,21 @@ msgstr "Elevazione"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Indirizzo email"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2095,27 +2196,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2128,16 +2229,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2148,27 +2253,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2176,8 +2281,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2201,7 +2314,7 @@ msgstr "Inserire un indirizzo email. Questo è necessario nel caso di perdita de
 msgid "Enter discount percentage value"
 msgstr "Inserire la percentuale di sconto"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2214,7 +2327,7 @@ msgstr "Inserire un valore percentuale, ad esempio 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Inserire un valore percentuale, ad esempio 14.0. Questa percentuale è applicata solo nel Profilo Analisi, ignorando l'applicazione dell'IVA"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Inserire un valore percentuale, ad esempio 14.0. Questa percentuale è applicato in tutto il software, può essere sovrascritto sui singoli elementi"
 
@@ -2238,7 +2351,7 @@ msgstr "Inserire il dettaglio di ogni servizio di analisi che si vuole copiare."
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2250,15 +2363,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2270,7 +2383,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Escludere dalla fattura"
 
@@ -2280,7 +2393,7 @@ msgstr "Escludere dalla fattura"
 msgid "Expected Result"
 msgstr "Risultato Atteso"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2306,7 +2419,7 @@ msgstr "Data Scadenza"
 msgid "Exponential format precision"
 msgstr "Precisione formato esponenziale"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Soglia formato esponenziale"
 
@@ -2314,7 +2427,7 @@ msgstr "Soglia formato esponenziale"
 msgid "Export"
 msgstr "Esportare"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2401,7 +2514,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2415,6 +2528,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2431,11 +2556,11 @@ msgstr "Nome"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2458,13 +2583,17 @@ msgstr ""
 msgid "From"
 msgstr "Da"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Nome completo"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2472,7 +2601,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Campione datato nel futuro"
 
@@ -2505,7 +2634,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Titolo. Ad esempio Sig., Sig.ra, Dott."
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Raggruppa i servizi di analisi per categoria nelle tabelle LIMS, utile quando la lista è lunga"
 
@@ -2519,7 +2648,7 @@ msgid "Hazardous"
 msgstr "Pericolosi"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Nascosto"
@@ -2532,8 +2661,20 @@ msgstr "Campo Nascosto"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2557,7 +2698,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2565,7 +2706,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2585,15 +2726,15 @@ msgstr "Se selezionato, un elenco verrà visualizzato accanto al campo risultato
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Se nselezionato, lo strumento sarà disponibile fino a che non sarà effettuata la prossima calibrazione valida. Questa casella di controllo verrà automaticamente deselezionata."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2601,7 +2742,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Se abilitato, il nome delle analisi verranno scritte in corsivo."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2641,7 +2782,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2672,11 +2813,11 @@ msgstr "Procedura di calibrazione in-lab"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Inattivo"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Includere e visualizzare le informazioni sui prezzi"
 
@@ -2873,7 +3014,7 @@ msgid "Internal Certificate"
 msgstr "Certificato Interno"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2894,13 +3035,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Non valido"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2963,15 +3104,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "La fattura Batch non ha Data Fine"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "La fattura Batch non ha Data Inizio"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "La fattura Batch non ha Titolo"
 
@@ -2983,7 +3124,7 @@ msgstr "Titolo Lavorativo"
 msgid "Job title"
 msgstr "Titolo lavorativo"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2995,9 +3136,9 @@ msgstr "Chiave"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Parola chiave"
 
@@ -3013,6 +3154,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Parole chiavi"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3057,8 +3202,8 @@ msgstr "Prodotti Lab"
 msgid "Lab URL"
 msgstr "Laboratorio URL"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Etichetta"
@@ -3067,7 +3212,7 @@ msgstr "Etichetta"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3075,13 +3220,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3094,7 +3239,7 @@ msgstr "Laboratorio"
 msgid "Laboratory Accredited"
 msgstr "Laboratorio accreditato"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3106,7 +3251,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Etichetta Larga"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3118,11 +3263,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Ritardo"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Ritardo delle analisi"
 
@@ -3168,15 +3313,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3200,7 +3345,7 @@ msgstr "Carica il documento di certificato qui"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3227,6 +3372,14 @@ msgstr "Tipo Posizione"
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3291,7 +3444,7 @@ msgstr "Uomo"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3315,7 +3468,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3339,7 +3492,7 @@ msgstr "Email manager"
 msgid "Manager Phone"
 msgstr "Telefono manager"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Manuale"
 
@@ -3368,7 +3521,7 @@ msgstr "Produttori"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3383,7 +3536,7 @@ msgstr "Tempo massimo"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3418,15 +3571,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "% Sconto membri"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Sconto applicato agli iscritti"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3434,7 +3587,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3465,7 +3618,7 @@ msgstr "Iniziali secondo nome"
 msgid "Middle name"
 msgstr "Secondo nome"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3476,7 +3629,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3494,7 +3647,7 @@ msgstr "Minimo 5 caratteri."
 msgid "Minimum Volume"
 msgstr "Volume Minimo"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Numero minimo di risultati per il calcolo statistico QC"
 
@@ -3525,6 +3678,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3538,11 +3695,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3578,13 +3735,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nome"
 
@@ -3594,6 +3755,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3636,6 +3801,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3684,6 +3853,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3728,12 +3901,26 @@ msgstr "Nessun elemento selezionato"
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "Nessun nuovo elemento è stato creato"
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3750,6 +3937,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3778,7 +3969,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Nessuno"
 
@@ -3794,11 +3985,11 @@ msgstr ""
 msgid "Not defined"
 msgstr "Non definito"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3819,7 +4010,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3831,7 +4022,7 @@ msgstr "Numero colonne"
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Numero di Analisi"
 
@@ -3847,16 +4038,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3866,6 +4057,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3884,11 +4079,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3896,13 +4091,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr "Solo per campi vuoti o pari a zero"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Aperto"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3910,8 +4105,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3939,7 +4142,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3961,11 +4164,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4062,11 +4265,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4079,6 +4282,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4098,12 +4302,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Punto di cattura"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4142,31 +4350,31 @@ msgstr "Precisione come numero di decimali"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Precisione come numero di cifre significative secondo l'incertezza. La posizione decimale deve essere fornita viene data dal primo numero diverso da zero nell'incertezza, in questa posizione il sistema arrotonderà l'incertezza e i risultati. Per esempio, con un risultato di 5.243 e dun incertezza di 0.22, il sistema mostrerà correttamente come 5.2 +-0.2. Se non viene impostato un intervallo di incertezza per il risultato, il sistema utilizzerà un impostazione di precisione fissa."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Separatore decimale preferito per i reports."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Separatore decimale preferito per i risultati"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Notazione scientifica preferita per i reports"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Notazione scientifica preferita per i risultati"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4199,7 +4407,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Conservatore"
 
@@ -4216,11 +4424,11 @@ msgstr "Preventivo"
 msgid "Preventive maintenance procedure"
 msgstr "Procedura manutenzione preventiva"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4248,7 +4456,7 @@ msgstr "Listino prezzi"
 msgid "Pricelists"
 msgstr "Listini prezzi"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4257,7 +4465,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4279,11 +4487,11 @@ msgstr "Data stampa:"
 msgid "Print pricelist"
 msgstr "Stampa Listini"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4296,7 +4504,7 @@ msgstr ""
 msgid "Priority"
 msgstr "Priorità"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Profilo"
 
@@ -4320,7 +4528,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4329,7 +4537,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "ID Protocollo"
 
@@ -4337,7 +4545,7 @@ msgstr "ID Protocollo"
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4346,8 +4554,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Pubblicato"
@@ -4363,6 +4575,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Risultati pubblicati"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4384,6 +4600,14 @@ msgstr ""
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "ID Campione QC"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4409,7 +4633,7 @@ msgstr "Reinserire la password. Assicurarsi che le password siano identiche."
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Riassegnare"
 
@@ -4421,30 +4645,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Ricevere"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Ricevuto"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Destinatari"
 
@@ -4495,11 +4723,15 @@ msgstr "Valori di riferimento"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "I Valori di esempio di riferimento sono zero o 'vuoto'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registro"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4525,9 +4757,9 @@ msgstr "Rifiuta Analisi"
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4543,7 +4775,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4604,8 +4836,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4641,11 +4881,11 @@ msgstr "ID Report"
 msgid "Report identification number"
 msgstr "Numero identificativo report"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4657,7 +4897,7 @@ msgstr "Caricare report"
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4666,7 +4906,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "ID richiesta"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Richiesta di nuove analisi"
 
@@ -4682,8 +4922,20 @@ msgstr "Volume richiesto"
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4691,15 +4943,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4724,15 +4977,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Risultato nel margine dell'intervallo"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Risultato fuori scala"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4740,7 +4993,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "I valori di risultato con almeno questo numero di cifre significative è visualizzato in notazione scientifica utilizzando la lettera 'e' per indicare l'esponente. La precisione può essere configueata nei singoli Servizi Analisi."
 
@@ -4756,16 +5009,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr "Interpretazione Risultati"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "I risultati sono stati revocati"
 
@@ -4773,7 +5030,7 @@ msgstr "I risultati sono stati revocati"
 msgid "Results interpretation"
 msgstr "Interpretazione risultati"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Risultati in attesa"
 
@@ -4797,7 +5054,7 @@ msgstr "Riesaminato"
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4833,6 +5090,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4858,6 +5119,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4867,7 +5129,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4881,7 +5143,7 @@ msgstr "Formula di saluto"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Campione"
 
@@ -4918,7 +5180,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "ID del campione"
 
@@ -4938,7 +5200,7 @@ msgstr "Matrice Campione"
 msgid "Sample Partitions"
 msgstr "Partizione del Campione"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4965,7 +5227,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Tipo di campione"
@@ -5026,7 +5288,7 @@ msgstr "Tipo Campione"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Campionatore"
 
@@ -5038,8 +5300,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Campioni"
@@ -5056,6 +5318,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5065,7 +5339,23 @@ msgstr "Campioni di questo tipo dovrebbero essere trattati come pericolosi"
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5073,7 +5363,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Data di campionamento"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Deviazione di Campionamento"
@@ -5086,7 +5376,7 @@ msgstr "Deviazioni di Campionamento"
 msgid "Sampling Frequency"
 msgstr "Frequenza di campionamento"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5094,14 +5384,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Salva"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5116,7 +5415,7 @@ msgstr "Programmare"
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5133,6 +5432,10 @@ msgstr "Nome scientifico"
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5141,7 +5444,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Secondi"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5231,11 +5534,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Selezionare un modello"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Selezionare il paese che il sito mostrerà di default"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Selezionare la valuta che il sito utilizzerà per visualizzare i prezzi."
 
@@ -5247,11 +5550,11 @@ msgstr "Selezionare il contenitore predefinito da utilizzare per questo servizio
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Selezionare la pagina predefinita di destinazione. Questa viene utilizzata quando un Cliente accede al sistema, o quando un cliente viene selezionato dall'elenco cartelle cliente."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5259,31 +5562,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Selezionare questo per attivare le fasi di raccolta campione del flusso di lavoro "
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5295,7 +5606,7 @@ msgstr "Selezionare quali analisi devono essere incluse nel foglio di lavoro"
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5307,11 +5618,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5333,7 +5644,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Contenitore Separato"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5347,7 +5658,7 @@ msgstr "Serial Nr."
 msgid "Service"
 msgstr "Servizio"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5375,7 +5686,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr "Impostare l'attività di manutenzione come chiusa"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5423,28 +5734,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5467,11 +5790,11 @@ msgstr "Codice Ubicazione"
 msgid "Site Description"
 msgstr "Descizione Ubicazione"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5492,7 +5815,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Etichetta Piccola"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5509,6 +5832,14 @@ msgstr "Alcine analisi utilizzano strumenti scaduti o non calibrati. Edizione ri
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Chiave Ordinamento"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5534,7 +5865,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "Specifiche"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5542,7 +5873,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5559,17 +5890,17 @@ msgstr "Data Inizio"
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Stato"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Stato"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Etichetta"
@@ -5578,7 +5909,11 @@ msgstr "Etichetta"
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Posizione Magazzino"
@@ -5618,7 +5953,11 @@ msgstr "Invia"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5626,7 +5965,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotale"
@@ -5668,7 +6007,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5694,7 +6033,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descrizione tecnica e istruzioni per l'analista"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5776,7 +6115,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Il separatore decimale selezionato in Impostazioni Bika sarà usato"
 
@@ -5784,7 +6123,7 @@ msgstr "Il separatore decimale selezionato in Impostazioni Bika sarà usato"
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "Lo sconto percentuale inserito qui, è applicato ai prezzi per i clienti contrassegnati come 'membri', normalmente membri di cooperative o collegati meritevoli di questo sconto"
 
@@ -5812,7 +6151,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5820,11 +6163,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "L'altezza o la profondita al quale il campione deve essere preso"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5861,11 +6204,11 @@ msgstr "Il minimo volume campione richiesto per analisi, ad esempio '10 ml' o '1
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Il numero di giorni prima della scadenza campione e non potrà essere vpiù analizzato. Questa impostazione può essere ignorata per singoli tipi campioni nella impostazione dei tipi campione"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Il numero di minuti prima che un utente sia disconnesso. 0 disabilita la disconnessione automatica"
 
@@ -5905,7 +6248,7 @@ msgstr "Il codice di riferimento rilasciato al laboratorio dall'ente di accredit
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5929,11 +6272,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Il numero seriale che identifica univocamente lo strumento"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "ID del protocollo analitico del servizio"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "L'ID commerciale del servizio ai fini contabili"
 
@@ -5985,11 +6328,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6013,11 +6356,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6049,8 +6392,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Consiglio. I documenti allegati non verranno caricati a meno che non sono presenti nell'istanza."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Titolo"
@@ -6077,34 +6420,42 @@ msgstr "Titolo del luogo"
 msgid "To"
 msgstr "A"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Da Conservare"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Da campionare"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Da mostrare sotto ogni sezione Categoria Analisi nei reports dei risultati."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Da verificare"
@@ -6117,7 +6468,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Totale"
 
@@ -6139,7 +6490,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Tipo"
@@ -6164,6 +6515,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6172,7 +6527,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6184,6 +6539,7 @@ msgstr "Impossibile caricare il modello"
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Non assegnati"
@@ -6216,8 +6572,12 @@ msgstr "IBAN nazione sconosciuta %s"
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6234,12 +6594,16 @@ msgstr "Formato file non riconoscibile ${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6250,7 +6614,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Caricare una firma digitalizzata da utilizzare sui report di analisi. Le dimensioni ideali sono di 250x150 pixel."
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6258,7 +6622,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Usa Prezzo Profilo Analisi"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6296,7 +6660,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6304,15 +6668,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Usando troppi pochi punti dati non genera significato statistico. Impostare un numero minimo accettabile di risultati prima di calcolare e tracciare statistiche QC"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6320,7 +6684,7 @@ msgstr "IVA"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "% IVA"
 
@@ -6567,8 +6931,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "I valori possono essere inseriti qui i quali sovrasciveranno i predefiniti specificati nel Campi Provvisori di Calcolo"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verificato"
@@ -6577,10 +6941,18 @@ msgstr "Verificato"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6595,6 +6967,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6630,6 +7010,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Settimane alla scadenza"
@@ -6642,21 +7026,21 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 "Quando abilitato, il campione è verificato automaticamente non appena tutti i risultati sono verificati. Oppure, gli utenti con sufficienti privilegi devono verificare manualmente i campioni in seguito.\n"
 "Default: abilitato"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6707,10 +7091,18 @@ msgstr "Modelli dei foglio di lavoro"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Fogli di lavoro"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6719,6 +7111,10 @@ msgstr ""
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Errata lunghezza IBAN da %s: %sshort da %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6802,6 +7198,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6906,8 +7306,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "disattivare"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6972,7 +7381,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7139,46 +7548,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7190,19 +7599,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7223,16 +7632,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7257,12 +7671,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7272,7 +7686,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7375,6 +7789,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7404,6 +7831,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7550,12 +7984,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7808,7 +8242,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7816,163 +8250,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7980,47 +8414,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8029,20 +8463,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8050,32 +8484,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8083,21 +8517,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8253,6 +8687,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8565,7 +9003,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8626,7 +9064,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8742,52 +9180,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8857,12 +9295,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8872,7 +9310,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9168,7 +9606,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9293,12 +9731,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9508,7 +9946,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9518,12 +9956,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9581,6 +10019,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10757,87 +11211,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10890,6 +11344,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10940,12 +11399,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11023,6 +11490,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11257,13 +11729,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11350,6 +11827,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11595,222 +12077,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12064,7 +12546,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12107,7 +12589,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ja/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ja/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Japanese (https://app.transifex.com/senaite/teams/87045/ja/)\n"

--- a/src/senaite/core/locales/ja/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ja/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Japanese (https://app.transifex.com/senaite/teams/87045/ja/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ja/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ja/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Japanese (https://app.transifex.com/senaite/teams/87045/ja/)\n"

--- a/src/senaite/core/locales/ja/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ja/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Japanese (https://app.transifex.com/senaite/teams/87045/ja/)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ja\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -27,6 +27,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -52,6 +53,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -121,6 +123,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -138,7 +144,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -196,7 +202,7 @@ msgid "Account Type"
 msgstr "アカウントタイプ"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -241,21 +247,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -283,15 +289,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -304,8 +314,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -369,12 +382,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -393,11 +414,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -426,14 +447,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -503,7 +540,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -540,7 +577,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -550,6 +587,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -564,18 +605,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -590,7 +627,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -678,11 +715,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -690,15 +731,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -749,7 +790,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -779,6 +820,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -799,7 +844,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -817,19 +862,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -837,12 +882,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -898,23 +943,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -934,15 +979,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -968,7 +1013,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1000,11 +1045,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1041,31 +1086,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1078,12 +1123,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1091,7 +1150,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1103,7 +1162,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1115,7 +1174,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1125,7 +1184,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1134,7 +1193,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1227,7 +1286,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1265,6 +1324,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1283,7 +1346,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1327,7 +1390,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1360,15 +1423,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1378,6 +1441,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1396,11 +1463,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1413,7 +1480,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1421,7 +1488,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1433,7 +1500,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1463,7 +1530,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1472,7 +1539,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1480,12 +1547,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1533,23 +1608,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1561,11 +1636,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1607,7 +1682,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1630,11 +1705,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1646,7 +1721,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1658,7 +1733,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1666,20 +1741,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1691,7 +1766,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1723,15 +1798,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1743,7 +1818,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1752,7 +1827,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1776,7 +1851,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1788,8 +1863,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1818,9 +1902,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1867,7 +1951,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1885,7 +1973,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1910,15 +1998,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1988,11 +2084,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2009,7 +2109,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2057,6 +2157,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2071,21 +2172,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2093,27 +2194,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2126,16 +2227,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2146,27 +2251,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2174,8 +2279,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2199,7 +2312,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2212,7 +2325,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2236,7 +2349,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2248,15 +2361,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2268,7 +2381,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2278,7 +2391,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2304,7 +2417,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2312,7 +2425,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2399,7 +2512,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2413,6 +2526,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2429,11 +2554,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2456,13 +2581,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2470,7 +2599,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2503,7 +2632,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2517,7 +2646,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2530,8 +2659,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2555,7 +2696,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2563,7 +2704,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2583,15 +2724,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2599,7 +2740,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2639,7 +2780,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2670,11 +2811,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2871,7 +3012,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2892,13 +3033,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2961,15 +3102,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2981,7 +3122,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2993,9 +3134,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3010,6 +3151,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3055,8 +3200,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3065,7 +3210,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3073,13 +3218,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3092,7 +3237,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3104,7 +3249,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3116,11 +3261,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3166,15 +3311,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3198,7 +3343,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3225,6 +3370,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3289,7 +3442,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3313,7 +3466,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3337,7 +3490,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3366,7 +3519,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3381,7 +3534,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3416,15 +3569,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3432,7 +3585,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3463,7 +3616,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3474,7 +3627,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3492,7 +3645,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3523,6 +3676,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3536,11 +3693,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3576,13 +3733,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3592,6 +3753,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3634,6 +3799,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3682,6 +3851,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3726,12 +3899,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3748,6 +3935,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3776,7 +3967,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3792,11 +3983,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3817,7 +4008,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3829,7 +4020,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3845,16 +4036,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3864,6 +4055,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3882,11 +4077,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3894,13 +4089,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3908,8 +4103,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3937,7 +4140,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3959,11 +4162,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4060,11 +4263,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4077,6 +4280,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4096,12 +4300,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4140,31 +4348,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4197,7 +4405,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4214,11 +4422,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4246,7 +4454,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4255,7 +4463,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4277,11 +4485,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4294,7 +4502,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4318,7 +4526,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4327,7 +4535,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4335,7 +4543,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4344,8 +4552,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4360,6 +4572,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4381,6 +4597,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4407,7 +4631,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4419,30 +4643,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4493,11 +4721,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4523,9 +4755,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4541,7 +4773,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4602,8 +4834,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4639,11 +4879,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4655,7 +4895,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4664,7 +4904,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4680,8 +4920,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4689,15 +4941,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4722,15 +4975,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4738,7 +4991,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4754,16 +5007,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4771,7 +5028,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4795,7 +5052,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4831,6 +5088,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4856,6 +5117,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4865,7 +5127,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4879,7 +5141,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4916,7 +5178,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4936,7 +5198,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4963,7 +5225,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5024,7 +5286,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5036,8 +5298,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5054,6 +5316,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5063,7 +5337,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5071,7 +5361,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5084,7 +5374,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5092,14 +5382,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5114,7 +5413,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5131,6 +5430,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5139,7 +5442,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5229,11 +5532,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5245,11 +5548,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5257,31 +5560,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5293,7 +5604,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5305,11 +5616,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5331,7 +5642,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5345,7 +5656,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5373,7 +5684,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5421,28 +5732,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5465,11 +5788,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5490,7 +5813,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5506,6 +5829,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5532,7 +5863,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5540,7 +5871,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5557,17 +5888,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5576,7 +5907,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5616,7 +5951,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5624,7 +5963,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5666,7 +6005,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5692,7 +6031,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5774,7 +6113,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5782,7 +6121,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5810,7 +6149,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5818,11 +6161,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5859,11 +6202,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5903,7 +6246,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5927,11 +6270,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5983,11 +6326,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6011,11 +6354,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6047,8 +6390,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6075,34 +6418,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6115,7 +6466,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6137,7 +6488,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6162,6 +6513,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6170,7 +6525,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6182,6 +6537,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6214,8 +6570,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6232,12 +6592,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6248,7 +6612,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6256,7 +6620,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6294,7 +6658,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6302,15 +6666,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6318,7 +6682,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6565,8 +6929,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6575,10 +6939,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6593,6 +6965,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6628,6 +7008,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6640,19 +7024,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6703,9 +7087,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6714,6 +7106,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6798,6 +7194,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6902,8 +7302,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6968,7 +7377,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7135,46 +7544,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7186,19 +7595,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7219,16 +7628,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7253,12 +7667,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7268,7 +7682,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7371,6 +7785,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7400,6 +7827,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7546,12 +7980,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7804,7 +8238,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7812,163 +8246,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7976,47 +8410,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8025,20 +8459,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8046,32 +8480,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8079,21 +8513,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8249,6 +8683,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8561,7 +8999,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8622,7 +9060,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8738,52 +9176,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8853,12 +9291,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8868,7 +9306,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9164,7 +9602,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9289,12 +9727,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9504,7 +9942,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9514,12 +9952,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9577,6 +10015,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10753,87 +11207,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10886,6 +11340,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10936,12 +11395,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11019,6 +11486,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11253,13 +11725,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11346,6 +11823,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11591,222 +12073,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12060,7 +12542,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12103,7 +12585,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ka_GE/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ka_GE/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Georgian (Georgia) (https://app.transifex.com/senaite/teams/87045/ka_GE/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ka_GE/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ka_GE/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Georgian (Georgia) (https://app.transifex.com/senaite/teams/87045/ka_GE/)\n"

--- a/src/senaite/core/locales/ka_GE/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ka_GE/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Georgian (Georgia) (https://app.transifex.com/senaite/teams/87045/ka_GE/)\n"

--- a/src/senaite/core/locales/ka_GE/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ka_GE/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Georgian (Georgia) (https://app.transifex.com/senaite/teams/87045/ka_GE/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ka_GE\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/kn/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/kn/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Kannada (https://app.transifex.com/senaite/teams/87045/kn/)\n"

--- a/src/senaite/core/locales/kn/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/kn/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Kannada (https://app.transifex.com/senaite/teams/87045/kn/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/kn/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/kn/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Kannada (https://app.transifex.com/senaite/teams/87045/kn/)\n"

--- a/src/senaite/core/locales/kn/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/kn/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Kannada (https://app.transifex.com/senaite/teams/87045/kn/)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: kn\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -27,6 +27,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -52,6 +53,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -121,6 +123,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -138,7 +144,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -196,7 +202,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -241,21 +247,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -283,15 +289,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -304,8 +314,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -369,12 +382,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -393,11 +414,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -426,14 +447,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -503,7 +540,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -540,7 +577,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -550,6 +587,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -564,18 +605,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -590,7 +627,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -678,11 +715,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -690,15 +731,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -749,7 +790,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -779,6 +820,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -799,7 +844,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -817,19 +862,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -837,12 +882,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -898,23 +943,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -934,15 +979,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -968,7 +1013,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1000,11 +1045,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1041,31 +1086,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1078,12 +1123,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1091,7 +1150,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1103,7 +1162,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1115,7 +1174,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1125,7 +1184,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1134,7 +1193,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1227,7 +1286,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1265,6 +1324,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1283,7 +1346,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1327,7 +1390,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1360,15 +1423,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1378,6 +1441,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1396,11 +1463,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1413,7 +1480,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1421,7 +1488,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1433,7 +1500,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1463,7 +1530,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1472,7 +1539,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1480,12 +1547,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1533,23 +1608,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1561,11 +1636,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1607,7 +1682,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1630,11 +1705,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1646,7 +1721,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1658,7 +1733,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1666,20 +1741,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1691,7 +1766,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1723,15 +1798,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1743,7 +1818,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1752,7 +1827,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1776,7 +1851,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1788,8 +1863,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1818,9 +1902,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1867,7 +1951,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1885,7 +1973,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1910,15 +1998,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1988,11 +2084,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2009,7 +2109,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2057,6 +2157,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2071,21 +2172,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2093,27 +2194,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2126,16 +2227,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2146,27 +2251,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2174,8 +2279,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2199,7 +2312,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2212,7 +2325,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2236,7 +2349,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2248,15 +2361,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2268,7 +2381,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2278,7 +2391,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2304,7 +2417,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2312,7 +2425,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2399,7 +2512,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2413,6 +2526,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2429,11 +2554,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2456,13 +2581,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2470,7 +2599,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2503,7 +2632,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2517,7 +2646,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2530,8 +2659,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2555,7 +2696,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2563,7 +2704,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2583,15 +2724,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2599,7 +2740,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2639,7 +2780,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2670,11 +2811,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2871,7 +3012,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2892,13 +3033,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2961,15 +3102,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2981,7 +3122,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2993,9 +3134,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3010,6 +3151,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3055,8 +3200,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3065,7 +3210,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3073,13 +3218,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3092,7 +3237,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3104,7 +3249,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3116,11 +3261,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3166,15 +3311,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3198,7 +3343,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3225,6 +3370,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3289,7 +3442,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3313,7 +3466,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3337,7 +3490,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3366,7 +3519,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3381,7 +3534,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3416,15 +3569,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3432,7 +3585,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3463,7 +3616,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3474,7 +3627,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3492,7 +3645,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3523,6 +3676,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3536,11 +3693,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3576,13 +3733,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3592,6 +3753,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3634,6 +3799,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3682,6 +3851,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3726,12 +3899,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3748,6 +3935,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3776,7 +3967,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3792,11 +3983,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3817,7 +4008,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3829,7 +4020,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3845,16 +4036,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3864,6 +4055,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3882,11 +4077,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3894,13 +4089,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3908,8 +4103,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3937,7 +4140,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3959,11 +4162,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4060,11 +4263,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4077,6 +4280,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4096,12 +4300,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4140,31 +4348,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4197,7 +4405,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4214,11 +4422,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4246,7 +4454,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4255,7 +4463,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4277,11 +4485,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4294,7 +4502,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4318,7 +4526,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4327,7 +4535,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4335,7 +4543,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4344,8 +4552,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4360,6 +4572,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4381,6 +4597,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4407,7 +4631,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4419,30 +4643,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4493,11 +4721,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4523,9 +4755,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4541,7 +4773,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4602,8 +4834,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4639,11 +4879,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4655,7 +4895,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4664,7 +4904,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4680,8 +4920,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4689,15 +4941,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4722,15 +4975,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4738,7 +4991,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4754,16 +5007,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4771,7 +5028,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4795,7 +5052,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4831,6 +5088,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4856,6 +5117,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4865,7 +5127,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4879,7 +5141,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4916,7 +5178,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4936,7 +5198,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4963,7 +5225,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5024,7 +5286,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5036,8 +5298,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5054,6 +5316,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5063,7 +5337,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5071,7 +5361,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5084,7 +5374,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5092,14 +5382,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5114,7 +5413,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5131,6 +5430,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5139,7 +5442,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5229,11 +5532,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5245,11 +5548,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5257,31 +5560,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5293,7 +5604,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5305,11 +5616,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5331,7 +5642,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5345,7 +5656,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5373,7 +5684,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5421,28 +5732,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5465,11 +5788,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5490,7 +5813,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5506,6 +5829,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5532,7 +5863,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5540,7 +5871,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5557,17 +5888,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5576,7 +5907,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5616,7 +5951,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5624,7 +5963,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5666,7 +6005,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5692,7 +6031,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5774,7 +6113,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5782,7 +6121,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5810,7 +6149,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5818,11 +6161,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5859,11 +6202,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5903,7 +6246,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5927,11 +6270,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5983,11 +6326,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6011,11 +6354,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6047,8 +6390,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6075,34 +6418,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6115,7 +6466,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6137,7 +6488,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6162,6 +6513,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6170,7 +6525,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6182,6 +6537,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6214,8 +6570,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6232,12 +6592,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6248,7 +6612,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6256,7 +6620,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6294,7 +6658,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6302,15 +6666,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6318,7 +6682,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6565,8 +6929,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6575,10 +6939,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6593,6 +6965,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6628,6 +7008,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6640,19 +7024,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6703,9 +7087,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6714,6 +7106,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6798,6 +7194,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6902,8 +7302,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6968,7 +7377,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7135,46 +7544,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7186,19 +7595,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7219,16 +7628,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7253,12 +7667,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7268,7 +7682,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7371,6 +7785,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7400,6 +7827,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7546,12 +7980,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7804,7 +8238,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7812,163 +8246,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7976,47 +8410,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8025,20 +8459,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8046,32 +8480,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8079,21 +8513,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8249,6 +8683,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8561,7 +8999,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8622,7 +9060,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8738,52 +9176,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8853,12 +9291,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8868,7 +9306,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9164,7 +9602,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9289,12 +9727,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9504,7 +9942,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9514,12 +9952,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9577,6 +10015,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10753,87 +11207,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10886,6 +11340,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10936,12 +11395,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11019,6 +11486,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11253,13 +11725,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11346,6 +11823,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11591,222 +12073,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12060,7 +12542,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12103,7 +12585,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/lt/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/lt/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Lithuanian (https://app.transifex.com/senaite/teams/87045/lt/)\n"

--- a/src/senaite/core/locales/lt/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/lt/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Lithuanian (https://app.transifex.com/senaite/teams/87045/lt/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/lt/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/lt/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Lithuanian (https://app.transifex.com/senaite/teams/87045/lt/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: lt\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Naudotojo tipas"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Aktyvus"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Pridėti"
 
@@ -284,15 +290,19 @@ msgstr "Pridėti kopiją"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Visi tyrimai priskirti"
 
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
+
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Tyrimai"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr "Bet koks"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr ""
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Pritaikyti šabloną"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,18 +606,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Užregistruotas"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr "Automatins duomenų užpildymas"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Automatiškai išregistruojama"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr "Grupė, partija"
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Grupės ID"
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Azimutas"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Sąskaitos pateikimo adresas"
@@ -800,7 +845,7 @@ msgstr "Šaka"
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Viso užsakymo nuolaida"
@@ -818,19 +863,19 @@ msgstr "Darbo telefonas"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC e-paštas"
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Anuliuoti"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Sąrašo numeris"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr ""
 msgid "Classic"
 msgstr "Klasikinis"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Užsakovas"
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Užsakovo ID"
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Užsakymas"
 
@@ -1126,7 +1185,7 @@ msgstr "Užsakymas"
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Užsakovo nuoroda"
 
@@ -1135,7 +1194,7 @@ msgstr "Užsakovo nuoroda"
 msgid "Client Reference"
 msgstr "Užsakovo nuoroda"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Užsakovo SID"
 
@@ -1228,7 +1287,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Patvirtinti slaptažodį"
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kontaktiniai duomenys"
@@ -1328,7 +1391,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1473,7 +1540,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1481,12 +1548,20 @@ msgstr ""
 msgid "Current"
 msgstr "Einamasis"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Pradžios data"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Paskelbimo data"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Gavimo data"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr "Užklausos data"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Tyrimo data"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Įprastinis mėginio išlaikymo periodas"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Numatytoji reikšmė"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Laipsnis"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6576,10 +6940,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,9 +7088,17 @@ msgstr "Darbo kortelių šablonai"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/lt/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/lt/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Lithuanian (https://app.transifex.com/senaite/teams/87045/lt/)\n"

--- a/src/senaite/core/locales/mn/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/mn/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Mongolian (https://app.transifex.com/senaite/teams/87045/mn/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/mn/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/mn/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Mongolian (https://app.transifex.com/senaite/teams/87045/mn/)\n"

--- a/src/senaite/core/locales/mn/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/mn/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Mongolian (https://app.transifex.com/senaite/teams/87045/mn/)\n"

--- a/src/senaite/core/locales/mn/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/mn/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Mongolian (https://app.transifex.com/senaite/teams/87045/mn/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: mn\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ms/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ms/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Malay (https://app.transifex.com/senaite/teams/87045/ms/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ms/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ms/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Malay (https://app.transifex.com/senaite/teams/87045/ms/)\n"

--- a/src/senaite/core/locales/ms/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ms/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Malay (https://app.transifex.com/senaite/teams/87045/ms/)\n"

--- a/src/senaite/core/locales/ms/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ms/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Malay (https://app.transifex.com/senaite/teams/87045/ms/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ms\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} lampiran dengan jumlah saiz ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr "%s tidak mempunyai lajur '%s'."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Kembali"
@@ -122,6 +124,10 @@ msgstr "*** Ini merupakan emel yang dijana secara automatik, sila jangan balas k
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Selamat datang ke SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Jenis Akaun"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr "Aktifkan"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Aktif"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Aktor"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Tambah"
 
@@ -284,15 +290,19 @@ msgstr "Tambah Duplikat"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Tambah ruang catatan kepada semua analisis"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr "Tambah Lampiran Baharu"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Tambah satu atau lebih lampiran untuk menerangkan sampel dalam sampel ini, atau menyatakan permohonan anda."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Tambah catatan"
 
@@ -370,13 +383,21 @@ msgstr "Semua analisis berstatus akreditasi adalah tersenarai di sini."
 msgid "All Analyses of Service"
 msgstr "Semua Analisis dalam Perkhidmatan"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Semua analisis telah ditugaskan"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Benarkan masuk Had Pengesanan secara manual"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -394,11 +415,11 @@ msgstr "Benarkan pengguna yang sama untuk mengesahkan berulang kali"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Benarkan pengguna yang sama untuk mengesahkan berulang kali tetapi bukan berterusan"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Benarkan mengesahkan keputusan sendiri"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,15 +448,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Dianalisis oleh"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analisis"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Analisis yang dimohon"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Spesifikasi analisis yang disunting kepada sampel secara langsung."
 
@@ -541,7 +578,7 @@ msgstr "Juruanalisis perlu dinyatakan."
 msgid "Any"
 msgstr "Sebarang"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr "Guna"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Guna templat"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,19 +606,15 @@ msgstr "Nombor Aset"
 msgid "Assign"
 msgstr "Tugaskan"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Telah Ditugaskan"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Ditugaskan kepada: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Tugasan belum siap"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Pembahagian secara auto semasa penerimaan"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Terima sampel secara auto"
 
@@ -691,15 +732,15 @@ msgstr "Terima sampel secara auto"
 msgid "Autofill"
 msgstr "Isi secara auto"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Log keluar secara auto"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr "Kelompok"
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID Kelompok"
 
@@ -780,6 +821,10 @@ msgstr "Berjaga-jaga bahawa julat yang dibekalkan dalam file spreadsheet daripad
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Alamat Bil"
@@ -800,7 +845,7 @@ msgstr "Jenama"
 msgid "Bulk Discount"
 msgstr "Diskaun Pukal"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Diskaun pukal digunakan"
@@ -818,19 +863,19 @@ msgstr "Telefon Syarikat"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "SK Emel"
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr "Penentukur"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Boleh mengesahkan, tetapi dihantar oleh pengguna semasa"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Boleh mengesahkan, tetapi telah disahkan oleh pengguna semasa"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Batalkan"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Telah dibatalkan"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "Tidak dapat mengesahkan, disahkan akhir sekali oleh pengguna semasa"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "Tidak boleh mengesahkan, dihantar oleh pengguna semasa"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "Tidak boleh mengesahkan, telah disahkan oleh pengguna semasa"
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Nombor Katalog"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Kategorikan perkhidmatan analisis"
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr "Perubahan Disimpan"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Perubahan disimpan."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Perubahan akan digunakan kepada semua bahagian."
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Pilih jenis pengesahan multi untuk pengguna yang sama. Tetapan ini akan membenarkan/tidak membenarkan pengesahan/pengesahan berturutan oleh pengguna yang sama."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,20 +1124,34 @@ msgstr "Bandar"
 msgid "Classic"
 msgstr "Klasik"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Klik untuk buka kategori ini"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Klien"
@@ -1104,7 +1163,7 @@ msgstr "ID Kumpulan Klien"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID Klien"
 
@@ -1116,7 +1175,7 @@ msgstr "Laman Mendarat Klien"
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Urutan Klien"
 
@@ -1126,7 +1185,7 @@ msgstr "Urutan Klien"
 msgid "Client Order Number"
 msgstr "Nombor Pesanan Klien"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Rujukan Klien"
 
@@ -1135,7 +1194,7 @@ msgstr "Rujukan Klien"
 msgid "Client Reference"
 msgstr "Rujukan Klien"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID Klien"
 
@@ -1228,7 +1287,7 @@ msgstr "Komen"
 msgid "Comments or results interpretation"
 msgstr "Komen atau interpretasi keputusan"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "ID Komersial"
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Sahkan kata laluan"
 msgid "Considerations"
 msgstr "Pertimbangan"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kenalan"
@@ -1328,7 +1391,7 @@ msgstr "Bekas"
 msgid "Contents of the file {}"
 msgstr "Kandungan fail {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr "Salin perkhidmatan analisis"
 msgid "Copy from"
 msgstr "Salin daripada"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Salin kepada baharu"
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "Negara"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Wujudkan Bahagian"
 
@@ -1422,7 +1489,7 @@ msgstr "Wujudkan Bahagian"
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr "Cipta Pengguna baharu"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr "{} bahagian dicipta: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Pencipta"
 
@@ -1473,7 +1540,7 @@ msgstr "Pencipta"
 msgid "Criteria"
 msgstr "Kriteria"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Mata wang"
 
@@ -1481,13 +1548,21 @@ msgstr "Mata wang"
 msgid "Current"
 msgstr "Semasa"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Tanda perpuluhan"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "DL"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1534,23 +1609,23 @@ msgstr "Tarikh Diubah"
 msgid "Date Opened"
 msgstr "Tarikh Dibuka"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Tarikh Diawet"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Tarikh Dicetak"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Tarikh Diterbit"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Tarikh Diterima"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Tarikh Didaftar"
 
@@ -1562,11 +1637,11 @@ msgstr "Tarikh Dimohon"
 msgid "Date Sample Received"
 msgstr "Tarikh Sampel Diterima"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Tarikh Disampel"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Tarikh Disahkan"
 
@@ -1608,7 +1683,7 @@ msgstr "Tarikh sijil penentukuran dikeluarkan"
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr "Tidak digunakan sehingga ujian penentukuran seterusnya"
 msgid "Deactivate"
 msgstr "Nyahaktif"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Tanda perpuluhan untuk digunakan dalam laporan bagi Klien ini."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr "Bekas Lalai"
 msgid "Default Department"
 msgstr "Jabatan Lalai"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Emel lalai untuk SK semua Sampel yang diterbitkan untuk klien ini"
 
@@ -1659,7 +1734,7 @@ msgstr "Alat Lalai"
 msgid "Default Method"
 msgstr "Kaedah Lalai"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Pengawetan Lalai"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Bilangan lalai untuk tambahan Sampel."
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Tanda perpuluhan lalai"
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr "Pelakat besar lalai"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Susun atur lalai dalam paparan helaian kerja"
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Jangkamasa lalai penahanan sampel"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Format tatatanda saintifik lalai untuk laporan"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Format tatatanda saintifik lalai untuk keputusan"
 
@@ -1744,7 +1819,7 @@ msgstr "Pelekat kecil lalai"
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Masa pusing balik lalai untuk analisis."
 
@@ -1753,7 +1828,7 @@ msgstr "Masa pusing balik lalai untuk analisis."
 msgid "Default value"
 msgstr "Nilai lalai"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6576,10 +6940,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,9 +7088,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ms_MY/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ms_MY/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Malay (Malaysia) (https://app.transifex.com/senaite/teams/87045/ms_MY/)\n"

--- a/src/senaite/core/locales/ms_MY/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ms_MY/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Malay (Malaysia) (https://app.transifex.com/senaite/teams/87045/ms_MY/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ms_MY/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ms_MY/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Malay (Malaysia) (https://app.transifex.com/senaite/teams/87045/ms_MY/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ms_MY\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ms_MY/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ms_MY/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Malay (Malaysia) (https://app.transifex.com/senaite/teams/87045/ms_MY/)\n"

--- a/src/senaite/core/locales/nl/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/nl/LC_MESSAGES/plone.po
@@ -18,320 +18,323 @@ msgstr ""
 
 #: senaite/core/browser/user/templates/account-panel.pt:16
 msgid "${action/title}"
-msgstr ""
+msgstr "${action/title}"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:167
 msgid "Activated add-ons"
-msgstr ""
+msgstr "Geactiveerde add-ons"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Alternative formats"
-msgstr ""
+msgstr "Alternatieve formaten"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:229
 msgid "Apply rule on the whole site"
-msgstr ""
+msgstr "Regel op de hele site toepassen"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:123
 msgid "Available add-ons"
-msgstr ""
+msgstr "Beschikbare add-ons"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:212
 msgid "Broken add-ons"
-msgstr ""
+msgstr "Defecte add-ons"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:256
 msgid "Configure rule"
-msgstr ""
+msgstr "Regel configureren"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:35
 msgid "Content rule settings updated."
-msgstr ""
+msgstr "Instellingen voor inhoudsregels bijgewerkt."
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:52
 msgid "Disable globally"
-msgstr ""
+msgstr "Globaal uitschakelen"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:314
 msgid "Enabled"
-msgstr ""
+msgstr "Ingeschakeld"
 
 #: senaite/core/browser/dexterity/templates/macros.pt:20
 #: senaite/core/browser/login/templates/login.pt:17
 msgid "Error"
-msgstr ""
+msgstr "Fout"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:78
 msgid "Filter:"
-msgstr ""
+msgstr "Filter:"
 
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:28
 msgid "Go to parent folder"
-msgstr ""
+msgstr "Ga naar bovenliggende map"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:222
 msgid "Go to the folder where you want the rule to apply, or at the site root, click on 'rule' tab, and then locally setup the rules."
-msgstr ""
+msgstr "Ga naar de map waar u de regel wilt toepassen, of klik in de siteroot op het tabblad 'regel' en stel de regels vervolgens lokaal in."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "Go to the upgrade page"
-msgstr ""
+msgstr "Ga naar de upgradepagina"
 
 #: senaite/core/browser/viewlets/templates/path_bar.pt:9
 msgid "Home"
-msgstr ""
+msgstr "Home"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:132
 msgid "Install"
-msgstr ""
+msgstr "Installeren"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Log in"
-msgstr ""
+msgstr "Inloggen"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Log out"
-msgstr ""
+msgstr "Uitloggen"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt:275
 msgid "More"
-msgstr ""
+msgstr "Meer"
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:79
 msgid "Move down"
-msgstr ""
+msgstr "Omlaag"
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:67
 msgid "Move up"
-msgstr ""
+msgstr "Omhoog"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:39
 msgid "No upgrades in this corner"
-msgstr ""
+msgstr "Geen upgrades in deze hoek"
 
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:56
 msgid "Note"
-msgstr ""
+msgstr "Opmerking"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:145
 msgid "Off"
-msgstr ""
+msgstr "Uit"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:144
 msgid "On"
-msgstr ""
+msgstr "Aan"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Relative URL for the SENAITE toolbar logo"
-msgstr ""
+msgstr "Relatieve URL voor het SENAITE-werkbalklogo"
 
 #: senaite/core/browser/sharing/templates/client_sharing.pt:67
 msgid "Search for user or group"
-msgstr ""
+msgstr "Zoeken naar gebruiker of groep"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Select which formats are available for users as alternative to the default format. Note that if new formats are installed, they will be enabled for text fields by default unless explicitly turned off here or by the relevant installer."
-msgstr ""
+msgstr "Selecteer welke formaten beschikbaar zijn voor gebruikers als alternatief voor het standaardformaat. Merk op dat wanneer nieuwe formaten worden geïnstalleerd, deze standaard worden ingeschakeld voor tekstvelden, tenzij ze hier of door de betreffende installer expliciet zijn uitgeschakeld."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:148
 msgid "Server:"
-msgstr ""
+msgstr "Server:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:15
 #: senaite/core/browser/controlpanel/templates/overview.pt:16
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:13
 msgid "Site Setup"
-msgstr ""
+msgstr "Site-instellingen"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Site title"
-msgstr ""
+msgstr "Sitetitel"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:218
 msgid "The rule is enabled but will perform nothing since it is not assigned anywhere."
-msgstr ""
+msgstr "De regel is ingeschakeld maar zal niets doen omdat deze nergens is toegewezen."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "The site configuration is outdated and needs to be upgraded. Please ${link_continue_with_the_upgrade}."
-msgstr ""
+msgstr "De siteconfiguratie is verouderd en moet worden geüpgraded. Gelieve ${link_continue_with_the_upgrade}."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:87
 msgid "There is no upgrade procedure defined for this addon. Please consult the addon documentation for upgrade information, or contact the addon author."
-msgstr ""
+msgstr "Er is geen upgradeprocedure gedefinieerd voor deze add-on. Raadpleeg de add-ondocumentatie voor upgrade-informatie of neem contact op met de auteur van de add-on."
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:124
 msgid "There is not any action performed by this rule. Click on Add button to setup an action."
-msgstr ""
+msgstr "Deze regel voert geen enkele actie uit. Klik op de knop Toevoegen om een actie in te stellen."
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:39
 msgid "There is not any additional condition checked on this rule."
-msgstr ""
+msgstr "Er wordt geen enkele aanvullende voorwaarde gecontroleerd voor deze regel."
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:32
 msgid "There was an error saving content rules."
-msgstr ""
+msgstr "Er is een fout opgetreden bij het opslaan van inhoudsregels."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:69
 msgid "This addon has been upgraded."
-msgstr ""
+msgstr "Deze add-on is geüpgraded."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:23
 msgid "This is the Add-on configuration section, you can activate and deactivate add-ons in the lists below."
-msgstr ""
+msgstr "Dit is het configuratiegedeelte voor add-ons; u kunt add-ons activeren en deactiveren in de onderstaande lijsten."
 
 #: senaite/core/profiles/default/registry.xml
 msgid "This must be a URL relative to the site root."
-msgstr ""
+msgstr "Dit moet een URL zijn die relatief is aan de siteroot."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:154
 msgid "This product cannot be uninstalled!"
-msgstr ""
+msgstr "Dit product kan niet worden verwijderd!"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:215
 msgid "This rule is not assigned to any location"
-msgstr ""
+msgstr "Deze regel is aan geen enkele locatie toegewezen"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "This shows up in the title bar of browsers and in syndication feeds."
-msgstr ""
+msgstr "Dit verschijnt in de titelbalk van browsers en in syndicatiefeeds."
 
 #: senaite/core/browser/portlets/templates/navigation.pt:5
 msgid "Toggle sidebar visibility"
-msgstr ""
+msgstr "Zichtbaarheid van zijbalk in-/uitschakelen"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:176
 msgid "Uninstall"
-msgstr ""
+msgstr "Verwijderen"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:105
 msgid "Upgrade them ALL!"
-msgstr ""
+msgstr "Upgrade ze ALLEMAAL!"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:36
 msgid "Upgrades"
-msgstr ""
+msgstr "Upgrades"
 
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:32
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:28
 msgid "Users and Groups"
-msgstr ""
+msgstr "Gebruikers en groepen"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:143
 msgid "WSGI:"
-msgstr ""
+msgstr "WSGI:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:53
 msgid "Whether or not content rules should be disabled globally. If this is selected, no rules will be executed anywhere in the portal."
-msgstr ""
+msgstr "Of inhoudsregels globaal moeten worden uitgeschakeld. Als dit is geselecteerd, worden er nergens in het portaal regels uitgevoerd."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:40
 msgid "You are up to date. High fives."
-msgstr ""
+msgstr "U bent helemaal bij. Gefeliciteerd."
 
 #. convert them to new-style portlets."
 #. Default: "There are legacy portlets defined here. Click the button to convert them to new-style portlets."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:69
+#, fuzzy
 msgid "action_convert_legacy_portlets"
-msgstr ""
+msgstr "Er zijn hier verouderde portlets gedefinieerd. Klik op de knop om ze te converteren naar portlets in de nieuwe stijl."
 
 #. Default: "Next ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:85
 msgid "batch_next_x_items"
-msgstr ""
+msgstr "Volgende ${number} items"
 
 #. Default: "Previous ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:19
 msgid "batch_previous_x_items"
-msgstr ""
+msgstr "Vorige ${number} items"
 
 #. Default: "Add action"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:183
 msgid "contentrules_add_action"
-msgstr ""
+msgstr "Actie toevoegen"
 
 #. Default: "Add condition"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:91
 msgid "contentrules_add_condition"
-msgstr ""
+msgstr "Voorwaarde toevoegen"
 
 #. Default: "Shortcuts:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:228
 msgid "contentrules_assignments_shortcuts"
-msgstr ""
+msgstr "Snelkoppelingen:"
 
 #. Default: "The actions executed by this rule can trigger other rules"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:305
 msgid "contentrules_description_cascading"
-msgstr ""
+msgstr "De acties die door deze regel worden uitgevoerd, kunnen andere regels triggeren"
 
 #. Default: "Enter a short description of the rule and its purpose."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:278
 msgid "contentrules_description_description"
-msgstr ""
+msgstr "Voer een korte beschrijving in van de regel en het doel ervan."
 
 #. only be invoked if all the rule's conditions are met. You can add new
 #. actions and conditions using the buttons below."
 #. Default: "Rules execute when a triggering event occurs. Rule actions will only be invoked if all the rule's conditions are met. You can add new actions and conditions using the buttons below."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:23
+#, fuzzy
 msgid "contentrules_description_execution"
-msgstr ""
+msgstr "Regels worden uitgevoerd wanneer een triggerende gebeurtenis plaatsvindt. Regelacties worden alleen aangeroepen als aan alle voorwaarden van de regel is voldaan. U kunt nieuwe acties en voorwaarden toevoegen met de onderstaande knoppen."
 
 #. Default: "Stop evaluating content rules after this rule completes"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:296
 msgid "contentrules_description_stop"
-msgstr ""
+msgstr "Stop met het evalueren van inhoudsregels nadat deze regel is voltooid"
 
 #. Default: "The rule will execute when the following event occurs."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:287
 msgid "contentrules_description_trigger"
-msgstr ""
+msgstr "De regel wordt uitgevoerd wanneer de volgende gebeurtenis plaatsvindt."
 
 #. Default: "Perform the following actions:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:117
 msgid "contentrules_perform_actions"
-msgstr ""
+msgstr "Voer de volgende acties uit:"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "continue with the upgrade"
-msgstr ""
+msgstr "doorgaan met de upgrade"
 
 #. Default: "There is no group or user attached to this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:171
 msgid "decription_no_members_assigned"
-msgstr ""
+msgstr "Er is geen groep of gebruiker aan deze groep gekoppeld."
 
 #. Rules will automatically perform actions on content when certain triggers
 #. take place. After defining rules, you may want to go to a folder to assign
 #. them, using the \"rules\" item in the actions menu."
 #. Default: "Use the form below to define, change or remove content rules. Rules will automatically perform actions on content when certain triggers take place. After defining rules, you may want to go to a folder to assign them, using the \"rules\" item in the actions menu."
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:24
+#, fuzzy
 msgid "description-contentrules-controlpanel"
-msgstr ""
+msgstr "Gebruik het onderstaande formulier om inhoudsregels te definiëren, wijzigen of verwijderen. Regels voeren automatisch acties uit op inhoud wanneer bepaalde triggers plaatsvinden. Na het definiëren van regels wilt u mogelijk naar een map gaan om ze toe te wijzen via het item \"regels\" in het actiemenu."
 
 #. Default: "The languages in which the site should be translatable."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_available_languages"
-msgstr ""
+msgstr "De talen waarin de site vertaalbaar moet zijn."
 
 #. Default: "Please set a descriptive title for the rule."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:266
 msgid "description_contentrule_title"
-msgstr ""
+msgstr "Stel een beschrijvende titel in voor de regel."
 
 #. Default: "This rule is assigned to the following locations:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:242
 msgid "description_contentrules_rule_assignments"
-msgstr ""
+msgstr "Deze regel is toegewezen aan de volgende locaties:"
 
 #. Default: "Configuration area for Plone and add-on Products."
 #: senaite/core/browser/controlpanel/templates/overview.pt:19
 msgid "description_control_panel"
-msgstr ""
+msgstr "Configuratiegebied voor Plone en add-onproducten."
 
 #. Default: "Required for the language selector viewlet to be rendered."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_cookie_manual_override"
-msgstr ""
+msgstr "Vereist opdat de viewlet voor taalselectie wordt weergegeven."
 
 #. sites that are under development. This allows many configuration changes to
 #. be immediately visible, but will make your site run more slowly. To turn
@@ -339,65 +342,73 @@ msgstr ""
 #. re-run bin/buildout and then restart the server process."
 #. Default: "You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:167
+#, fuzzy
 msgid "description_debug_mode"
-msgstr ""
+msgstr "U draait in \"debugmodus\". Deze modus is bedoeld voor sites die in ontwikkeling zijn. Hierdoor zijn veel configuratiewijzigingen onmiddellijk zichtbaar, maar uw site zal langzamer draaien. Om de debugmodus uit te schakelen, stopt u de server, stelt u 'debug-mode=off' in uw buildout.cfg in, voert u bin/buildout opnieuw uit en start u vervolgens het serverproces opnieuw."
 
 #. here. Note that this doesn't actually delete the group or user, it is only
 #. removed from this group."
 #. Default: "You can add or remove groups and users from this particular group here. Note that this doesn't actually delete the group or user, it is only removed from this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:78
+#, fuzzy
 msgid "description_group_members_of"
-msgstr ""
+msgstr "U kunt hier groepen en gebruikers toevoegen aan of verwijderen uit deze specifieke groep. Merk op dat dit de groep of gebruiker niet daadwerkelijk verwijdert; deze wordt alleen uit deze groep verwijderd."
 
 #. business units. Groups are not directly related to permissions on a global
 #. level, you normally use Roles for that - and let certain Groups have a
 #. particular role."
 #. Default: "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:55
+#, fuzzy
 msgid "description_groups_management"
-msgstr ""
+msgstr "Groepen zijn logische verzamelingen van gebruikers, zoals afdelingen en bedrijfsonderdelen. Groepen zijn niet direct gerelateerd aan machtigingen op globaal niveau; daarvoor gebruikt u normaal gesproken rollen, en laat u bepaalde groepen een specifieke rol hebben."
 
 #. membership in another group."
 #. Default: "The symbol ${image_link_icon} indicates a role inherited from membership in another group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:66
+#, fuzzy
 msgid "description_groups_management2"
-msgstr ""
+msgstr "Het symbool ${image_link_icon} geeft een rol aan die is overgeërfd van het lidmaatschap van een andere groep."
 
 #. assigned in this context. Use the buttons on each portlet to move them up
 #. or down, delete or edit them. To add a new portlet, use the drop-down list
 #. at the top of the column."
 #. Default: "The portlet columns will first display portlets explicitly assigned in this context. Use the buttons on each portlet to move them up or down, delete or edit them. To add a new portlet, use the drop-down list at the top of the column."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:52
+#, fuzzy
 msgid "description_manage_contextual_portlets"
-msgstr ""
+msgstr "De portletkolommen tonen eerst de portlets die expliciet in deze context zijn toegewezen. Gebruik de knoppen op elke portlet om ze omhoog of omlaag te verplaatsen, te verwijderen of te bewerken. Gebruik de vervolgkeuzelijst bovenaan de kolom om een nieuwe portlet toe te voegen."
 
 #. listing of groups, so you may not see the groups defined by those plugins
 #. unless doing a specific search."
 #. Default: "Note: Some or all of your PAS groups source plugins do not allow listing of groups, so you may not see the groups defined by those plugins unless doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:72
+#, fuzzy
 msgid "description_pas_group_listing"
-msgstr ""
+msgstr "Opmerking: Sommige of al uw PAS-groepbronplugins staan het weergeven van groepen niet toe, dus mogelijk ziet u de door die plugins gedefinieerde groepen niet, tenzij u een specifieke zoekopdracht uitvoert."
 
 #. Default: "Show all search results"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:332
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:250
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:189
 msgid "description_pas_show_all_search_results"
-msgstr ""
+msgstr "Alle zoekresultaten weergeven"
 
 #. of users, so you may not see the users defined by those plugins unless
 #. doing a specific search."
 #. Default: "Some or all of your PAS user source plugins do not allow listing of users, so you may not see the users defined by those plugins unless doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:57
+#, fuzzy
 msgid "description_pas_users_listing"
-msgstr ""
+msgstr "Sommige of al uw PAS-gebruikerbronplugins staan het weergeven van gebruikers niet toe, dus mogelijk ziet u de door die plugins gedefinieerde gebruikers niet, tenzij u een specifieke zoekopdracht uitvoert."
 
 #. you can do so using the drop-down boxes. Portlets that are included by
 #. these categories are shown below the selection box."
 #. Default: "If you wish to block or unblock certain categories of portlets, you can do so using the drop-down boxes. Portlets that are included by these categories are shown below the selection box."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:59
+#, fuzzy
 msgid "description_portlets_block_unblock"
-msgstr ""
+msgstr "Als u bepaalde categorieën portlets wilt blokkeren of deblokkeren, kunt u dat doen met de vervolgkeuzelijsten. Portlets die door deze categorieën worden opgenomen, worden onder het keuzevak weergegeven."
 
 #. mode of operation for a live Plone site, but means that some configuration
 #. changes will not take effect until your server is restarted or a product
@@ -406,8 +417,9 @@ msgstr ""
 #. bin/buildout and then restart the server process."
 #. Default: "You are running in \"production mode\". This is the preferred mode of operation for a live Plone site, but means that some configuration changes will not take effect until your server is restarted or a product refreshed. If this is a development instance, and you want to enable debug mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:155
+#, fuzzy
 msgid "description_production_mode"
-msgstr ""
+msgstr "U draait in \"productiemodus\". Dit is de voorkeursmodus voor een actieve Plone-site, maar betekent dat sommige configuratiewijzigingen pas van kracht worden nadat uw server opnieuw is opgestart of een product is vernieuwd. Als dit een ontwikkelinstantie is en u de debugmodus wilt inschakelen, stopt u de server, stelt u 'debug-mode=on' in uw buildout.cfg in, voert u bin/buildout opnieuw uit en start u vervolgens het serverproces opnieuw."
 
 #. Access should be granted only to the client group below. <br /> Client
 #. contacts which are linked to a user account will be automatically added to
@@ -416,126 +428,130 @@ msgstr ""
 #. contents. </div>"
 #. Default: "Grant access for users or groups <div class=\"font-italic\"> Access should be granted only to the client group below. <br /> Client contacts which are linked to a user account will be automatically added to this group and have therefore the same roles granted immediately. <br /> Other granted access to users or groups will only affect new created contents. </div>"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:43
+#, fuzzy
 msgid "description_sharing_control"
-msgstr ""
+msgstr "Verleen toegang voor gebruikers of groepen <div class=\"font-italic\"> Toegang mag alleen worden verleend aan de onderstaande clientgroep. <br /> Clientcontactpersonen die aan een gebruikersaccount zijn gekoppeld, worden automatisch aan deze groep toegevoegd en krijgen daardoor onmiddellijk dezelfde rollen. <br /> Andere verleende toegang aan gebruikers of groepen heeft alleen invloed op nieuw aangemaakte inhoud. </div>"
 
 #. log in."
 #. Default: "Cookies are not enabled. You must enable cookies before you can log in."
 #: senaite/core/browser/login/templates/login.pt:20
+#, fuzzy
 msgid "enable_cookies_message_before_login"
-msgstr ""
+msgstr "Cookies zijn niet ingeschakeld. U moet cookies inschakelen voordat u kunt inloggen."
 
 #. Default: "File already uploaded:"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_input.pt:19
 msgid "file_already_uploaded"
-msgstr ""
+msgstr "Bestand al geüpload:"
 
 #. Default: "Get help"
 #: senaite/core/browser/login/templates/login.pt:105
 msgid "footer_login_link_get_help"
-msgstr ""
+msgstr "Hulp krijgen"
 
 #. Default: "Sign up here"
 #: senaite/core/browser/login/templates/login.pt:110
 msgid "footer_login_link_signup"
-msgstr ""
+msgstr "Meld u hier aan"
 
 #. Default: "Up to rule management"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:16
 msgid "go_to_contentrules_management"
-msgstr ""
+msgstr "Naar regelbeheer"
 
 #. Default: "Add ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:24
 msgid "heading_add_item"
-msgstr ""
+msgstr "${itemtype} toevoegen"
 
 #. Default: "Assign to groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:111
 msgid "heading_assign_to_groups"
-msgstr ""
+msgstr "Aan groepen toewijzen"
 
 #. Default: "Available languages"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_available_languages"
-msgstr ""
+msgstr "Beschikbare talen"
 
 #. Default: "Use cookie for manual override"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_cookie_manual_override"
-msgstr ""
+msgstr "Cookie gebruiken voor handmatige overschrijving"
 
 #. Default: "Create a Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:22
 msgid "heading_create_group"
-msgstr ""
+msgstr "Een groep aanmaken"
 
 #. Default: "Manage access for ${folder}"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:37
 msgid "heading_currently_assigned_shares"
-msgstr ""
+msgstr "Toegang beheren voor ${folder}"
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:58
 msgid "heading_edit_groupproperties"
-msgstr ""
+msgstr "Groep: ${groupname}"
 
 #. Default: "Edit ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:34
 msgid "heading_edit_item"
-msgstr ""
+msgstr "${itemtype} bewerken"
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:27
 msgid "heading_group_members"
-msgstr ""
+msgstr "Groepsleden"
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:55
 msgid "heading_group_members_of"
-msgstr ""
+msgstr "Groep: ${groupname}"
 
 #. Default: "Current group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:91
 msgid "heading_groupmembers_current"
-msgstr ""
+msgstr "Huidige groepsleden"
 
 #. Default: "Current group memberships"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:70
 msgid "heading_memberships_current"
-msgstr ""
+msgstr "Huidige groepslidmaatschappen"
 
 #. Default: "Portlets assigned here"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:40
 msgid "heading_portlets_assigned_here"
-msgstr ""
+msgstr "Hier toegewezen portlets"
 
 #. Default: "Search for groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:110
 msgid "heading_search_groups"
-msgstr ""
+msgstr "Zoeken naar groepen"
 
 #. Default: "Search for new group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:184
 msgid "heading_search_newmembers"
-msgstr ""
+msgstr "Zoeken naar nieuwe groepsleden"
 
 #. Default: "Version Overview"
 #: senaite/core/browser/controlpanel/templates/overview.pt:135
 msgid "heading_version_overview"
-msgstr ""
+msgstr "Versieoverzicht"
 
 #. and type the document as you usually do."
 #. Default: "If you are unsure of which format to use, just select Plain Text and type the document as you usually do."
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:52
+#, fuzzy
 msgid "help_format_wysiwyg"
-msgstr ""
+msgstr "Als u niet zeker weet welk formaat u moet gebruiken, selecteer dan gewoon Platte tekst en typ het document zoals u dat gewoonlijk doet."
 
 #. creation."
 #. Default: "A unique identifier for the group. Can not be changed after creation."
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:34
+#, fuzzy
 msgid "help_groupname"
-msgstr ""
+msgstr "Een unieke identificatie voor de groep. Kan na aanmaken niet meer worden gewijzigd."
 
 #. inherited. If you disable this, only the explicitly defined sharing
 #. permissions will be valid. In the overview, the symbol
@@ -544,499 +560,505 @@ msgstr ""
 #. administrator."
 #. Default: "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol ${image_confirm_icon} indicates an inherited value. Similarly, the symbol ${image_link_icon} indicates a global role, which is managed by the site administrator."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:191
+#, fuzzy
 msgid "help_inherit_local_roles"
-msgstr ""
+msgstr "Standaard worden machtigingen van de container van dit item overgeërfd. Als u dit uitschakelt, zijn alleen de expliciet gedefinieerde deelmachtigingen geldig. In het overzicht geeft het symbool ${image_confirm_icon} een overgeërfde waarde aan. Op vergelijkbare wijze geeft het symbool ${image_link_icon} een globale rol aan, die door de sitebeheerder wordt beheerd."
 
 #. Default: "go here"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
 msgid "help_sharing_go_here"
-msgstr ""
+msgstr "ga hierheen"
 
 #. container. To adjust them for the entire container, ${go_here}."
 #. Default: "You are adjusting the sharing privileges for a default view in a container. To adjust them for the entire container, ${go_here}."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
+#, fuzzy
 msgid "help_sharing_page_default_page"
-msgstr ""
+msgstr "U past de deelrechten aan voor een standaardweergave in een container. Om ze aan te passen voor de hele container, ${go_here}."
 
 #. Default: "HTML"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:73
 msgid "html"
-msgstr ""
+msgstr "HTML"
 
 #. Default: "If all of the following conditions are met:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:31
 msgid "if_all_conditions_met"
-msgstr ""
+msgstr "Als aan alle volgende voorwaarden is voldaan:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:148
 msgid "inactive"
-msgstr ""
+msgstr "inactief"
 
 #. Default: "Add"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:105
 msgid "label_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Add New Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:83
 msgid "label_add_new_group"
-msgstr ""
+msgstr "Nieuwe groep toevoegen"
 
 #. Default: "Add New User"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:66
 msgid "label_add_new_user"
-msgstr ""
+msgstr "Nieuwe gebruiker toevoegen"
 
 #. Default: "Add portlet"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:10
 msgid "label_add_portlet"
-msgstr ""
+msgstr "Portlet toevoegen"
 
 #. Default: "Add portlet…"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:17
 msgid "label_add_portlet_ellipsis"
-msgstr ""
+msgstr "Portlet toevoegen…"
 
 #. Default: "Add user to selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:204
 msgid "label_add_user_to_group"
-msgstr ""
+msgstr "Gebruiker toevoegen aan geselecteerde groepen"
 
 #. Default: "Add selected groups and users to this group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:339
 msgid "label_add_users_to_group"
-msgstr ""
+msgstr "Geselecteerde groepen en gebruikers aan deze groep toevoegen"
 
 #. Default: "Cancel"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:198
 #: senaite/core/skins/senaite_templates/edit_macros.pt:262
 msgid "label_cancel"
-msgstr ""
+msgstr "Annuleren"
 
 #. Default: "Add content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:189
 msgid "label_contentrule_add"
-msgstr ""
+msgstr "Inhoudsregel toevoegen"
 
 #. Default: "Assignments"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:209
 msgid "label_contentrules_rule_assignments"
-msgstr ""
+msgstr "Toewijzingen"
 
 #. Default: "enabled"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:114
 msgid "label_contentrules_rule_enabled"
-msgstr ""
+msgstr "ingeschakeld"
 
 #. Default: "event"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:113
 msgid "label_contentrules_rule_event"
-msgstr ""
+msgstr "gebeurtenis"
 
 #. Default: "content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:112
 msgid "label_contentrules_rule_listing"
-msgstr ""
+msgstr "inhoudsregel"
 
 #. Default: "Convert portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:77
 msgid "label_convert_portlets"
-msgstr ""
+msgstr "Portlets converteren"
 
 #. Default: "Delete"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:175
 msgid "label_delete"
-msgstr ""
+msgstr "Verwijderen"
 
 #. Default: "Description"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:272
 msgid "label_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Disable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:170
 msgid "label_disable"
-msgstr ""
+msgstr "Uitschakelen"
 
 #. Default: "Edit"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:52
 msgid "label_edit"
-msgstr ""
+msgstr "Bewerken"
 
 #. Default: "Enable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:165
 msgid "label_enable"
-msgstr ""
+msgstr "Inschakelen"
 
 #. Default: "Find a group here"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:37
 msgid "label_find_group"
-msgstr ""
+msgstr "Vind hier een groep"
 
 #. Default: "Format"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:50
 msgid "label_format"
-msgstr ""
+msgstr "Formaat"
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:69
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:67
 msgid "label_group_members"
-msgstr ""
+msgstr "Groepsleden"
 
 #. Default: "Group Memberships"
 #: senaite/core/browser/user/templates/account-configlet.pt:41
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:62
 msgid "label_group_memberships"
-msgstr ""
+msgstr "Groepslidmaatschappen"
 
 #. Default: "Group Properties"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:71
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:70
 msgid "label_group_properties"
-msgstr ""
+msgstr "Groepseigenschappen"
 
 #. Default: "Group Search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:106
 msgid "label_group_search"
-msgstr ""
+msgstr "Groepen zoeken"
 
 #. Default: "Groups"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:45
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:42
 msgid "label_groups"
-msgstr ""
+msgstr "Groepen"
 
 #. Default: "Hide"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:103
 msgid "label_hide_item"
-msgstr ""
+msgstr "Verbergen"
 
 #. Default: "Inherit permissions from higher levels"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:180
 msgid "label_inherit_local_roles"
-msgstr ""
+msgstr "Machtigingen van hogere niveaus overerven"
 
 #. If you wanted to manage the portlets of the container itself, ${go_here}."
 #. Default: "You are managing the portlets of the default view of a container. If you wanted to manage the portlets of the container itself, ${go_here}."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
+#, fuzzy
 msgid "label_manage_portlets_default_view_container"
-msgstr ""
+msgstr "U beheert de portlets van de standaardweergave van een container. Als u de portlets van de container zelf wilt beheren, ${go_here}."
 
 #. Default: "go here"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
 msgid "label_manage_portlets_default_view_container_go_here"
-msgstr ""
+msgstr "ga hierheen"
 
 #. Default: "Name"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:102
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:28
 msgid "label_name"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Next"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:247
 msgid "label_next"
-msgstr ""
+msgstr "Volgende"
 
 #. Default: "No group was specified."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:35
 msgid "label_no_group_specified"
-msgstr ""
+msgstr "Er is geen groep opgegeven."
 
 #. Default: "No preference panels available."
 #: senaite/core/browser/controlpanel/templates/overview.pt:123
 msgid "label_no_prefs_panels_available"
-msgstr ""
+msgstr "Geen voorkeurspanelen beschikbaar."
 
 #. Default: "Previous"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:239
 msgid "label_previous"
-msgstr ""
+msgstr "Vorige"
 
 #. Default: "This can be risky, are you sure you want to do this?"
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:104
 msgid "label_product_upgrade_all_action"
-msgstr ""
+msgstr "Dit kan riskant zijn, weet u zeker dat u dit wilt doen?"
 
 #. Default: "New profile version is ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:81
 msgid "label_product_upgrade_new_profile_version"
-msgstr ""
+msgstr "Nieuwe profielversie is ${version}."
 
 #. Default: "Old profile version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:78
 msgid "label_product_upgrade_old_profile_version"
-msgstr ""
+msgstr "Oude profielversie was ${version}."
 
 #. Default: "Old version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:74
 msgid "label_product_upgrade_old_version"
-msgstr ""
+msgstr "Oude versie was ${version}."
 
 #. Default: "Quick search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:200
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:120
 msgid "label_quick_search"
-msgstr ""
+msgstr "Snel zoeken"
 
 #. Default: "Remove"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:55
 msgid "label_remove"
-msgstr ""
+msgstr "Verwijderen"
 
 #. Default: "Remove from selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:103
 msgid "label_remove_selected_groups"
-msgstr ""
+msgstr "Verwijderen uit geselecteerde groepen"
 
 #. Default: "Remove selected groups / users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:175
 msgid "label_remove_selected_users"
-msgstr ""
+msgstr "Geselecteerde groepen / gebruikers verwijderen"
 
 #. Default: "(Required)"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:30
 msgid "label_required"
-msgstr ""
+msgstr "(Vereist)"
 
 #. Default: "Event trigger: ${trigger}"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:285
 msgid "label_rule_event_trigger"
-msgstr ""
+msgstr "Gebeurtenistrigger: ${trigger}"
 
 #. Default: "Search"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:78
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:214
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:120
 msgid "label_search"
-msgstr ""
+msgstr "Zoeken"
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:219
 msgid "label_search_large"
-msgstr ""
+msgstr "Alles weergeven"
 
 #. Default: "Show"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:91
 msgid "label_show_item"
-msgstr ""
+msgstr "Weergeven"
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:127
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:106
 msgid "label_showall"
-msgstr ""
+msgstr "Alles weergeven"
 
 #. Default: "Up to Groups Overview"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:49
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:18
 msgid "label_up_to_groups_overview"
-msgstr ""
+msgstr "Naar groepsoverzicht"
 
 #. Default: "Up to Users Overview"
 #: senaite/core/browser/user/templates/account-configlet.pt:13
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:36
 msgid "label_up_to_usersoverview"
-msgstr ""
+msgstr "Naar gebruikersoverzicht"
 
 #. Default: "User Search"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:85
 msgid "label_user_search"
-msgstr ""
+msgstr "Gebruikers zoeken"
 
 #. Default: "Users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:43
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:39
 msgid "label_users"
-msgstr ""
+msgstr "Gebruikers"
 
 #. Default: "Content rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:73
 msgid "legend-contentrules"
-msgstr ""
+msgstr "Inhoudsregels"
 
 #. Default: "E-mail Address"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:114
 msgid "listingheader_email_address"
-msgstr ""
+msgstr "E-mailadres"
 
 #. Default: "Group Name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:146
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:79
 msgid "listingheader_group_name"
-msgstr ""
+msgstr "Groepsnaam"
 
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:78
 msgid "listingheader_group_remove"
-msgstr ""
+msgstr "listingheader_group_remove"
 
 #. Default: "Group/User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:242
 msgid "listingheader_group_user_name"
-msgstr ""
+msgstr "Groeps-/gebruikersnaam"
 
 #. Default: "Remove"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:159
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:123
 msgid "listingheader_remove"
-msgstr ""
+msgstr "Verwijderen"
 
 #. Default: "Reset Password"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:122
 msgid "listingheader_reset_password"
-msgstr ""
+msgstr "Wachtwoord opnieuw instellen"
 
 #. Default: "User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:113
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:120
 msgid "listingheader_user_name"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 #. Default: "Need an account?"
 #: senaite/core/browser/login/templates/login.pt:109
 msgid "need_an_account"
-msgstr ""
+msgstr "Hebt u een account nodig?"
 
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
-msgstr ""
+msgstr "Geen bestand"
 
 #. Default: "No image"
 #: senaite/core/z3cform/widgets/namedimage/display.pt:17
 msgid "no_image"
-msgstr ""
+msgstr "Geen afbeelding"
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82
 msgid "plain_text"
-msgstr ""
+msgstr "Platte tekst"
 
 #. Default: "Return"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:22
 msgid "return_to_view"
-msgstr ""
+msgstr "Terug"
 
 #. Default: "Structured Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:64
 msgid "structured_text"
-msgstr ""
+msgstr "Gestructureerde tekst"
 
 #. Default: "Current sharing permissions"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:92
 msgid "summary_assigned_roles"
-msgstr ""
+msgstr "Huidige deelmachtigingen"
 
 #. Default: "Select roles for each group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:139
 msgid "summary_roles_for_groups"
-msgstr ""
+msgstr "Selecteer rollen voor elke groep"
 
 #. various features including contact forms, email notification and password
 #. reset will not work. Go to the ${label_mail_control_panel_link} to fix
 #. this."
 #. Default: "You have not configured a mail host or a site 'From' address, various features including contact forms, email notification and password reset will not work. Go to the ${label_mail_control_panel_link} to fix this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:53
+#, fuzzy
 msgid "text_no_mailhost_configured"
-msgstr ""
+msgstr "U hebt geen mailhost of een 'Van'-adres voor de site geconfigureerd; diverse functies waaronder contactformulieren, e-mailmeldingen en het opnieuw instellen van wachtwoorden zullen niet werken. Ga naar de ${label_mail_control_panel_link} om dit op te lossen."
 
 #. Default: "Mail control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:54
 msgid "text_no_mailhost_configured_control_panel_link"
-msgstr ""
+msgstr "Mailconfiguratiescherm"
 
 #. Default: "PIL is not installed properly, image scaling will not work."
 #: senaite/core/browser/controlpanel/templates/overview.pt:90
 msgid "text_no_pil_installed"
-msgstr ""
+msgstr "PIL is niet correct geïnstalleerd, het schalen van afbeeldingen zal niet werken."
 
 #. Default: "Enter a group or user name to search for or click 'Show All'."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:308
 msgid "text_no_searchstring"
-msgstr ""
+msgstr "Voer een groeps- of gebruikersnaam in om naar te zoeken of klik op 'Alles weergeven'."
 
 #. Default: "Enter a group or user name to search for."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:302
 msgid "text_no_searchstring_large"
-msgstr ""
+msgstr "Voer een groeps- of gebruikersnaam in om naar te zoeken."
 
 #. work properly for timezone aware date/time values. Go to the
 #. ${label_mail_event_settings_link} to fix this."
 #. Default: "You have not set the portal timezone. Date/Time handling will not work properly for timezone aware date/time values. Go to the ${label_mail_event_settings_link} to fix this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:74
+#, fuzzy
 msgid "text_no_timezone_configured"
-msgstr ""
+msgstr "U hebt de tijdzone van het portaal niet ingesteld. De verwerking van datum/tijd zal niet correct werken voor tijdzonebewuste datum-/tijdwaarden. Ga naar de ${label_mail_event_settings_link} om dit op te lossen."
 
 #. Default: "Date and Time Settings control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:75
 msgid "text_no_timezone_configured_control_panel_link"
-msgstr ""
+msgstr "Configuratiescherm voor datum- en tijdinstellingen"
 
 #. Default: "Enter a username to search for"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:195
 msgid "text_no_user_searchstring"
-msgstr ""
+msgstr "Voer een gebruikersnaam in om naar te zoeken"
 
 #. Default: "Enter a username to search for, or click 'Show All'"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:201
 msgid "text_no_user_searchstring_largesite"
-msgstr ""
+msgstr "Voer een gebruikersnaam in om naar te zoeken, of klik op 'Alles weergeven'"
 
 #. Default: "No matches"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:297
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:231
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:191
 msgid "text_nomatches"
-msgstr ""
+msgstr "Geen overeenkomsten"
 
 #. Default: "This user does not belong to any group."
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:102
 msgid "text_user_not_in_any_group"
-msgstr ""
+msgstr "Deze gebruiker behoort tot geen enkele groep."
 
 #. Default: "Edit content rule"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:13
 msgid "title_edit_contentrule"
-msgstr ""
+msgstr "Inhoudsregel bewerken"
 
 #. Default: "Legacy portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:67
 msgid "title_legacy_portlets"
-msgstr ""
+msgstr "Verouderde portlets"
 
 #. Default: "Content Rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:21
 msgid "title_manage_contentrules"
-msgstr ""
+msgstr "Inhoudsregels"
 
 #. Default: "Manage portlets for ${context_title}"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:14
 msgid "title_manage_contextual_portlets"
-msgstr ""
+msgstr "Portlets beheren voor ${context_title}"
 
 #. Default: "Personal Information"
 #: senaite/core/browser/user/templates/account-configlet.pt:33
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:58
 msgid "title_personal_information_form"
-msgstr ""
+msgstr "Persoonlijke informatie"
 
 #. Default: "Send a mail to this user"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:158
 msgid "title_send_mail_to_user"
-msgstr ""
+msgstr "Een e-mail sturen naar deze gebruiker"
 
 #. Default: "Trouble logging in?"
 #: senaite/core/browser/login/templates/login.pt:104
 msgid "trouble_logging_in"
-msgstr ""
+msgstr "Problemen met inloggen?"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:153
 msgid "unassigned"
-msgstr ""
+msgstr "niet toegewezen"
 
 #. ${image_link_icon} indicates a role inherited from membership in a group."
 #. Default: "Note that roles set here apply directly to a user. The symbol ${image_link_icon} indicates a role inherited from membership in a group."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:52
+#, fuzzy
 msgid "user_roles_note"
-msgstr ""
+msgstr "Merk op dat de hier ingestelde rollen direct van toepassing zijn op een gebruiker. Het symbool ${image_link_icon} geeft een rol aan die is overgeërfd van het lidmaatschap van een groep."

--- a/src/senaite/core/locales/nl/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/nl/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Dutch (https://app.transifex.com/senaite/teams/87045/nl/)\n"
@@ -18,323 +18,320 @@ msgstr ""
 
 #: senaite/core/browser/user/templates/account-panel.pt:16
 msgid "${action/title}"
-msgstr "${action/title}"
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:167
 msgid "Activated add-ons"
-msgstr "Geactiveerde add-ons"
+msgstr ""
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Alternative formats"
-msgstr "Alternatieve formaten"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:229
 msgid "Apply rule on the whole site"
-msgstr "Regel op de hele site toepassen"
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:123
 msgid "Available add-ons"
-msgstr "Beschikbare add-ons"
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:212
 msgid "Broken add-ons"
-msgstr "Defecte add-ons"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:256
 msgid "Configure rule"
-msgstr "Regel configureren"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:35
 msgid "Content rule settings updated."
-msgstr "Instellingen voor inhoudsregels bijgewerkt."
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:52
 msgid "Disable globally"
-msgstr "Globaal uitschakelen"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:314
 msgid "Enabled"
-msgstr "Ingeschakeld"
+msgstr ""
 
 #: senaite/core/browser/dexterity/templates/macros.pt:20
 #: senaite/core/browser/login/templates/login.pt:17
 msgid "Error"
-msgstr "Fout"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:78
 msgid "Filter:"
-msgstr "Filter:"
+msgstr ""
 
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:28
 msgid "Go to parent folder"
-msgstr "Ga naar bovenliggende map"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:222
 msgid "Go to the folder where you want the rule to apply, or at the site root, click on 'rule' tab, and then locally setup the rules."
-msgstr "Ga naar de map waar u de regel wilt toepassen, of klik in de siteroot op het tabblad 'regel' en stel de regels vervolgens lokaal in."
+msgstr ""
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "Go to the upgrade page"
-msgstr "Ga naar de upgradepagina"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/path_bar.pt:9
 msgid "Home"
-msgstr "Home"
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:132
 msgid "Install"
-msgstr "Installeren"
+msgstr ""
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Log in"
-msgstr "Inloggen"
+msgstr ""
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Log out"
-msgstr "Uitloggen"
+msgstr ""
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt:275
 msgid "More"
-msgstr "Meer"
+msgstr ""
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:79
 msgid "Move down"
-msgstr "Omlaag"
+msgstr ""
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:67
 msgid "Move up"
-msgstr "Omhoog"
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:39
 msgid "No upgrades in this corner"
-msgstr "Geen upgrades in deze hoek"
+msgstr ""
 
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:56
 msgid "Note"
-msgstr "Opmerking"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:145
 msgid "Off"
-msgstr "Uit"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:144
 msgid "On"
-msgstr "Aan"
+msgstr ""
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Relative URL for the SENAITE toolbar logo"
-msgstr "Relatieve URL voor het SENAITE-werkbalklogo"
+msgstr ""
 
 #: senaite/core/browser/sharing/templates/client_sharing.pt:67
 msgid "Search for user or group"
-msgstr "Zoeken naar gebruiker of groep"
+msgstr ""
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Select which formats are available for users as alternative to the default format. Note that if new formats are installed, they will be enabled for text fields by default unless explicitly turned off here or by the relevant installer."
-msgstr "Selecteer welke formaten beschikbaar zijn voor gebruikers als alternatief voor het standaardformaat. Merk op dat wanneer nieuwe formaten worden geïnstalleerd, deze standaard worden ingeschakeld voor tekstvelden, tenzij ze hier of door de betreffende installer expliciet zijn uitgeschakeld."
+msgstr ""
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:148
 msgid "Server:"
-msgstr "Server:"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:15
 #: senaite/core/browser/controlpanel/templates/overview.pt:16
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:13
 msgid "Site Setup"
-msgstr "Site-instellingen"
+msgstr ""
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Site title"
-msgstr "Sitetitel"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:218
 msgid "The rule is enabled but will perform nothing since it is not assigned anywhere."
-msgstr "De regel is ingeschakeld maar zal niets doen omdat deze nergens is toegewezen."
+msgstr ""
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "The site configuration is outdated and needs to be upgraded. Please ${link_continue_with_the_upgrade}."
-msgstr "De siteconfiguratie is verouderd en moet worden geüpgraded. Gelieve ${link_continue_with_the_upgrade}."
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:87
 msgid "There is no upgrade procedure defined for this addon. Please consult the addon documentation for upgrade information, or contact the addon author."
-msgstr "Er is geen upgradeprocedure gedefinieerd voor deze add-on. Raadpleeg de add-ondocumentatie voor upgrade-informatie of neem contact op met de auteur van de add-on."
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:124
 msgid "There is not any action performed by this rule. Click on Add button to setup an action."
-msgstr "Deze regel voert geen enkele actie uit. Klik op de knop Toevoegen om een actie in te stellen."
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:39
 msgid "There is not any additional condition checked on this rule."
-msgstr "Er wordt geen enkele aanvullende voorwaarde gecontroleerd voor deze regel."
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:32
 msgid "There was an error saving content rules."
-msgstr "Er is een fout opgetreden bij het opslaan van inhoudsregels."
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:69
 msgid "This addon has been upgraded."
-msgstr "Deze add-on is geüpgraded."
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:23
 msgid "This is the Add-on configuration section, you can activate and deactivate add-ons in the lists below."
-msgstr "Dit is het configuratiegedeelte voor add-ons; u kunt add-ons activeren en deactiveren in de onderstaande lijsten."
+msgstr ""
 
 #: senaite/core/profiles/default/registry.xml
 msgid "This must be a URL relative to the site root."
-msgstr "Dit moet een URL zijn die relatief is aan de siteroot."
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:154
 msgid "This product cannot be uninstalled!"
-msgstr "Dit product kan niet worden verwijderd!"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:215
 msgid "This rule is not assigned to any location"
-msgstr "Deze regel is aan geen enkele locatie toegewezen"
+msgstr ""
 
 #: senaite/core/profiles/default/registry.xml
 msgid "This shows up in the title bar of browsers and in syndication feeds."
-msgstr "Dit verschijnt in de titelbalk van browsers en in syndicatiefeeds."
+msgstr ""
 
 #: senaite/core/browser/portlets/templates/navigation.pt:5
 msgid "Toggle sidebar visibility"
-msgstr "Zichtbaarheid van zijbalk in-/uitschakelen"
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:176
 msgid "Uninstall"
-msgstr "Verwijderen"
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:105
 msgid "Upgrade them ALL!"
-msgstr "Upgrade ze ALLEMAAL!"
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:36
 msgid "Upgrades"
-msgstr "Upgrades"
+msgstr ""
 
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:32
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:28
 msgid "Users and Groups"
-msgstr "Gebruikers en groepen"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:143
 msgid "WSGI:"
-msgstr "WSGI:"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:53
 msgid "Whether or not content rules should be disabled globally. If this is selected, no rules will be executed anywhere in the portal."
-msgstr "Of inhoudsregels globaal moeten worden uitgeschakeld. Als dit is geselecteerd, worden er nergens in het portaal regels uitgevoerd."
+msgstr ""
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:40
 msgid "You are up to date. High fives."
-msgstr "U bent helemaal bij. Gefeliciteerd."
+msgstr ""
 
 #. convert them to new-style portlets."
 #. Default: "There are legacy portlets defined here. Click the button to convert them to new-style portlets."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:69
-#, fuzzy
 msgid "action_convert_legacy_portlets"
-msgstr "Er zijn hier verouderde portlets gedefinieerd. Klik op de knop om ze te converteren naar portlets in de nieuwe stijl."
+msgstr ""
 
 #. Default: "Next ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:85
 msgid "batch_next_x_items"
-msgstr "Volgende ${number} items"
+msgstr ""
 
 #. Default: "Previous ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:19
 msgid "batch_previous_x_items"
-msgstr "Vorige ${number} items"
+msgstr ""
 
 #. Default: "Add action"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:183
 msgid "contentrules_add_action"
-msgstr "Actie toevoegen"
+msgstr ""
 
 #. Default: "Add condition"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:91
 msgid "contentrules_add_condition"
-msgstr "Voorwaarde toevoegen"
+msgstr ""
 
 #. Default: "Shortcuts:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:228
 msgid "contentrules_assignments_shortcuts"
-msgstr "Snelkoppelingen:"
+msgstr ""
 
 #. Default: "The actions executed by this rule can trigger other rules"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:305
 msgid "contentrules_description_cascading"
-msgstr "De acties die door deze regel worden uitgevoerd, kunnen andere regels triggeren"
+msgstr ""
 
 #. Default: "Enter a short description of the rule and its purpose."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:278
 msgid "contentrules_description_description"
-msgstr "Voer een korte beschrijving in van de regel en het doel ervan."
+msgstr ""
 
 #. only be invoked if all the rule's conditions are met. You can add new
 #. actions and conditions using the buttons below."
 #. Default: "Rules execute when a triggering event occurs. Rule actions will only be invoked if all the rule's conditions are met. You can add new actions and conditions using the buttons below."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:23
-#, fuzzy
 msgid "contentrules_description_execution"
-msgstr "Regels worden uitgevoerd wanneer een triggerende gebeurtenis plaatsvindt. Regelacties worden alleen aangeroepen als aan alle voorwaarden van de regel is voldaan. U kunt nieuwe acties en voorwaarden toevoegen met de onderstaande knoppen."
+msgstr ""
 
 #. Default: "Stop evaluating content rules after this rule completes"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:296
 msgid "contentrules_description_stop"
-msgstr "Stop met het evalueren van inhoudsregels nadat deze regel is voltooid"
+msgstr ""
 
 #. Default: "The rule will execute when the following event occurs."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:287
 msgid "contentrules_description_trigger"
-msgstr "De regel wordt uitgevoerd wanneer de volgende gebeurtenis plaatsvindt."
+msgstr ""
 
 #. Default: "Perform the following actions:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:117
 msgid "contentrules_perform_actions"
-msgstr "Voer de volgende acties uit:"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "continue with the upgrade"
-msgstr "doorgaan met de upgrade"
+msgstr ""
 
 #. Default: "There is no group or user attached to this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:171
 msgid "decription_no_members_assigned"
-msgstr "Er is geen groep of gebruiker aan deze groep gekoppeld."
+msgstr ""
 
 #. Rules will automatically perform actions on content when certain triggers
 #. take place. After defining rules, you may want to go to a folder to assign
 #. them, using the \"rules\" item in the actions menu."
 #. Default: "Use the form below to define, change or remove content rules. Rules will automatically perform actions on content when certain triggers take place. After defining rules, you may want to go to a folder to assign them, using the \"rules\" item in the actions menu."
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:24
-#, fuzzy
 msgid "description-contentrules-controlpanel"
-msgstr "Gebruik het onderstaande formulier om inhoudsregels te definiëren, wijzigen of verwijderen. Regels voeren automatisch acties uit op inhoud wanneer bepaalde triggers plaatsvinden. Na het definiëren van regels wilt u mogelijk naar een map gaan om ze toe te wijzen via het item \"regels\" in het actiemenu."
+msgstr ""
 
 #. Default: "The languages in which the site should be translatable."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_available_languages"
-msgstr "De talen waarin de site vertaalbaar moet zijn."
+msgstr ""
 
 #. Default: "Please set a descriptive title for the rule."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:266
 msgid "description_contentrule_title"
-msgstr "Stel een beschrijvende titel in voor de regel."
+msgstr ""
 
 #. Default: "This rule is assigned to the following locations:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:242
 msgid "description_contentrules_rule_assignments"
-msgstr "Deze regel is toegewezen aan de volgende locaties:"
+msgstr ""
 
 #. Default: "Configuration area for Plone and add-on Products."
 #: senaite/core/browser/controlpanel/templates/overview.pt:19
 msgid "description_control_panel"
-msgstr "Configuratiegebied voor Plone en add-onproducten."
+msgstr ""
 
 #. Default: "Required for the language selector viewlet to be rendered."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_cookie_manual_override"
-msgstr "Vereist opdat de viewlet voor taalselectie wordt weergegeven."
+msgstr ""
 
 #. sites that are under development. This allows many configuration changes to
 #. be immediately visible, but will make your site run more slowly. To turn
@@ -342,73 +339,65 @@ msgstr "Vereist opdat de viewlet voor taalselectie wordt weergegeven."
 #. re-run bin/buildout and then restart the server process."
 #. Default: "You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:167
-#, fuzzy
 msgid "description_debug_mode"
-msgstr "U draait in \"debugmodus\". Deze modus is bedoeld voor sites die in ontwikkeling zijn. Hierdoor zijn veel configuratiewijzigingen onmiddellijk zichtbaar, maar uw site zal langzamer draaien. Om de debugmodus uit te schakelen, stopt u de server, stelt u 'debug-mode=off' in uw buildout.cfg in, voert u bin/buildout opnieuw uit en start u vervolgens het serverproces opnieuw."
+msgstr ""
 
 #. here. Note that this doesn't actually delete the group or user, it is only
 #. removed from this group."
 #. Default: "You can add or remove groups and users from this particular group here. Note that this doesn't actually delete the group or user, it is only removed from this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:78
-#, fuzzy
 msgid "description_group_members_of"
-msgstr "U kunt hier groepen en gebruikers toevoegen aan of verwijderen uit deze specifieke groep. Merk op dat dit de groep of gebruiker niet daadwerkelijk verwijdert; deze wordt alleen uit deze groep verwijderd."
+msgstr ""
 
 #. business units. Groups are not directly related to permissions on a global
 #. level, you normally use Roles for that - and let certain Groups have a
 #. particular role."
 #. Default: "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:55
-#, fuzzy
 msgid "description_groups_management"
-msgstr "Groepen zijn logische verzamelingen van gebruikers, zoals afdelingen en bedrijfsonderdelen. Groepen zijn niet direct gerelateerd aan machtigingen op globaal niveau; daarvoor gebruikt u normaal gesproken rollen, en laat u bepaalde groepen een specifieke rol hebben."
+msgstr ""
 
 #. membership in another group."
 #. Default: "The symbol ${image_link_icon} indicates a role inherited from membership in another group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:66
-#, fuzzy
 msgid "description_groups_management2"
-msgstr "Het symbool ${image_link_icon} geeft een rol aan die is overgeërfd van het lidmaatschap van een andere groep."
+msgstr ""
 
 #. assigned in this context. Use the buttons on each portlet to move them up
 #. or down, delete or edit them. To add a new portlet, use the drop-down list
 #. at the top of the column."
 #. Default: "The portlet columns will first display portlets explicitly assigned in this context. Use the buttons on each portlet to move them up or down, delete or edit them. To add a new portlet, use the drop-down list at the top of the column."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:52
-#, fuzzy
 msgid "description_manage_contextual_portlets"
-msgstr "De portletkolommen tonen eerst de portlets die expliciet in deze context zijn toegewezen. Gebruik de knoppen op elke portlet om ze omhoog of omlaag te verplaatsen, te verwijderen of te bewerken. Gebruik de vervolgkeuzelijst bovenaan de kolom om een nieuwe portlet toe te voegen."
+msgstr ""
 
 #. listing of groups, so you may not see the groups defined by those plugins
 #. unless doing a specific search."
 #. Default: "Note: Some or all of your PAS groups source plugins do not allow listing of groups, so you may not see the groups defined by those plugins unless doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:72
-#, fuzzy
 msgid "description_pas_group_listing"
-msgstr "Opmerking: Sommige of al uw PAS-groepbronplugins staan het weergeven van groepen niet toe, dus mogelijk ziet u de door die plugins gedefinieerde groepen niet, tenzij u een specifieke zoekopdracht uitvoert."
+msgstr ""
 
 #. Default: "Show all search results"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:332
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:250
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:189
 msgid "description_pas_show_all_search_results"
-msgstr "Alle zoekresultaten weergeven"
+msgstr ""
 
 #. of users, so you may not see the users defined by those plugins unless
 #. doing a specific search."
 #. Default: "Some or all of your PAS user source plugins do not allow listing of users, so you may not see the users defined by those plugins unless doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:57
-#, fuzzy
 msgid "description_pas_users_listing"
-msgstr "Sommige of al uw PAS-gebruikerbronplugins staan het weergeven van gebruikers niet toe, dus mogelijk ziet u de door die plugins gedefinieerde gebruikers niet, tenzij u een specifieke zoekopdracht uitvoert."
+msgstr ""
 
 #. you can do so using the drop-down boxes. Portlets that are included by
 #. these categories are shown below the selection box."
 #. Default: "If you wish to block or unblock certain categories of portlets, you can do so using the drop-down boxes. Portlets that are included by these categories are shown below the selection box."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:59
-#, fuzzy
 msgid "description_portlets_block_unblock"
-msgstr "Als u bepaalde categorieën portlets wilt blokkeren of deblokkeren, kunt u dat doen met de vervolgkeuzelijsten. Portlets die door deze categorieën worden opgenomen, worden onder het keuzevak weergegeven."
+msgstr ""
 
 #. mode of operation for a live Plone site, but means that some configuration
 #. changes will not take effect until your server is restarted or a product
@@ -417,9 +406,8 @@ msgstr "Als u bepaalde categorieën portlets wilt blokkeren of deblokkeren, kunt
 #. bin/buildout and then restart the server process."
 #. Default: "You are running in \"production mode\". This is the preferred mode of operation for a live Plone site, but means that some configuration changes will not take effect until your server is restarted or a product refreshed. If this is a development instance, and you want to enable debug mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:155
-#, fuzzy
 msgid "description_production_mode"
-msgstr "U draait in \"productiemodus\". Dit is de voorkeursmodus voor een actieve Plone-site, maar betekent dat sommige configuratiewijzigingen pas van kracht worden nadat uw server opnieuw is opgestart of een product is vernieuwd. Als dit een ontwikkelinstantie is en u de debugmodus wilt inschakelen, stopt u de server, stelt u 'debug-mode=on' in uw buildout.cfg in, voert u bin/buildout opnieuw uit en start u vervolgens het serverproces opnieuw."
+msgstr ""
 
 #. Access should be granted only to the client group below. <br /> Client
 #. contacts which are linked to a user account will be automatically added to
@@ -428,130 +416,126 @@ msgstr "U draait in \"productiemodus\". Dit is de voorkeursmodus voor een actiev
 #. contents. </div>"
 #. Default: "Grant access for users or groups <div class=\"font-italic\"> Access should be granted only to the client group below. <br /> Client contacts which are linked to a user account will be automatically added to this group and have therefore the same roles granted immediately. <br /> Other granted access to users or groups will only affect new created contents. </div>"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:43
-#, fuzzy
 msgid "description_sharing_control"
-msgstr "Verleen toegang voor gebruikers of groepen <div class=\"font-italic\"> Toegang mag alleen worden verleend aan de onderstaande clientgroep. <br /> Clientcontactpersonen die aan een gebruikersaccount zijn gekoppeld, worden automatisch aan deze groep toegevoegd en krijgen daardoor onmiddellijk dezelfde rollen. <br /> Andere verleende toegang aan gebruikers of groepen heeft alleen invloed op nieuw aangemaakte inhoud. </div>"
+msgstr ""
 
 #. log in."
 #. Default: "Cookies are not enabled. You must enable cookies before you can log in."
 #: senaite/core/browser/login/templates/login.pt:20
-#, fuzzy
 msgid "enable_cookies_message_before_login"
-msgstr "Cookies zijn niet ingeschakeld. U moet cookies inschakelen voordat u kunt inloggen."
+msgstr ""
 
 #. Default: "File already uploaded:"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_input.pt:19
 msgid "file_already_uploaded"
-msgstr "Bestand al geüpload:"
+msgstr ""
 
 #. Default: "Get help"
 #: senaite/core/browser/login/templates/login.pt:105
 msgid "footer_login_link_get_help"
-msgstr "Hulp krijgen"
+msgstr ""
 
 #. Default: "Sign up here"
 #: senaite/core/browser/login/templates/login.pt:110
 msgid "footer_login_link_signup"
-msgstr "Meld u hier aan"
+msgstr ""
 
 #. Default: "Up to rule management"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:16
 msgid "go_to_contentrules_management"
-msgstr "Naar regelbeheer"
+msgstr ""
 
 #. Default: "Add ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:24
 msgid "heading_add_item"
-msgstr "${itemtype} toevoegen"
+msgstr ""
 
 #. Default: "Assign to groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:111
 msgid "heading_assign_to_groups"
-msgstr "Aan groepen toewijzen"
+msgstr ""
 
 #. Default: "Available languages"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_available_languages"
-msgstr "Beschikbare talen"
+msgstr ""
 
 #. Default: "Use cookie for manual override"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_cookie_manual_override"
-msgstr "Cookie gebruiken voor handmatige overschrijving"
+msgstr ""
 
 #. Default: "Create a Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:22
 msgid "heading_create_group"
-msgstr "Een groep aanmaken"
+msgstr ""
 
 #. Default: "Manage access for ${folder}"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:37
 msgid "heading_currently_assigned_shares"
-msgstr "Toegang beheren voor ${folder}"
+msgstr ""
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:58
 msgid "heading_edit_groupproperties"
-msgstr "Groep: ${groupname}"
+msgstr ""
 
 #. Default: "Edit ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:34
 msgid "heading_edit_item"
-msgstr "${itemtype} bewerken"
+msgstr ""
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:27
 msgid "heading_group_members"
-msgstr "Groepsleden"
+msgstr ""
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:55
 msgid "heading_group_members_of"
-msgstr "Groep: ${groupname}"
+msgstr ""
 
 #. Default: "Current group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:91
 msgid "heading_groupmembers_current"
-msgstr "Huidige groepsleden"
+msgstr ""
 
 #. Default: "Current group memberships"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:70
 msgid "heading_memberships_current"
-msgstr "Huidige groepslidmaatschappen"
+msgstr ""
 
 #. Default: "Portlets assigned here"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:40
 msgid "heading_portlets_assigned_here"
-msgstr "Hier toegewezen portlets"
+msgstr ""
 
 #. Default: "Search for groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:110
 msgid "heading_search_groups"
-msgstr "Zoeken naar groepen"
+msgstr ""
 
 #. Default: "Search for new group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:184
 msgid "heading_search_newmembers"
-msgstr "Zoeken naar nieuwe groepsleden"
+msgstr ""
 
 #. Default: "Version Overview"
 #: senaite/core/browser/controlpanel/templates/overview.pt:135
 msgid "heading_version_overview"
-msgstr "Versieoverzicht"
+msgstr ""
 
 #. and type the document as you usually do."
 #. Default: "If you are unsure of which format to use, just select Plain Text and type the document as you usually do."
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:52
-#, fuzzy
 msgid "help_format_wysiwyg"
-msgstr "Als u niet zeker weet welk formaat u moet gebruiken, selecteer dan gewoon Platte tekst en typ het document zoals u dat gewoonlijk doet."
+msgstr ""
 
 #. creation."
 #. Default: "A unique identifier for the group. Can not be changed after creation."
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:34
-#, fuzzy
 msgid "help_groupname"
-msgstr "Een unieke identificatie voor de groep. Kan na aanmaken niet meer worden gewijzigd."
+msgstr ""
 
 #. inherited. If you disable this, only the explicitly defined sharing
 #. permissions will be valid. In the overview, the symbol
@@ -560,505 +544,499 @@ msgstr "Een unieke identificatie voor de groep. Kan na aanmaken niet meer worden
 #. administrator."
 #. Default: "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol ${image_confirm_icon} indicates an inherited value. Similarly, the symbol ${image_link_icon} indicates a global role, which is managed by the site administrator."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:191
-#, fuzzy
 msgid "help_inherit_local_roles"
-msgstr "Standaard worden machtigingen van de container van dit item overgeërfd. Als u dit uitschakelt, zijn alleen de expliciet gedefinieerde deelmachtigingen geldig. In het overzicht geeft het symbool ${image_confirm_icon} een overgeërfde waarde aan. Op vergelijkbare wijze geeft het symbool ${image_link_icon} een globale rol aan, die door de sitebeheerder wordt beheerd."
+msgstr ""
 
 #. Default: "go here"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
 msgid "help_sharing_go_here"
-msgstr "ga hierheen"
+msgstr ""
 
 #. container. To adjust them for the entire container, ${go_here}."
 #. Default: "You are adjusting the sharing privileges for a default view in a container. To adjust them for the entire container, ${go_here}."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
-#, fuzzy
 msgid "help_sharing_page_default_page"
-msgstr "U past de deelrechten aan voor een standaardweergave in een container. Om ze aan te passen voor de hele container, ${go_here}."
+msgstr ""
 
 #. Default: "HTML"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:73
 msgid "html"
-msgstr "HTML"
+msgstr ""
 
 #. Default: "If all of the following conditions are met:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:31
 msgid "if_all_conditions_met"
-msgstr "Als aan alle volgende voorwaarden is voldaan:"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:148
 msgid "inactive"
-msgstr "inactief"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:105
 msgid "label_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Add New Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:83
 msgid "label_add_new_group"
-msgstr "Nieuwe groep toevoegen"
+msgstr ""
 
 #. Default: "Add New User"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:66
 msgid "label_add_new_user"
-msgstr "Nieuwe gebruiker toevoegen"
+msgstr ""
 
 #. Default: "Add portlet"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:10
 msgid "label_add_portlet"
-msgstr "Portlet toevoegen"
+msgstr ""
 
 #. Default: "Add portlet…"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:17
 msgid "label_add_portlet_ellipsis"
-msgstr "Portlet toevoegen…"
+msgstr ""
 
 #. Default: "Add user to selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:204
 msgid "label_add_user_to_group"
-msgstr "Gebruiker toevoegen aan geselecteerde groepen"
+msgstr ""
 
 #. Default: "Add selected groups and users to this group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:339
 msgid "label_add_users_to_group"
-msgstr "Geselecteerde groepen en gebruikers aan deze groep toevoegen"
+msgstr ""
 
 #. Default: "Cancel"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:198
 #: senaite/core/skins/senaite_templates/edit_macros.pt:262
 msgid "label_cancel"
-msgstr "Annuleren"
+msgstr ""
 
 #. Default: "Add content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:189
 msgid "label_contentrule_add"
-msgstr "Inhoudsregel toevoegen"
+msgstr ""
 
 #. Default: "Assignments"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:209
 msgid "label_contentrules_rule_assignments"
-msgstr "Toewijzingen"
+msgstr ""
 
 #. Default: "enabled"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:114
 msgid "label_contentrules_rule_enabled"
-msgstr "ingeschakeld"
+msgstr ""
 
 #. Default: "event"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:113
 msgid "label_contentrules_rule_event"
-msgstr "gebeurtenis"
+msgstr ""
 
 #. Default: "content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:112
 msgid "label_contentrules_rule_listing"
-msgstr "inhoudsregel"
+msgstr ""
 
 #. Default: "Convert portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:77
 msgid "label_convert_portlets"
-msgstr "Portlets converteren"
+msgstr ""
 
 #. Default: "Delete"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:175
 msgid "label_delete"
-msgstr "Verwijderen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:272
 msgid "label_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Disable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:170
 msgid "label_disable"
-msgstr "Uitschakelen"
+msgstr ""
 
 #. Default: "Edit"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:52
 msgid "label_edit"
-msgstr "Bewerken"
+msgstr ""
 
 #. Default: "Enable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:165
 msgid "label_enable"
-msgstr "Inschakelen"
+msgstr ""
 
 #. Default: "Find a group here"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:37
 msgid "label_find_group"
-msgstr "Vind hier een groep"
+msgstr ""
 
 #. Default: "Format"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:50
 msgid "label_format"
-msgstr "Formaat"
+msgstr ""
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:69
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:67
 msgid "label_group_members"
-msgstr "Groepsleden"
+msgstr ""
 
 #. Default: "Group Memberships"
 #: senaite/core/browser/user/templates/account-configlet.pt:41
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:62
 msgid "label_group_memberships"
-msgstr "Groepslidmaatschappen"
+msgstr ""
 
 #. Default: "Group Properties"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:71
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:70
 msgid "label_group_properties"
-msgstr "Groepseigenschappen"
+msgstr ""
 
 #. Default: "Group Search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:106
 msgid "label_group_search"
-msgstr "Groepen zoeken"
+msgstr ""
 
 #. Default: "Groups"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:45
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:42
 msgid "label_groups"
-msgstr "Groepen"
+msgstr ""
 
 #. Default: "Hide"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:103
 msgid "label_hide_item"
-msgstr "Verbergen"
+msgstr ""
 
 #. Default: "Inherit permissions from higher levels"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:180
 msgid "label_inherit_local_roles"
-msgstr "Machtigingen van hogere niveaus overerven"
+msgstr ""
 
 #. If you wanted to manage the portlets of the container itself, ${go_here}."
 #. Default: "You are managing the portlets of the default view of a container. If you wanted to manage the portlets of the container itself, ${go_here}."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
-#, fuzzy
 msgid "label_manage_portlets_default_view_container"
-msgstr "U beheert de portlets van de standaardweergave van een container. Als u de portlets van de container zelf wilt beheren, ${go_here}."
+msgstr ""
 
 #. Default: "go here"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
 msgid "label_manage_portlets_default_view_container_go_here"
-msgstr "ga hierheen"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:102
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:28
 msgid "label_name"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Next"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:247
 msgid "label_next"
-msgstr "Volgende"
+msgstr ""
 
 #. Default: "No group was specified."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:35
 msgid "label_no_group_specified"
-msgstr "Er is geen groep opgegeven."
+msgstr ""
 
 #. Default: "No preference panels available."
 #: senaite/core/browser/controlpanel/templates/overview.pt:123
 msgid "label_no_prefs_panels_available"
-msgstr "Geen voorkeurspanelen beschikbaar."
+msgstr ""
 
 #. Default: "Previous"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:239
 msgid "label_previous"
-msgstr "Vorige"
+msgstr ""
 
 #. Default: "This can be risky, are you sure you want to do this?"
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:104
 msgid "label_product_upgrade_all_action"
-msgstr "Dit kan riskant zijn, weet u zeker dat u dit wilt doen?"
+msgstr ""
 
 #. Default: "New profile version is ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:81
 msgid "label_product_upgrade_new_profile_version"
-msgstr "Nieuwe profielversie is ${version}."
+msgstr ""
 
 #. Default: "Old profile version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:78
 msgid "label_product_upgrade_old_profile_version"
-msgstr "Oude profielversie was ${version}."
+msgstr ""
 
 #. Default: "Old version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:74
 msgid "label_product_upgrade_old_version"
-msgstr "Oude versie was ${version}."
+msgstr ""
 
 #. Default: "Quick search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:200
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:120
 msgid "label_quick_search"
-msgstr "Snel zoeken"
+msgstr ""
 
 #. Default: "Remove"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:55
 msgid "label_remove"
-msgstr "Verwijderen"
+msgstr ""
 
 #. Default: "Remove from selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:103
 msgid "label_remove_selected_groups"
-msgstr "Verwijderen uit geselecteerde groepen"
+msgstr ""
 
 #. Default: "Remove selected groups / users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:175
 msgid "label_remove_selected_users"
-msgstr "Geselecteerde groepen / gebruikers verwijderen"
+msgstr ""
 
 #. Default: "(Required)"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:30
 msgid "label_required"
-msgstr "(Vereist)"
+msgstr ""
 
 #. Default: "Event trigger: ${trigger}"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:285
 msgid "label_rule_event_trigger"
-msgstr "Gebeurtenistrigger: ${trigger}"
+msgstr ""
 
 #. Default: "Search"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:78
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:214
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:120
 msgid "label_search"
-msgstr "Zoeken"
+msgstr ""
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:219
 msgid "label_search_large"
-msgstr "Alles weergeven"
+msgstr ""
 
 #. Default: "Show"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:91
 msgid "label_show_item"
-msgstr "Weergeven"
+msgstr ""
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:127
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:106
 msgid "label_showall"
-msgstr "Alles weergeven"
+msgstr ""
 
 #. Default: "Up to Groups Overview"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:49
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:18
 msgid "label_up_to_groups_overview"
-msgstr "Naar groepsoverzicht"
+msgstr ""
 
 #. Default: "Up to Users Overview"
 #: senaite/core/browser/user/templates/account-configlet.pt:13
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:36
 msgid "label_up_to_usersoverview"
-msgstr "Naar gebruikersoverzicht"
+msgstr ""
 
 #. Default: "User Search"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:85
 msgid "label_user_search"
-msgstr "Gebruikers zoeken"
+msgstr ""
 
 #. Default: "Users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:43
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:39
 msgid "label_users"
-msgstr "Gebruikers"
+msgstr ""
 
 #. Default: "Content rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:73
 msgid "legend-contentrules"
-msgstr "Inhoudsregels"
+msgstr ""
 
 #. Default: "E-mail Address"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:114
 msgid "listingheader_email_address"
-msgstr "E-mailadres"
+msgstr ""
 
 #. Default: "Group Name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:146
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:79
 msgid "listingheader_group_name"
-msgstr "Groepsnaam"
+msgstr ""
 
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:78
 msgid "listingheader_group_remove"
-msgstr "listingheader_group_remove"
+msgstr ""
 
 #. Default: "Group/User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:242
 msgid "listingheader_group_user_name"
-msgstr "Groeps-/gebruikersnaam"
+msgstr ""
 
 #. Default: "Remove"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:159
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:123
 msgid "listingheader_remove"
-msgstr "Verwijderen"
+msgstr ""
 
 #. Default: "Reset Password"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:122
 msgid "listingheader_reset_password"
-msgstr "Wachtwoord opnieuw instellen"
+msgstr ""
 
 #. Default: "User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:113
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:120
 msgid "listingheader_user_name"
-msgstr "Gebruikersnaam"
+msgstr ""
 
 #. Default: "Need an account?"
 #: senaite/core/browser/login/templates/login.pt:109
 msgid "need_an_account"
-msgstr "Hebt u een account nodig?"
+msgstr ""
 
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
-msgstr "Geen bestand"
+msgstr ""
 
 #. Default: "No image"
 #: senaite/core/z3cform/widgets/namedimage/display.pt:17
 msgid "no_image"
-msgstr "Geen afbeelding"
+msgstr ""
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82
 msgid "plain_text"
-msgstr "Platte tekst"
+msgstr ""
 
 #. Default: "Return"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:22
 msgid "return_to_view"
-msgstr "Terug"
+msgstr ""
 
 #. Default: "Structured Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:64
 msgid "structured_text"
-msgstr "Gestructureerde tekst"
+msgstr ""
 
 #. Default: "Current sharing permissions"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:92
 msgid "summary_assigned_roles"
-msgstr "Huidige deelmachtigingen"
+msgstr ""
 
 #. Default: "Select roles for each group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:139
 msgid "summary_roles_for_groups"
-msgstr "Selecteer rollen voor elke groep"
+msgstr ""
 
 #. various features including contact forms, email notification and password
 #. reset will not work. Go to the ${label_mail_control_panel_link} to fix
 #. this."
 #. Default: "You have not configured a mail host or a site 'From' address, various features including contact forms, email notification and password reset will not work. Go to the ${label_mail_control_panel_link} to fix this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:53
-#, fuzzy
 msgid "text_no_mailhost_configured"
-msgstr "U hebt geen mailhost of een 'Van'-adres voor de site geconfigureerd; diverse functies waaronder contactformulieren, e-mailmeldingen en het opnieuw instellen van wachtwoorden zullen niet werken. Ga naar de ${label_mail_control_panel_link} om dit op te lossen."
+msgstr ""
 
 #. Default: "Mail control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:54
 msgid "text_no_mailhost_configured_control_panel_link"
-msgstr "Mailconfiguratiescherm"
+msgstr ""
 
 #. Default: "PIL is not installed properly, image scaling will not work."
 #: senaite/core/browser/controlpanel/templates/overview.pt:90
 msgid "text_no_pil_installed"
-msgstr "PIL is niet correct geïnstalleerd, het schalen van afbeeldingen zal niet werken."
+msgstr ""
 
 #. Default: "Enter a group or user name to search for or click 'Show All'."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:308
 msgid "text_no_searchstring"
-msgstr "Voer een groeps- of gebruikersnaam in om naar te zoeken of klik op 'Alles weergeven'."
+msgstr ""
 
 #. Default: "Enter a group or user name to search for."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:302
 msgid "text_no_searchstring_large"
-msgstr "Voer een groeps- of gebruikersnaam in om naar te zoeken."
+msgstr ""
 
 #. work properly for timezone aware date/time values. Go to the
 #. ${label_mail_event_settings_link} to fix this."
 #. Default: "You have not set the portal timezone. Date/Time handling will not work properly for timezone aware date/time values. Go to the ${label_mail_event_settings_link} to fix this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:74
-#, fuzzy
 msgid "text_no_timezone_configured"
-msgstr "U hebt de tijdzone van het portaal niet ingesteld. De verwerking van datum/tijd zal niet correct werken voor tijdzonebewuste datum-/tijdwaarden. Ga naar de ${label_mail_event_settings_link} om dit op te lossen."
+msgstr ""
 
 #. Default: "Date and Time Settings control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:75
 msgid "text_no_timezone_configured_control_panel_link"
-msgstr "Configuratiescherm voor datum- en tijdinstellingen"
+msgstr ""
 
 #. Default: "Enter a username to search for"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:195
 msgid "text_no_user_searchstring"
-msgstr "Voer een gebruikersnaam in om naar te zoeken"
+msgstr ""
 
 #. Default: "Enter a username to search for, or click 'Show All'"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:201
 msgid "text_no_user_searchstring_largesite"
-msgstr "Voer een gebruikersnaam in om naar te zoeken, of klik op 'Alles weergeven'"
+msgstr ""
 
 #. Default: "No matches"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:297
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:231
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:191
 msgid "text_nomatches"
-msgstr "Geen overeenkomsten"
+msgstr ""
 
 #. Default: "This user does not belong to any group."
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:102
 msgid "text_user_not_in_any_group"
-msgstr "Deze gebruiker behoort tot geen enkele groep."
+msgstr ""
 
 #. Default: "Edit content rule"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:13
 msgid "title_edit_contentrule"
-msgstr "Inhoudsregel bewerken"
+msgstr ""
 
 #. Default: "Legacy portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:67
 msgid "title_legacy_portlets"
-msgstr "Verouderde portlets"
+msgstr ""
 
 #. Default: "Content Rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:21
 msgid "title_manage_contentrules"
-msgstr "Inhoudsregels"
+msgstr ""
 
 #. Default: "Manage portlets for ${context_title}"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:14
 msgid "title_manage_contextual_portlets"
-msgstr "Portlets beheren voor ${context_title}"
+msgstr ""
 
 #. Default: "Personal Information"
 #: senaite/core/browser/user/templates/account-configlet.pt:33
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:58
 msgid "title_personal_information_form"
-msgstr "Persoonlijke informatie"
+msgstr ""
 
 #. Default: "Send a mail to this user"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:158
 msgid "title_send_mail_to_user"
-msgstr "Een e-mail sturen naar deze gebruiker"
+msgstr ""
 
 #. Default: "Trouble logging in?"
 #: senaite/core/browser/login/templates/login.pt:104
 msgid "trouble_logging_in"
-msgstr "Problemen met inloggen?"
+msgstr ""
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:153
 msgid "unassigned"
-msgstr "niet toegewezen"
+msgstr ""
 
 #. ${image_link_icon} indicates a role inherited from membership in a group."
 #. Default: "Note that roles set here apply directly to a user. The symbol ${image_link_icon} indicates a role inherited from membership in a group."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:52
-#, fuzzy
 msgid "user_roles_note"
-msgstr "Merk op dat de hier ingestelde rollen direct van toepassing zijn op een gebruiker. Het symbool ${image_link_icon} geeft een rol aan die is overgeërfd van het lidmaatschap van een groep."
+msgstr ""

--- a/src/senaite/core/locales/nl/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/nl/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Dutch (https://app.transifex.com/senaite/teams/87045/nl/)\n"
@@ -18,320 +18,323 @@ msgstr ""
 
 #: senaite/core/browser/user/templates/account-panel.pt:16
 msgid "${action/title}"
-msgstr ""
+msgstr "${action/title}"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:167
 msgid "Activated add-ons"
-msgstr ""
+msgstr "Geactiveerde add-ons"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Alternative formats"
-msgstr ""
+msgstr "Alternatieve formaten"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:229
 msgid "Apply rule on the whole site"
-msgstr ""
+msgstr "Regel op de hele site toepassen"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:123
 msgid "Available add-ons"
-msgstr ""
+msgstr "Beschikbare add-ons"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:212
 msgid "Broken add-ons"
-msgstr ""
+msgstr "Defecte add-ons"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:256
 msgid "Configure rule"
-msgstr ""
+msgstr "Regel configureren"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:35
 msgid "Content rule settings updated."
-msgstr ""
+msgstr "Instellingen voor inhoudsregels bijgewerkt."
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:52
 msgid "Disable globally"
-msgstr ""
+msgstr "Globaal uitschakelen"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:314
 msgid "Enabled"
-msgstr ""
+msgstr "Ingeschakeld"
 
 #: senaite/core/browser/dexterity/templates/macros.pt:20
 #: senaite/core/browser/login/templates/login.pt:17
 msgid "Error"
-msgstr ""
+msgstr "Fout"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:78
 msgid "Filter:"
-msgstr ""
+msgstr "Filter:"
 
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:28
 msgid "Go to parent folder"
-msgstr ""
+msgstr "Ga naar bovenliggende map"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:222
 msgid "Go to the folder where you want the rule to apply, or at the site root, click on 'rule' tab, and then locally setup the rules."
-msgstr ""
+msgstr "Ga naar de map waar u de regel wilt toepassen, of klik in de siteroot op het tabblad 'regel' en stel de regels vervolgens lokaal in."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "Go to the upgrade page"
-msgstr ""
+msgstr "Ga naar de upgradepagina"
 
 #: senaite/core/browser/viewlets/templates/path_bar.pt:9
 msgid "Home"
-msgstr ""
+msgstr "Home"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:132
 msgid "Install"
-msgstr ""
+msgstr "Installeren"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Log in"
-msgstr ""
+msgstr "Inloggen"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Log out"
-msgstr ""
+msgstr "Uitloggen"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt:275
 msgid "More"
-msgstr ""
+msgstr "Meer"
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:79
 msgid "Move down"
-msgstr ""
+msgstr "Omlaag"
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:67
 msgid "Move up"
-msgstr ""
+msgstr "Omhoog"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:39
 msgid "No upgrades in this corner"
-msgstr ""
+msgstr "Geen upgrades in deze hoek"
 
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:56
 msgid "Note"
-msgstr ""
+msgstr "Opmerking"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:145
 msgid "Off"
-msgstr ""
+msgstr "Uit"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:144
 msgid "On"
-msgstr ""
+msgstr "Aan"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Relative URL for the SENAITE toolbar logo"
-msgstr ""
+msgstr "Relatieve URL voor het SENAITE-werkbalklogo"
 
 #: senaite/core/browser/sharing/templates/client_sharing.pt:67
 msgid "Search for user or group"
-msgstr ""
+msgstr "Zoeken naar gebruiker of groep"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Select which formats are available for users as alternative to the default format. Note that if new formats are installed, they will be enabled for text fields by default unless explicitly turned off here or by the relevant installer."
-msgstr ""
+msgstr "Selecteer welke formaten beschikbaar zijn voor gebruikers als alternatief voor het standaardformaat. Merk op dat wanneer nieuwe formaten worden geïnstalleerd, deze standaard worden ingeschakeld voor tekstvelden, tenzij ze hier of door de betreffende installer expliciet zijn uitgeschakeld."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:148
 msgid "Server:"
-msgstr ""
+msgstr "Server:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:15
 #: senaite/core/browser/controlpanel/templates/overview.pt:16
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:13
 msgid "Site Setup"
-msgstr ""
+msgstr "Site-instellingen"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Site title"
-msgstr ""
+msgstr "Sitetitel"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:218
 msgid "The rule is enabled but will perform nothing since it is not assigned anywhere."
-msgstr ""
+msgstr "De regel is ingeschakeld maar zal niets doen omdat deze nergens is toegewezen."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "The site configuration is outdated and needs to be upgraded. Please ${link_continue_with_the_upgrade}."
-msgstr ""
+msgstr "De siteconfiguratie is verouderd en moet worden geüpgraded. Gelieve ${link_continue_with_the_upgrade}."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:87
 msgid "There is no upgrade procedure defined for this addon. Please consult the addon documentation for upgrade information, or contact the addon author."
-msgstr ""
+msgstr "Er is geen upgradeprocedure gedefinieerd voor deze add-on. Raadpleeg de add-ondocumentatie voor upgrade-informatie of neem contact op met de auteur van de add-on."
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:124
 msgid "There is not any action performed by this rule. Click on Add button to setup an action."
-msgstr ""
+msgstr "Deze regel voert geen enkele actie uit. Klik op de knop Toevoegen om een actie in te stellen."
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:39
 msgid "There is not any additional condition checked on this rule."
-msgstr ""
+msgstr "Er wordt geen enkele aanvullende voorwaarde gecontroleerd voor deze regel."
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:32
 msgid "There was an error saving content rules."
-msgstr ""
+msgstr "Er is een fout opgetreden bij het opslaan van inhoudsregels."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:69
 msgid "This addon has been upgraded."
-msgstr ""
+msgstr "Deze add-on is geüpgraded."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:23
 msgid "This is the Add-on configuration section, you can activate and deactivate add-ons in the lists below."
-msgstr ""
+msgstr "Dit is het configuratiegedeelte voor add-ons; u kunt add-ons activeren en deactiveren in de onderstaande lijsten."
 
 #: senaite/core/profiles/default/registry.xml
 msgid "This must be a URL relative to the site root."
-msgstr ""
+msgstr "Dit moet een URL zijn die relatief is aan de siteroot."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:154
 msgid "This product cannot be uninstalled!"
-msgstr ""
+msgstr "Dit product kan niet worden verwijderd!"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:215
 msgid "This rule is not assigned to any location"
-msgstr ""
+msgstr "Deze regel is aan geen enkele locatie toegewezen"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "This shows up in the title bar of browsers and in syndication feeds."
-msgstr ""
+msgstr "Dit verschijnt in de titelbalk van browsers en in syndicatiefeeds."
 
 #: senaite/core/browser/portlets/templates/navigation.pt:5
 msgid "Toggle sidebar visibility"
-msgstr ""
+msgstr "Zichtbaarheid van zijbalk in-/uitschakelen"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:176
 msgid "Uninstall"
-msgstr ""
+msgstr "Verwijderen"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:105
 msgid "Upgrade them ALL!"
-msgstr ""
+msgstr "Upgrade ze ALLEMAAL!"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:36
 msgid "Upgrades"
-msgstr ""
+msgstr "Upgrades"
 
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:32
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:28
 msgid "Users and Groups"
-msgstr ""
+msgstr "Gebruikers en groepen"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:143
 msgid "WSGI:"
-msgstr ""
+msgstr "WSGI:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:53
 msgid "Whether or not content rules should be disabled globally. If this is selected, no rules will be executed anywhere in the portal."
-msgstr ""
+msgstr "Of inhoudsregels globaal moeten worden uitgeschakeld. Als dit is geselecteerd, worden er nergens in het portaal regels uitgevoerd."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:40
 msgid "You are up to date. High fives."
-msgstr ""
+msgstr "U bent helemaal bij. Gefeliciteerd."
 
 #. convert them to new-style portlets."
 #. Default: "There are legacy portlets defined here. Click the button to convert them to new-style portlets."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:69
+#, fuzzy
 msgid "action_convert_legacy_portlets"
-msgstr ""
+msgstr "Er zijn hier verouderde portlets gedefinieerd. Klik op de knop om ze te converteren naar portlets in de nieuwe stijl."
 
 #. Default: "Next ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:85
 msgid "batch_next_x_items"
-msgstr ""
+msgstr "Volgende ${number} items"
 
 #. Default: "Previous ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:19
 msgid "batch_previous_x_items"
-msgstr ""
+msgstr "Vorige ${number} items"
 
 #. Default: "Add action"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:183
 msgid "contentrules_add_action"
-msgstr ""
+msgstr "Actie toevoegen"
 
 #. Default: "Add condition"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:91
 msgid "contentrules_add_condition"
-msgstr ""
+msgstr "Voorwaarde toevoegen"
 
 #. Default: "Shortcuts:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:228
 msgid "contentrules_assignments_shortcuts"
-msgstr ""
+msgstr "Snelkoppelingen:"
 
 #. Default: "The actions executed by this rule can trigger other rules"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:305
 msgid "contentrules_description_cascading"
-msgstr ""
+msgstr "De acties die door deze regel worden uitgevoerd, kunnen andere regels triggeren"
 
 #. Default: "Enter a short description of the rule and its purpose."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:278
 msgid "contentrules_description_description"
-msgstr ""
+msgstr "Voer een korte beschrijving in van de regel en het doel ervan."
 
 #. only be invoked if all the rule's conditions are met. You can add new
 #. actions and conditions using the buttons below."
 #. Default: "Rules execute when a triggering event occurs. Rule actions will only be invoked if all the rule's conditions are met. You can add new actions and conditions using the buttons below."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:23
+#, fuzzy
 msgid "contentrules_description_execution"
-msgstr ""
+msgstr "Regels worden uitgevoerd wanneer een triggerende gebeurtenis plaatsvindt. Regelacties worden alleen aangeroepen als aan alle voorwaarden van de regel is voldaan. U kunt nieuwe acties en voorwaarden toevoegen met de onderstaande knoppen."
 
 #. Default: "Stop evaluating content rules after this rule completes"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:296
 msgid "contentrules_description_stop"
-msgstr ""
+msgstr "Stop met het evalueren van inhoudsregels nadat deze regel is voltooid"
 
 #. Default: "The rule will execute when the following event occurs."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:287
 msgid "contentrules_description_trigger"
-msgstr ""
+msgstr "De regel wordt uitgevoerd wanneer de volgende gebeurtenis plaatsvindt."
 
 #. Default: "Perform the following actions:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:117
 msgid "contentrules_perform_actions"
-msgstr ""
+msgstr "Voer de volgende acties uit:"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "continue with the upgrade"
-msgstr ""
+msgstr "doorgaan met de upgrade"
 
 #. Default: "There is no group or user attached to this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:171
 msgid "decription_no_members_assigned"
-msgstr ""
+msgstr "Er is geen groep of gebruiker aan deze groep gekoppeld."
 
 #. Rules will automatically perform actions on content when certain triggers
 #. take place. After defining rules, you may want to go to a folder to assign
 #. them, using the \"rules\" item in the actions menu."
 #. Default: "Use the form below to define, change or remove content rules. Rules will automatically perform actions on content when certain triggers take place. After defining rules, you may want to go to a folder to assign them, using the \"rules\" item in the actions menu."
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:24
+#, fuzzy
 msgid "description-contentrules-controlpanel"
-msgstr ""
+msgstr "Gebruik het onderstaande formulier om inhoudsregels te definiëren, wijzigen of verwijderen. Regels voeren automatisch acties uit op inhoud wanneer bepaalde triggers plaatsvinden. Na het definiëren van regels wilt u mogelijk naar een map gaan om ze toe te wijzen via het item \"regels\" in het actiemenu."
 
 #. Default: "The languages in which the site should be translatable."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_available_languages"
-msgstr ""
+msgstr "De talen waarin de site vertaalbaar moet zijn."
 
 #. Default: "Please set a descriptive title for the rule."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:266
 msgid "description_contentrule_title"
-msgstr ""
+msgstr "Stel een beschrijvende titel in voor de regel."
 
 #. Default: "This rule is assigned to the following locations:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:242
 msgid "description_contentrules_rule_assignments"
-msgstr ""
+msgstr "Deze regel is toegewezen aan de volgende locaties:"
 
 #. Default: "Configuration area for Plone and add-on Products."
 #: senaite/core/browser/controlpanel/templates/overview.pt:19
 msgid "description_control_panel"
-msgstr ""
+msgstr "Configuratiegebied voor Plone en add-onproducten."
 
 #. Default: "Required for the language selector viewlet to be rendered."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_cookie_manual_override"
-msgstr ""
+msgstr "Vereist opdat de viewlet voor taalselectie wordt weergegeven."
 
 #. sites that are under development. This allows many configuration changes to
 #. be immediately visible, but will make your site run more slowly. To turn
@@ -339,65 +342,73 @@ msgstr ""
 #. re-run bin/buildout and then restart the server process."
 #. Default: "You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:167
+#, fuzzy
 msgid "description_debug_mode"
-msgstr ""
+msgstr "U draait in \"debugmodus\". Deze modus is bedoeld voor sites die in ontwikkeling zijn. Hierdoor zijn veel configuratiewijzigingen onmiddellijk zichtbaar, maar uw site zal langzamer draaien. Om de debugmodus uit te schakelen, stopt u de server, stelt u 'debug-mode=off' in uw buildout.cfg in, voert u bin/buildout opnieuw uit en start u vervolgens het serverproces opnieuw."
 
 #. here. Note that this doesn't actually delete the group or user, it is only
 #. removed from this group."
 #. Default: "You can add or remove groups and users from this particular group here. Note that this doesn't actually delete the group or user, it is only removed from this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:78
+#, fuzzy
 msgid "description_group_members_of"
-msgstr ""
+msgstr "U kunt hier groepen en gebruikers toevoegen aan of verwijderen uit deze specifieke groep. Merk op dat dit de groep of gebruiker niet daadwerkelijk verwijdert; deze wordt alleen uit deze groep verwijderd."
 
 #. business units. Groups are not directly related to permissions on a global
 #. level, you normally use Roles for that - and let certain Groups have a
 #. particular role."
 #. Default: "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:55
+#, fuzzy
 msgid "description_groups_management"
-msgstr ""
+msgstr "Groepen zijn logische verzamelingen van gebruikers, zoals afdelingen en bedrijfsonderdelen. Groepen zijn niet direct gerelateerd aan machtigingen op globaal niveau; daarvoor gebruikt u normaal gesproken rollen, en laat u bepaalde groepen een specifieke rol hebben."
 
 #. membership in another group."
 #. Default: "The symbol ${image_link_icon} indicates a role inherited from membership in another group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:66
+#, fuzzy
 msgid "description_groups_management2"
-msgstr ""
+msgstr "Het symbool ${image_link_icon} geeft een rol aan die is overgeërfd van het lidmaatschap van een andere groep."
 
 #. assigned in this context. Use the buttons on each portlet to move them up
 #. or down, delete or edit them. To add a new portlet, use the drop-down list
 #. at the top of the column."
 #. Default: "The portlet columns will first display portlets explicitly assigned in this context. Use the buttons on each portlet to move them up or down, delete or edit them. To add a new portlet, use the drop-down list at the top of the column."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:52
+#, fuzzy
 msgid "description_manage_contextual_portlets"
-msgstr ""
+msgstr "De portletkolommen tonen eerst de portlets die expliciet in deze context zijn toegewezen. Gebruik de knoppen op elke portlet om ze omhoog of omlaag te verplaatsen, te verwijderen of te bewerken. Gebruik de vervolgkeuzelijst bovenaan de kolom om een nieuwe portlet toe te voegen."
 
 #. listing of groups, so you may not see the groups defined by those plugins
 #. unless doing a specific search."
 #. Default: "Note: Some or all of your PAS groups source plugins do not allow listing of groups, so you may not see the groups defined by those plugins unless doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:72
+#, fuzzy
 msgid "description_pas_group_listing"
-msgstr ""
+msgstr "Opmerking: Sommige of al uw PAS-groepbronplugins staan het weergeven van groepen niet toe, dus mogelijk ziet u de door die plugins gedefinieerde groepen niet, tenzij u een specifieke zoekopdracht uitvoert."
 
 #. Default: "Show all search results"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:332
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:250
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:189
 msgid "description_pas_show_all_search_results"
-msgstr ""
+msgstr "Alle zoekresultaten weergeven"
 
 #. of users, so you may not see the users defined by those plugins unless
 #. doing a specific search."
 #. Default: "Some or all of your PAS user source plugins do not allow listing of users, so you may not see the users defined by those plugins unless doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:57
+#, fuzzy
 msgid "description_pas_users_listing"
-msgstr ""
+msgstr "Sommige of al uw PAS-gebruikerbronplugins staan het weergeven van gebruikers niet toe, dus mogelijk ziet u de door die plugins gedefinieerde gebruikers niet, tenzij u een specifieke zoekopdracht uitvoert."
 
 #. you can do so using the drop-down boxes. Portlets that are included by
 #. these categories are shown below the selection box."
 #. Default: "If you wish to block or unblock certain categories of portlets, you can do so using the drop-down boxes. Portlets that are included by these categories are shown below the selection box."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:59
+#, fuzzy
 msgid "description_portlets_block_unblock"
-msgstr ""
+msgstr "Als u bepaalde categorieën portlets wilt blokkeren of deblokkeren, kunt u dat doen met de vervolgkeuzelijsten. Portlets die door deze categorieën worden opgenomen, worden onder het keuzevak weergegeven."
 
 #. mode of operation for a live Plone site, but means that some configuration
 #. changes will not take effect until your server is restarted or a product
@@ -406,8 +417,9 @@ msgstr ""
 #. bin/buildout and then restart the server process."
 #. Default: "You are running in \"production mode\". This is the preferred mode of operation for a live Plone site, but means that some configuration changes will not take effect until your server is restarted or a product refreshed. If this is a development instance, and you want to enable debug mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:155
+#, fuzzy
 msgid "description_production_mode"
-msgstr ""
+msgstr "U draait in \"productiemodus\". Dit is de voorkeursmodus voor een actieve Plone-site, maar betekent dat sommige configuratiewijzigingen pas van kracht worden nadat uw server opnieuw is opgestart of een product is vernieuwd. Als dit een ontwikkelinstantie is en u de debugmodus wilt inschakelen, stopt u de server, stelt u 'debug-mode=on' in uw buildout.cfg in, voert u bin/buildout opnieuw uit en start u vervolgens het serverproces opnieuw."
 
 #. Access should be granted only to the client group below. <br /> Client
 #. contacts which are linked to a user account will be automatically added to
@@ -416,126 +428,130 @@ msgstr ""
 #. contents. </div>"
 #. Default: "Grant access for users or groups <div class=\"font-italic\"> Access should be granted only to the client group below. <br /> Client contacts which are linked to a user account will be automatically added to this group and have therefore the same roles granted immediately. <br /> Other granted access to users or groups will only affect new created contents. </div>"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:43
+#, fuzzy
 msgid "description_sharing_control"
-msgstr ""
+msgstr "Verleen toegang voor gebruikers of groepen <div class=\"font-italic\"> Toegang mag alleen worden verleend aan de onderstaande clientgroep. <br /> Clientcontactpersonen die aan een gebruikersaccount zijn gekoppeld, worden automatisch aan deze groep toegevoegd en krijgen daardoor onmiddellijk dezelfde rollen. <br /> Andere verleende toegang aan gebruikers of groepen heeft alleen invloed op nieuw aangemaakte inhoud. </div>"
 
 #. log in."
 #. Default: "Cookies are not enabled. You must enable cookies before you can log in."
 #: senaite/core/browser/login/templates/login.pt:20
+#, fuzzy
 msgid "enable_cookies_message_before_login"
-msgstr ""
+msgstr "Cookies zijn niet ingeschakeld. U moet cookies inschakelen voordat u kunt inloggen."
 
 #. Default: "File already uploaded:"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_input.pt:19
 msgid "file_already_uploaded"
-msgstr ""
+msgstr "Bestand al geüpload:"
 
 #. Default: "Get help"
 #: senaite/core/browser/login/templates/login.pt:105
 msgid "footer_login_link_get_help"
-msgstr ""
+msgstr "Hulp krijgen"
 
 #. Default: "Sign up here"
 #: senaite/core/browser/login/templates/login.pt:110
 msgid "footer_login_link_signup"
-msgstr ""
+msgstr "Meld u hier aan"
 
 #. Default: "Up to rule management"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:16
 msgid "go_to_contentrules_management"
-msgstr ""
+msgstr "Naar regelbeheer"
 
 #. Default: "Add ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:24
 msgid "heading_add_item"
-msgstr ""
+msgstr "${itemtype} toevoegen"
 
 #. Default: "Assign to groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:111
 msgid "heading_assign_to_groups"
-msgstr ""
+msgstr "Aan groepen toewijzen"
 
 #. Default: "Available languages"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_available_languages"
-msgstr ""
+msgstr "Beschikbare talen"
 
 #. Default: "Use cookie for manual override"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_cookie_manual_override"
-msgstr ""
+msgstr "Cookie gebruiken voor handmatige overschrijving"
 
 #. Default: "Create a Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:22
 msgid "heading_create_group"
-msgstr ""
+msgstr "Een groep aanmaken"
 
 #. Default: "Manage access for ${folder}"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:37
 msgid "heading_currently_assigned_shares"
-msgstr ""
+msgstr "Toegang beheren voor ${folder}"
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:58
 msgid "heading_edit_groupproperties"
-msgstr ""
+msgstr "Groep: ${groupname}"
 
 #. Default: "Edit ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:34
 msgid "heading_edit_item"
-msgstr ""
+msgstr "${itemtype} bewerken"
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:27
 msgid "heading_group_members"
-msgstr ""
+msgstr "Groepsleden"
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:55
 msgid "heading_group_members_of"
-msgstr ""
+msgstr "Groep: ${groupname}"
 
 #. Default: "Current group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:91
 msgid "heading_groupmembers_current"
-msgstr ""
+msgstr "Huidige groepsleden"
 
 #. Default: "Current group memberships"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:70
 msgid "heading_memberships_current"
-msgstr ""
+msgstr "Huidige groepslidmaatschappen"
 
 #. Default: "Portlets assigned here"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:40
 msgid "heading_portlets_assigned_here"
-msgstr ""
+msgstr "Hier toegewezen portlets"
 
 #. Default: "Search for groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:110
 msgid "heading_search_groups"
-msgstr ""
+msgstr "Zoeken naar groepen"
 
 #. Default: "Search for new group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:184
 msgid "heading_search_newmembers"
-msgstr ""
+msgstr "Zoeken naar nieuwe groepsleden"
 
 #. Default: "Version Overview"
 #: senaite/core/browser/controlpanel/templates/overview.pt:135
 msgid "heading_version_overview"
-msgstr ""
+msgstr "Versieoverzicht"
 
 #. and type the document as you usually do."
 #. Default: "If you are unsure of which format to use, just select Plain Text and type the document as you usually do."
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:52
+#, fuzzy
 msgid "help_format_wysiwyg"
-msgstr ""
+msgstr "Als u niet zeker weet welk formaat u moet gebruiken, selecteer dan gewoon Platte tekst en typ het document zoals u dat gewoonlijk doet."
 
 #. creation."
 #. Default: "A unique identifier for the group. Can not be changed after creation."
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:34
+#, fuzzy
 msgid "help_groupname"
-msgstr ""
+msgstr "Een unieke identificatie voor de groep. Kan na aanmaken niet meer worden gewijzigd."
 
 #. inherited. If you disable this, only the explicitly defined sharing
 #. permissions will be valid. In the overview, the symbol
@@ -544,494 +560,505 @@ msgstr ""
 #. administrator."
 #. Default: "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol ${image_confirm_icon} indicates an inherited value. Similarly, the symbol ${image_link_icon} indicates a global role, which is managed by the site administrator."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:191
+#, fuzzy
 msgid "help_inherit_local_roles"
-msgstr ""
+msgstr "Standaard worden machtigingen van de container van dit item overgeërfd. Als u dit uitschakelt, zijn alleen de expliciet gedefinieerde deelmachtigingen geldig. In het overzicht geeft het symbool ${image_confirm_icon} een overgeërfde waarde aan. Op vergelijkbare wijze geeft het symbool ${image_link_icon} een globale rol aan, die door de sitebeheerder wordt beheerd."
 
 #. Default: "go here"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
 msgid "help_sharing_go_here"
-msgstr ""
+msgstr "ga hierheen"
 
 #. container. To adjust them for the entire container, ${go_here}."
 #. Default: "You are adjusting the sharing privileges for a default view in a container. To adjust them for the entire container, ${go_here}."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
+#, fuzzy
 msgid "help_sharing_page_default_page"
-msgstr ""
+msgstr "U past de deelrechten aan voor een standaardweergave in een container. Om ze aan te passen voor de hele container, ${go_here}."
 
 #. Default: "HTML"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:73
 msgid "html"
-msgstr ""
+msgstr "HTML"
 
 #. Default: "If all of the following conditions are met:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:31
 msgid "if_all_conditions_met"
-msgstr ""
+msgstr "Als aan alle volgende voorwaarden is voldaan:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:148
 msgid "inactive"
-msgstr ""
+msgstr "inactief"
 
 #. Default: "Add"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:105
 msgid "label_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Add New Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:83
 msgid "label_add_new_group"
-msgstr ""
+msgstr "Nieuwe groep toevoegen"
 
 #. Default: "Add New User"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:66
 msgid "label_add_new_user"
-msgstr ""
+msgstr "Nieuwe gebruiker toevoegen"
 
 #. Default: "Add portlet"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:10
 msgid "label_add_portlet"
-msgstr ""
+msgstr "Portlet toevoegen"
 
 #. Default: "Add portlet…"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:17
 msgid "label_add_portlet_ellipsis"
-msgstr ""
+msgstr "Portlet toevoegen…"
 
 #. Default: "Add user to selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:204
 msgid "label_add_user_to_group"
-msgstr ""
+msgstr "Gebruiker toevoegen aan geselecteerde groepen"
 
 #. Default: "Add selected groups and users to this group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:339
 msgid "label_add_users_to_group"
-msgstr ""
+msgstr "Geselecteerde groepen en gebruikers aan deze groep toevoegen"
 
 #. Default: "Cancel"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:198
 #: senaite/core/skins/senaite_templates/edit_macros.pt:262
 msgid "label_cancel"
-msgstr ""
+msgstr "Annuleren"
 
 #. Default: "Add content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:189
 msgid "label_contentrule_add"
-msgstr ""
+msgstr "Inhoudsregel toevoegen"
 
 #. Default: "Assignments"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:209
 msgid "label_contentrules_rule_assignments"
-msgstr ""
+msgstr "Toewijzingen"
 
 #. Default: "enabled"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:114
 msgid "label_contentrules_rule_enabled"
-msgstr ""
+msgstr "ingeschakeld"
 
 #. Default: "event"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:113
 msgid "label_contentrules_rule_event"
-msgstr ""
+msgstr "gebeurtenis"
 
 #. Default: "content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:112
 msgid "label_contentrules_rule_listing"
-msgstr ""
+msgstr "inhoudsregel"
 
 #. Default: "Convert portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:77
 msgid "label_convert_portlets"
-msgstr ""
+msgstr "Portlets converteren"
 
 #. Default: "Delete"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:175
 msgid "label_delete"
-msgstr ""
+msgstr "Verwijderen"
 
 #. Default: "Description"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:272
 msgid "label_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Disable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:170
 msgid "label_disable"
-msgstr ""
+msgstr "Uitschakelen"
 
 #. Default: "Edit"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:52
 msgid "label_edit"
-msgstr ""
+msgstr "Bewerken"
 
 #. Default: "Enable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:165
 msgid "label_enable"
-msgstr ""
+msgstr "Inschakelen"
 
 #. Default: "Find a group here"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:37
 msgid "label_find_group"
-msgstr ""
+msgstr "Vind hier een groep"
 
 #. Default: "Format"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:50
 msgid "label_format"
-msgstr ""
+msgstr "Formaat"
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:69
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:67
 msgid "label_group_members"
-msgstr ""
+msgstr "Groepsleden"
 
 #. Default: "Group Memberships"
 #: senaite/core/browser/user/templates/account-configlet.pt:41
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:62
 msgid "label_group_memberships"
-msgstr ""
+msgstr "Groepslidmaatschappen"
 
 #. Default: "Group Properties"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:71
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:70
 msgid "label_group_properties"
-msgstr ""
+msgstr "Groepseigenschappen"
 
 #. Default: "Group Search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:106
 msgid "label_group_search"
-msgstr ""
+msgstr "Groepen zoeken"
 
 #. Default: "Groups"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:45
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:42
 msgid "label_groups"
-msgstr ""
+msgstr "Groepen"
 
 #. Default: "Hide"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:103
 msgid "label_hide_item"
-msgstr ""
+msgstr "Verbergen"
 
 #. Default: "Inherit permissions from higher levels"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:180
 msgid "label_inherit_local_roles"
-msgstr ""
+msgstr "Machtigingen van hogere niveaus overerven"
 
 #. If you wanted to manage the portlets of the container itself, ${go_here}."
 #. Default: "You are managing the portlets of the default view of a container. If you wanted to manage the portlets of the container itself, ${go_here}."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
+#, fuzzy
 msgid "label_manage_portlets_default_view_container"
-msgstr ""
+msgstr "U beheert de portlets van de standaardweergave van een container. Als u de portlets van de container zelf wilt beheren, ${go_here}."
 
 #. Default: "go here"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
 msgid "label_manage_portlets_default_view_container_go_here"
-msgstr ""
+msgstr "ga hierheen"
 
 #. Default: "Name"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:102
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:28
 msgid "label_name"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Next"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:247
 msgid "label_next"
-msgstr ""
+msgstr "Volgende"
 
 #. Default: "No group was specified."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:35
 msgid "label_no_group_specified"
-msgstr ""
+msgstr "Er is geen groep opgegeven."
 
 #. Default: "No preference panels available."
 #: senaite/core/browser/controlpanel/templates/overview.pt:123
 msgid "label_no_prefs_panels_available"
-msgstr ""
+msgstr "Geen voorkeurspanelen beschikbaar."
 
 #. Default: "Previous"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:239
 msgid "label_previous"
-msgstr ""
+msgstr "Vorige"
 
 #. Default: "This can be risky, are you sure you want to do this?"
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:104
 msgid "label_product_upgrade_all_action"
-msgstr ""
+msgstr "Dit kan riskant zijn, weet u zeker dat u dit wilt doen?"
 
 #. Default: "New profile version is ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:81
 msgid "label_product_upgrade_new_profile_version"
-msgstr ""
+msgstr "Nieuwe profielversie is ${version}."
 
 #. Default: "Old profile version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:78
 msgid "label_product_upgrade_old_profile_version"
-msgstr ""
+msgstr "Oude profielversie was ${version}."
 
 #. Default: "Old version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:74
 msgid "label_product_upgrade_old_version"
-msgstr ""
+msgstr "Oude versie was ${version}."
 
 #. Default: "Quick search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:200
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:120
 msgid "label_quick_search"
-msgstr ""
+msgstr "Snel zoeken"
 
 #. Default: "Remove"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:55
 msgid "label_remove"
-msgstr ""
+msgstr "Verwijderen"
 
 #. Default: "Remove from selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:103
 msgid "label_remove_selected_groups"
-msgstr ""
+msgstr "Verwijderen uit geselecteerde groepen"
 
 #. Default: "Remove selected groups / users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:175
 msgid "label_remove_selected_users"
-msgstr ""
+msgstr "Geselecteerde groepen / gebruikers verwijderen"
 
 #. Default: "(Required)"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:30
 msgid "label_required"
-msgstr ""
+msgstr "(Vereist)"
 
 #. Default: "Event trigger: ${trigger}"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:285
 msgid "label_rule_event_trigger"
-msgstr ""
+msgstr "Gebeurtenistrigger: ${trigger}"
 
 #. Default: "Search"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:78
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:214
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:120
 msgid "label_search"
-msgstr ""
+msgstr "Zoeken"
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:219
 msgid "label_search_large"
-msgstr ""
+msgstr "Alles weergeven"
 
 #. Default: "Show"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:91
 msgid "label_show_item"
-msgstr ""
+msgstr "Weergeven"
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:127
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:106
 msgid "label_showall"
-msgstr ""
+msgstr "Alles weergeven"
 
 #. Default: "Up to Groups Overview"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:49
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:18
 msgid "label_up_to_groups_overview"
-msgstr ""
+msgstr "Naar groepsoverzicht"
 
 #. Default: "Up to Users Overview"
 #: senaite/core/browser/user/templates/account-configlet.pt:13
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:36
 msgid "label_up_to_usersoverview"
-msgstr ""
+msgstr "Naar gebruikersoverzicht"
 
 #. Default: "User Search"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:85
 msgid "label_user_search"
-msgstr ""
+msgstr "Gebruikers zoeken"
 
 #. Default: "Users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:43
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:39
 msgid "label_users"
-msgstr ""
+msgstr "Gebruikers"
 
 #. Default: "Content rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:73
 msgid "legend-contentrules"
-msgstr ""
+msgstr "Inhoudsregels"
 
 #. Default: "E-mail Address"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:114
 msgid "listingheader_email_address"
-msgstr ""
+msgstr "E-mailadres"
 
 #. Default: "Group Name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:146
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:79
 msgid "listingheader_group_name"
-msgstr ""
+msgstr "Groepsnaam"
 
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:78
 msgid "listingheader_group_remove"
-msgstr ""
+msgstr "listingheader_group_remove"
 
 #. Default: "Group/User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:242
 msgid "listingheader_group_user_name"
-msgstr ""
+msgstr "Groeps-/gebruikersnaam"
 
 #. Default: "Remove"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:159
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:123
 msgid "listingheader_remove"
-msgstr ""
+msgstr "Verwijderen"
 
 #. Default: "Reset Password"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:122
 msgid "listingheader_reset_password"
-msgstr ""
+msgstr "Wachtwoord opnieuw instellen"
 
 #. Default: "User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:113
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:120
 msgid "listingheader_user_name"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 #. Default: "Need an account?"
 #: senaite/core/browser/login/templates/login.pt:109
 msgid "need_an_account"
-msgstr ""
+msgstr "Hebt u een account nodig?"
 
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
-msgstr ""
+msgstr "Geen bestand"
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
+msgstr "Geen afbeelding"
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82
 msgid "plain_text"
-msgstr ""
+msgstr "Platte tekst"
 
 #. Default: "Return"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:22
 msgid "return_to_view"
-msgstr ""
+msgstr "Terug"
 
 #. Default: "Structured Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:64
 msgid "structured_text"
-msgstr ""
+msgstr "Gestructureerde tekst"
 
 #. Default: "Current sharing permissions"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:92
 msgid "summary_assigned_roles"
-msgstr ""
+msgstr "Huidige deelmachtigingen"
 
 #. Default: "Select roles for each group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:139
 msgid "summary_roles_for_groups"
-msgstr ""
+msgstr "Selecteer rollen voor elke groep"
 
 #. various features including contact forms, email notification and password
 #. reset will not work. Go to the ${label_mail_control_panel_link} to fix
 #. this."
 #. Default: "You have not configured a mail host or a site 'From' address, various features including contact forms, email notification and password reset will not work. Go to the ${label_mail_control_panel_link} to fix this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:53
+#, fuzzy
 msgid "text_no_mailhost_configured"
-msgstr ""
+msgstr "U hebt geen mailhost of een 'Van'-adres voor de site geconfigureerd; diverse functies waaronder contactformulieren, e-mailmeldingen en het opnieuw instellen van wachtwoorden zullen niet werken. Ga naar de ${label_mail_control_panel_link} om dit op te lossen."
 
 #. Default: "Mail control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:54
 msgid "text_no_mailhost_configured_control_panel_link"
-msgstr ""
+msgstr "Mailconfiguratiescherm"
 
 #. Default: "PIL is not installed properly, image scaling will not work."
 #: senaite/core/browser/controlpanel/templates/overview.pt:90
 msgid "text_no_pil_installed"
-msgstr ""
+msgstr "PIL is niet correct geïnstalleerd, het schalen van afbeeldingen zal niet werken."
 
 #. Default: "Enter a group or user name to search for or click 'Show All'."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:308
 msgid "text_no_searchstring"
-msgstr ""
+msgstr "Voer een groeps- of gebruikersnaam in om naar te zoeken of klik op 'Alles weergeven'."
 
 #. Default: "Enter a group or user name to search for."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:302
 msgid "text_no_searchstring_large"
-msgstr ""
+msgstr "Voer een groeps- of gebruikersnaam in om naar te zoeken."
 
 #. work properly for timezone aware date/time values. Go to the
 #. ${label_mail_event_settings_link} to fix this."
 #. Default: "You have not set the portal timezone. Date/Time handling will not work properly for timezone aware date/time values. Go to the ${label_mail_event_settings_link} to fix this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:74
+#, fuzzy
 msgid "text_no_timezone_configured"
-msgstr ""
+msgstr "U hebt de tijdzone van het portaal niet ingesteld. De verwerking van datum/tijd zal niet correct werken voor tijdzonebewuste datum-/tijdwaarden. Ga naar de ${label_mail_event_settings_link} om dit op te lossen."
 
 #. Default: "Date and Time Settings control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:75
 msgid "text_no_timezone_configured_control_panel_link"
-msgstr ""
+msgstr "Configuratiescherm voor datum- en tijdinstellingen"
 
 #. Default: "Enter a username to search for"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:195
 msgid "text_no_user_searchstring"
-msgstr ""
+msgstr "Voer een gebruikersnaam in om naar te zoeken"
 
 #. Default: "Enter a username to search for, or click 'Show All'"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:201
 msgid "text_no_user_searchstring_largesite"
-msgstr ""
+msgstr "Voer een gebruikersnaam in om naar te zoeken, of klik op 'Alles weergeven'"
 
 #. Default: "No matches"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:297
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:231
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:191
 msgid "text_nomatches"
-msgstr ""
+msgstr "Geen overeenkomsten"
 
 #. Default: "This user does not belong to any group."
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:102
 msgid "text_user_not_in_any_group"
-msgstr ""
+msgstr "Deze gebruiker behoort tot geen enkele groep."
 
 #. Default: "Edit content rule"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:13
 msgid "title_edit_contentrule"
-msgstr ""
+msgstr "Inhoudsregel bewerken"
 
 #. Default: "Legacy portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:67
 msgid "title_legacy_portlets"
-msgstr ""
+msgstr "Verouderde portlets"
 
 #. Default: "Content Rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:21
 msgid "title_manage_contentrules"
-msgstr ""
+msgstr "Inhoudsregels"
 
 #. Default: "Manage portlets for ${context_title}"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:14
 msgid "title_manage_contextual_portlets"
-msgstr ""
+msgstr "Portlets beheren voor ${context_title}"
 
 #. Default: "Personal Information"
 #: senaite/core/browser/user/templates/account-configlet.pt:33
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:58
 msgid "title_personal_information_form"
-msgstr ""
+msgstr "Persoonlijke informatie"
 
 #. Default: "Send a mail to this user"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:158
 msgid "title_send_mail_to_user"
-msgstr ""
+msgstr "Een e-mail sturen naar deze gebruiker"
 
 #. Default: "Trouble logging in?"
 #: senaite/core/browser/login/templates/login.pt:104
 msgid "trouble_logging_in"
-msgstr ""
+msgstr "Problemen met inloggen?"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:153
 msgid "unassigned"
-msgstr ""
+msgstr "niet toegewezen"
 
 #. ${image_link_icon} indicates a role inherited from membership in a group."
 #. Default: "Note that roles set here apply directly to a user. The symbol ${image_link_icon} indicates a role inherited from membership in a group."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:52
+#, fuzzy
 msgid "user_roles_note"
-msgstr ""
+msgstr "Merk op dat de hier ingestelde rollen direct van toepassing zijn op een gebruiker. Het symbool ${image_link_icon} geeft een rol aan die is overgeërfd van het lidmaatschap van een groep."

--- a/src/senaite/core/locales/nl/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/nl/LC_MESSAGES/senaite.core.po
@@ -21,84 +21,84 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
-msgstr ""
+msgstr " <p>De ID-server levert unieke opeenvolgende ID's voor objecten zoals Monsters en Werkbladen enz., op basis van een formaat dat per inhoudstype is opgegeven.</p><p>Het formaat wordt op vergelijkbare wijze opgebouwd als de Python-formaatsyntaxis, met vooraf gedefinieerde variabelen per inhoudstype, waarbij de ID's worden opgehoogd via een volgnummer, 'seq', en de opvulling ervan als een aantal cijfers, bijv. '03d' voor een reeks ID's van 001 tot 999.</p><p>Alfanumerieke voorvoegsels voor ID's worden ongewijzigd in de formaten opgenomen, bijv. WS voor Werkblad in WS-{seq:03d} levert opeenvolgende Werkblad-ID's op: WS-001, WS-002, WS-003 enz.</p><p>Voor dynamische generatie van alfanumerieke en opeenvolgende ID's kan het jokerteken {alpha} worden gebruikt. Bijv. WS-{alpha:2a3d} levert WS-AA001, WS-AA002, WS-AB034 enz. op.</p><p>Variabelen die kunnen worden gebruikt zijn onder andere:<table><tr><th style='width:150px'>Inhoudstype</th><th>Variabelen</th></tr><tr><td>Client-ID</td><td>{clientId}</td></tr><tr><td>Jaar</td><td>{year}</td></tr><tr><td>Monster-ID</td><td>{sampleId}</td></tr><tr><td>Monstertype</td><td>{sampleType}</td></tr><tr><td>Monsternamedatum</td><td>{samplingDate}</td></tr><tr><td>Datum bemonsterd</td><td>{dateSampled}</td></tr></table></p><p>Configuratie-instellingen:<ul><li>formaat:<ul><li>een python-formaattekenreeks opgebouwd uit vooraf gedefinieerde variabelen zoals sampleId, clientId, sampleType.</li><li>de speciale variabele 'seq' moet als laatste in de formaattekenreeks worden geplaatst</li></ul></li><li>reekstype: [generated|counter]</li><li>context: bij type counter levert dit context aan de telfunctie</li><li>tellertype: [backreference|contained]</li><li>tellerreferentie: een parameter voor de telfunctie</li><li>voorvoegsel: standaardvoorvoegsel als er geen is opgegeven in de formaattekenreeks</li><li>splitslengte: het aantal delen dat in het voorvoegsel wordt opgenomen</li></ul></p>"
 
 #: bika/lims/browser/publish/templates/email.pt:143
 msgid "${amount} attachments with a total size of ${total_size}"
-msgstr ""
+msgstr "${amount} bijlagen met een totale grootte van ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
 #: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
-msgstr ""
+msgstr "${back_link}"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:32
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
-msgstr ""
+msgstr "${contact_fullname} kan inloggen op de LIMS met ${contact_username} als gebruikersnaam. Contactpersonen moeten hun eigen wachtwoord wijzigen. Als een wachtwoord vergeten is, kan een contactpersoon via het inlogformulier een nieuw wachtwoord aanvragen."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:105
 msgid "${items} were successfully created."
-msgstr ""
+msgstr "${items} zijn met succes aangemaakt."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:110
 msgid "${item} was successfully created."
-msgstr ""
+msgstr "${item} is met succes aangemaakt."
 
 #: bika/lims/utils/analysisrequest.py:885
 msgid "%s has been rejected"
-msgstr ""
+msgstr "%s is afgewezen"
 
 #: senaite/core/exportimport/setupdata/__init__.py:89
 msgid "%s has no '%s' column."
-msgstr ""
+msgstr "%s heeft geen '%s'-kolom."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
 #: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
-msgstr ""
+msgstr "&larr; Terug"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "&larr; Back to the ${back_link}"
-msgstr ""
+msgstr "&larr; Terug naar de ${back_link}"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:30
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:35
 msgid "&larr; Go back"
-msgstr ""
+msgstr "&larr; Ga terug"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:46
 msgid "&larr; Go back to see all samples"
-msgstr ""
+msgstr "&larr; Ga terug om alle monsters te bekijken"
 
 #: bika/lims/validators.py:884
 msgid "'Max' value must be above 'Min' value"
-msgstr ""
+msgstr "De waarde 'Max' moet boven de waarde 'Min' liggen"
 
 #: bika/lims/validators.py:879
 msgid "'Max' value must be numeric"
-msgstr ""
+msgstr "De waarde 'Max' moet numeriek zijn"
 
 #: bika/lims/validators.py:877
 msgid "'Min' value must be numeric"
-msgstr ""
+msgstr "De waarde 'Min' moet numeriek zijn"
 
 #: bika/lims/validators.py:898
 msgid "'Warn Max' value must be above 'Max' value"
-msgstr ""
+msgstr "De waarde 'Waarschuw Max' moet boven de waarde 'Max' liggen"
 
 #: bika/lims/validators.py:895
 msgid "'Warn Max' value must be numeric or empty"
-msgstr ""
+msgstr "De waarde 'Waarschuw Max' moet numeriek of leeg zijn"
 
 #: bika/lims/validators.py:891
 msgid "'Warn Min' value must be below 'Min' value"
-msgstr ""
+msgstr "De waarde 'Waarschuw Min' moet onder de waarde 'Min' liggen"
 
 #: bika/lims/validators.py:888
 msgid "'Warn Min' value must be numeric or empty"
-msgstr ""
+msgstr "De waarde 'Waarschuw Min' moet numeriek of leeg zijn"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:255
 msgid "(Blank)"
@@ -118,7 +118,7 @@ msgstr "(Vereist)"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:26
 msgid "*** This is an automatically generated email, please do not reply to this message. ***"
-msgstr ""
+msgstr "*** Dit is een automatisch gegenereerd e-mailbericht, gelieve niet op dit bericht te antwoorden. ***"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:91
 msgid "+-"
@@ -126,69 +126,69 @@ msgstr "±"
 
 # senaite.app.listing: Column-filter row — boolean select placeholder
 msgid "-- Select --"
-msgstr ""
+msgstr "-- Selecteren --"
 
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
-msgstr ""
+msgstr "... Kies een Instrument ..."
 
 #: bika/lims/browser/fields/resultrangefield.py:40
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:126
 msgid "< Min"
-msgstr ""
+msgstr "< Min"
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:61
 msgid "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Go to worksheet template setup"
-msgstr ""
+msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Ga naar werkbladsjabloon-instellingen"
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:15
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
-msgstr ""
+msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Welkom bij SENAITE"
 
 #: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
-msgstr ""
+msgstr "<p>De ID-server levert unieke opeenvolgende ID's voor objecten zoals Monsters en Werkbladen enz., op basis van een formaat dat per inhoudstype is opgegeven. Het formaat wordt op vergelijkbare wijze opgebouwd als de Python-formaatsyntaxis, bijv. <code>WS-{seq:03d}</code> levert <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> enz. op.</p><p>De huidige persistente tellerwaarden worden beheerd in de <a href='ng'>weergave Nummergenerator</a>.</p><details class='id-server-cheatsheet'><summary>Beschikbare variabelen</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variabele</th><th>Beschrijving</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeriek volgnummer, optioneel met voorloopnullen.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alfanumerieke teller, bijv. <code>{alpha:2a3d}</code> levert AA001, AA002, ..., AB001, ... op</td></tr><tr><td><code>{year}</code></td><td>Huidig jaar met twee cijfers (bijv. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Huidige datum als <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client-ID (alleen monsters).</td></tr><tr><td><code>{sampleType}</code></td><td>Voorvoegsel monstertype.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Monsterdata (Python <code>strftime</code>-specificaties zijn van toepassing).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>Voor partities/hertesten/secundairen: de bovenliggende monster-ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Partitieteller per bovenliggend monster.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Tellers voor hertesten, secundairen en totaal aantal testen.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuratievelden</summary><ul><li><strong>Formaat</strong>: het ID-sjabloon.</li><li><strong>Reekstype</strong>: <code>generated</code> gebruikt de persistente nummerteller; <code>counter</code> gebruikt het aantal gerelateerde objecten.</li><li><strong>Context</strong>: alleen gebruikt door het type <code>counter</code>; de benoemde context waarop de teller van toepassing is.</li><li><strong>Tellertype</strong>: <code>backreference</code> (verouderd) of <code>contained</code>.</li><li><strong>Tellerreferentie</strong>: relatienaam (backreference) of metatype (contained).</li><li><strong>Voorvoegsel</strong>: standaardvoorvoegsel als er geen in het formaat staat.</li><li><strong>Splitslengte</strong>: hoeveel segmenten van het formaat het voorvoegsel van de opslagsleutel worden. Bepaalt hoe de teller wordt gepartitioneerd (bijv. per jaar, per monstertype).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 
 #: bika/lims/content/calculation.py:133
 msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-msgstr ""
+msgstr "<p>De formule die u hier typt, wordt dynamisch berekend wanneer een analyse die deze berekening gebruikt wordt weergegeven.</p><p>Om een Berekening in te voeren, gebruikt u standaard rekenkundige operatoren,  + - * / ( ), en alle beschikbare sleutelwoorden, zowel van andere Analysediensten als van de hier opgegeven Tussentijdse velden, als variabelen. Plaats ze tussen vierkante haken [ ].</p><p>Bijv. de berekening voor Totale hardheid, het totaal van Calcium (ppm)- en Magnesium (ppm)-ionen in water, wordt ingevoerd als [Ca] + [Mg], waarbij Ca en MG de sleutelwoorden zijn voor die twee Analysediensten.</p>"
 
 #: bika/lims/browser/fields/resultrangefield.py:41
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:131
 msgid "> Max"
-msgstr ""
+msgstr "> Max"
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "A Document/File attachment"
-msgstr ""
+msgstr "Een document-/bestandsbijlage"
 
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "A published results report"
-msgstr ""
+msgstr "Een gepubliceerd resultatenrapport"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:66
 msgid "A short title for the site. This will be shown in the title of the browser window on each page."
-msgstr ""
+msgstr "Een korte titel voor de site. Deze wordt op elke pagina in de titel van het browservenster weergegeven."
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "A simple file attachment"
-msgstr ""
+msgstr "Een eenvoudige bestandsbijlage"
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "A simple image attachment"
-msgstr ""
+msgstr "Een eenvoudige afbeeldingsbijlage"
 
 #: bika/lims/profiles/default/types/ARTemplate.xml
 msgid "AR Template"
-msgstr ""
+msgstr "AR-sjabloon"
 
 #: bika/lims/profiles/default/types/ARTemplates.xml
 msgid "AR Templates"
-msgstr ""
+msgstr "AR-sjablonen"
 
 #: bika/lims/profiles/default/types/ARReport.xml
 msgid "ARReport"
-msgstr ""
+msgstr "ARReport"
 
 #: bika/lims/content/organisation.py:130
 msgid "Account Name"
@@ -205,7 +205,7 @@ msgstr "Rekeningtype"
 #: senaite/core/content/analysisprofile.py:64
 #: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
-msgstr ""
+msgstr "Boekhouding"
 
 #: senaite/core/content/laboratory.py:109
 msgid "Accreditation"
@@ -221,7 +221,7 @@ msgstr "Accreditatie-instelling URL"
 
 #: bika/lims/content/laboratory.py:162
 msgid "Accreditation Logo"
-msgstr ""
+msgstr "Accreditatielogo"
 
 #: bika/lims/content/laboratory.py:152
 msgid "Accreditation Reference"
@@ -229,7 +229,7 @@ msgstr "Accreditatie referentie"
 
 #: bika/lims/content/laboratory.py:175
 msgid "Accreditation page header"
-msgstr ""
+msgstr "Koptekst accreditatiepagina"
 
 #: senaite/core/browser/widgets/services_widget.py:323
 msgid "Accredited"
@@ -244,7 +244,7 @@ msgstr "Actie"
 #: senaite/core/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
 msgid "Activate"
-msgstr ""
+msgstr "Activeren"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
@@ -254,11 +254,11 @@ msgstr "Actieve"
 
 #: senaite/core/content/resultsreport.py:52
 msgid "Actor"
-msgstr ""
+msgstr "Actor"
 
 #: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
-msgstr ""
+msgstr "Volledige naam actor"
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
@@ -272,7 +272,7 @@ msgstr "Toevoegen van Analyses"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:301
 msgid "Add Attachment"
-msgstr ""
+msgstr "Bijlage toevoegen"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Blank Reference"
@@ -280,94 +280,94 @@ msgstr "Lege verwijzing toevoegen"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Control Reference"
-msgstr ""
+msgstr "Controlereferentie toevoegen"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Duplicate"
-msgstr ""
+msgstr "Duplicaat toevoegen"
 
 #: senaite/core/browser/viewlets/templates/add_samples.pt:22
 msgid "Add Samples"
-msgstr ""
+msgstr "Monsters toevoegen"
 
 #: senaite/core/api/remarks.py:492
 msgid "Add a remark..."
-msgstr ""
+msgstr "Een opmerking toevoegen..."
 
 #: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
-msgstr ""
+msgstr "Een opmerkingenveld toevoegen aan alle analyses"
 
 #: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
-msgstr ""
+msgstr "Voeg aangepaste CSS-regels toe voor het logo, bijv. height:15px; width:150px;"
 
 #: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
-msgstr ""
+msgstr "Standaard selecteerbare labels toevoegen"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:205
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:38
 msgid "Add new Attachment"
-msgstr ""
+msgstr "Nieuwe bijlage toevoegen"
 
 #: bika/lims/content/analysisrequest.py:1026
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
-msgstr ""
+msgstr "Voeg een of meer bijlagen toe om het monster in dit monster te beschrijven of om uw aanvraag te specificeren."
 
 #: senaite/core/browser/samples/view.py:879
 msgid "Add or remove labels on the selected samples"
-msgstr ""
+msgstr "Labels toevoegen aan of verwijderen van de geselecteerde monsters"
 
 #: senaite/core/api/remarks.py:477
 msgid "Add remarks"
-msgstr ""
+msgstr "Opmerkingen toevoegen"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:169
 msgid "Add-ons"
-msgstr ""
+msgstr "Add-ons"
 
 #: bika/lims/content/calculation.py:111
 msgid "Additional Python Libraries"
-msgstr ""
+msgstr "Aanvullende Python-bibliotheken"
 
 #: bika/lims/content/analysisrequest.py:237
 msgid "Additional email addresses to be notified"
-msgstr ""
+msgstr "Aanvullende e-mailadressen die op de hoogte moeten worden gebracht"
 
 #: bika/lims/content/analysisservice.py:117
 msgid "Additional result values"
-msgstr ""
+msgstr "Aanvullende resultaatwaarden"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:137
 #: senaite/core/z3cform/widgets/address.py:119
 msgid "Address"
-msgstr ""
+msgstr "Adres"
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Adds the ability to add/remove labels"
-msgstr ""
+msgstr "Voegt de mogelijkheid toe om labels toe te voegen/te verwijderen"
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "Adds the ability to share a content across clients"
-msgstr ""
+msgstr "Voegt de mogelijkheid toe om inhoud te delen tussen klanten"
 
 #: bika/lims/content/sampletype.py:231
 msgid "Admitted sticker templates"
-msgstr ""
+msgstr "Toegestane stickersjablonen"
 
 #: bika/lims/content/sampletype.py:204
 msgid "Admitted stickers for the sample type"
-msgstr ""
+msgstr "Toegestane stickers voor het monstertype"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:138
 msgid "Advanced"
-msgstr ""
+msgstr "Geavanceerd"
 
 #: bika/lims/browser/instrument.py:660
 #: bika/lims/content/instrumentcertification.py:92
 msgid "Agency"
-msgstr ""
+msgstr "Instantie"
 
 #: senaite/core/browser/clients/client/attachments/view.py:87
 #: senaite/core/browser/clients/client/contacts/view.py:95
@@ -377,11 +377,11 @@ msgstr "Alle"
 
 #: bika/lims/browser/accreditation.py:75
 msgid "All Accredited analysis services are listed here."
-msgstr ""
+msgstr "Alle geaccrediteerde analysediensten worden hier vermeld."
 
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:41
 msgid "All Analyses of Service"
-msgstr ""
+msgstr "Alle analyses van dienst"
 
 #: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
@@ -389,64 +389,64 @@ msgstr "Alle analyses toegewezen"
 
 # senaite.app.listing: Column config — empty state when no columns are visible
 msgid "All columns are hidden."
-msgstr ""
+msgstr "Alle kolommen zijn verborgen."
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
-msgstr ""
+msgstr "Handmatige invoer van detectiegrens toestaan"
 
 #: bika/lims/content/abstractbaseanalysis.py:728
 msgid "Allow Manual Entry"
-msgstr ""
+msgstr "Handmatige invoer toestaan"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
-msgstr ""
+msgstr "Leeg toestaan"
 
 #: bika/lims/content/abstractbaseanalysis.py:685
 msgid "Allow manual uncertainty value input"
-msgstr ""
+msgstr "Handmatige invoer van onzekerheidswaarde toestaan"
 
 #: senaite/core/vocabularies/setup.py:175
 msgid "Allow same user to verify multiple times"
-msgstr ""
+msgstr "Dezelfde gebruiker toestaan meerdere keren te verifiëren"
 
 #: senaite/core/vocabularies/setup.py:177
 msgid "Allow same user to verify multiple times, but not consecutively"
-msgstr ""
+msgstr "Dezelfde gebruiker toestaan meerdere keren te verifiëren, maar niet achtereenvolgens"
 
 #: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
-msgstr ""
+msgstr "Zelfverificatie van resultaten toestaan"
 
 #: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
-msgstr ""
+msgstr "Indiening van resultaten voor niet-toegewezen analyses toestaan"
 
 #: bika/lims/content/abstractbaseanalysis.py:336
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
-msgstr ""
+msgstr "De analist toestaan de standaard detectiegrenzen (LDL en UDL) handmatig te vervangen in de weergaven voor resultaatinvoer"
 
 #: bika/lims/content/abstractbaseanalysis.py:686
 msgid "Allow the analyst to manually replace the default uncertainty value."
-msgstr ""
+msgstr "De analist toestaan de standaard onzekerheidswaarde handmatig te vervangen."
 
 #: bika/lims/content/abstractbaseanalysis.py:379
 msgid "Allow to introduce analysis results manually"
-msgstr ""
+msgstr "Toestaan analyseresultaten handmatig in te voeren"
 
 #: senaite/core/exportimport/instruments/importer.py:371
 msgid "Allowed analysis states: {allowed_states}, "
-msgstr ""
+msgstr "Toegestane analysestatussen: {allowed_states}, "
 
 #: senaite/core/exportimport/instruments/importer.py:368
 msgid "Allowed sample states: {allowed_states}, "
-msgstr ""
+msgstr "Toegestane monsterstatussen: {allowed_states}, "
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:60
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:60
 msgid "Analysed by"
-msgstr ""
+msgstr "Geanalyseerd door"
 
 #: senaite/core/browser/dashboard/dashboard.py:506
 #: senaite/core/browser/samples/view.py:248
@@ -456,23 +456,23 @@ msgstr "Analyses"
 
 #: senaite/core/browser/dashboard/dashboard.py:485
 msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr ""
+msgstr "Analyses toegewezen aan een werkblad, in afwachting van resultaten"
 
 #: senaite/core/browser/dashboard/dashboard.py:498
 msgid "Analyses included in a published report"
-msgstr ""
+msgstr "Analyses opgenomen in een gepubliceerd rapport"
 
 #: senaite/core/browser/dashboard/dashboard.py:480
 msgid "Analyses not yet assigned to a worksheet"
-msgstr ""
+msgstr "Analyses die nog niet aan een werkblad zijn toegewezen"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
-msgstr ""
+msgstr "Aangevraagde analyses"
 
 #: senaite/core/browser/dashboard/dashboard.py:494
 msgid "Analyses that have been verified"
-msgstr ""
+msgstr "Analyses die zijn geverifieerd"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -482,46 +482,46 @@ msgstr "Analyse"
 
 #: senaite/core/exportimport/instruments/importer.py:657
 msgid "Analysis '{keyword}' of sample '{sid}' has the result '{result}' set, which is kept due to the selected override option"
-msgstr ""
+msgstr "Analyse '{keyword}' van monster '{sid}' heeft het resultaat '{result}' ingesteld, dat behouden blijft vanwege de geselecteerde overschrijfoptie"
 
 #: bika/lims/content/abstractbaseanalysis.py:362
 msgid "Analysis Keyword"
-msgstr ""
+msgstr "Analyse-sleutelwoord"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:93
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Profiles"
-msgstr ""
+msgstr "Analyseprofielen"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:22
 msgid "Analysis Report"
-msgstr ""
+msgstr "Analyserapport"
 
 #: bika/lims/browser/publish/reports_listing.py:55
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Reports"
-msgstr ""
+msgstr "Analyserapporten"
 
 #: bika/lims/browser/publish/emailview.py:310
 msgid "Analysis Results for {}"
-msgstr ""
+msgstr "Analyseresultaten voor {}"
 
 #: bika/lims/browser/fields/referenceresultsfield.py:34
 #: bika/lims/browser/fields/resultrangefield.py:33
 #: bika/lims/browser/referencesample.py:222
 msgid "Analysis Service"
-msgstr ""
+msgstr "Analysedienst"
 
 #: bika/lims/config.py:61
 #: bika/lims/controlpanel/bika_analysisservices.py:149
 #: bika/lims/profiles/default/types/AnalysisServices.xml
 msgid "Analysis Services"
-msgstr ""
+msgstr "Analysediensten"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:76
 #: bika/lims/profiles/default/types/AnalysisSpec.xml
 msgid "Analysis Specification"
-msgstr ""
+msgstr "Analysespecificatie"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:64
 #: bika/lims/profiles/default/types/AnalysisSpecs.xml
@@ -535,35 +535,35 @@ msgstr "Soort analyse"
 
 #: bika/lims/content/analysisservice.py:266
 msgid "Analysis conditions"
-msgstr ""
+msgstr "Analysecondities"
 
 #: senaite/core/browser/modals/conditions.py:165
 msgid "Analysis conditions updated: {}"
-msgstr ""
+msgstr "Analysecondities bijgewerkt: {}"
 
 #: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
-msgstr ""
+msgstr "Analysespecificaties die rechtstreeks op het monster worden bewerkt."
 
 #: senaite/core/content/interpretationtemplate.py:59
 msgid "Analysis templates"
-msgstr ""
+msgstr "Analysesjablonen"
 
 #: senaite/core/profiles/default/types/AnalysisCategories.xml
 msgid "AnalysisCategories"
-msgstr ""
+msgstr "AnalysisCategories"
 
 #: senaite/core/profiles/default/types/AnalysisCategory.xml
 msgid "AnalysisCategory"
-msgstr ""
+msgstr "AnalysisCategory"
 
 #: senaite/core/profiles/default/types/AnalysisProfile.xml
 msgid "AnalysisProfile"
-msgstr ""
+msgstr "AnalysisProfile"
 
 #: senaite/core/profiles/default/types/AnalysisProfiles.xml
 msgid "AnalysisProfiles"
-msgstr ""
+msgstr "AnalysisProfiles"
 
 #: senaite/core/browser/modals/analysis/schema.py:87
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:35
@@ -572,7 +572,7 @@ msgstr "Analist"
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:42
 msgid "Analyst must be specified."
-msgstr ""
+msgstr "Analist moet worden opgegeven."
 
 #: bika/lims/browser/fields/partitionsetupfield.py:57
 msgid "Any"
@@ -580,11 +580,11 @@ msgstr "Elke"
 
 #: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
-msgstr ""
+msgstr "Weergave"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:217
 msgid "Apply"
-msgstr ""
+msgstr "Toepassen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
@@ -592,19 +592,19 @@ msgstr "Sjabloon toepassen"
 
 # senaite.app.listing: Saved filter presets — apply button tooltip
 msgid "Apply this filter"
-msgstr ""
+msgstr "Deze filter toepassen"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
-msgstr ""
+msgstr "Breed toepassen"
 
 #: bika/lims/content/instrument.py:308
 msgid "Asset Number"
-msgstr ""
+msgstr "Inventarisnummer"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Assign"
-msgstr ""
+msgstr "Toewijzen"
 
 #: senaite/core/browser/dashboard/dashboard.py:147
 #: senaite/core/browser/samples/view.py:443
@@ -614,27 +614,27 @@ msgstr "Toegewezen"
 
 #: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
+msgstr "Toegewezen aan: ${worksheet_id}"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
-msgstr ""
+msgstr "Er zijn ten minste twee opties voor het keuzeveld vereist"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:244
 msgid "Attach to Sample"
-msgstr ""
+msgstr "Aan monster koppelen"
 
 #: senaite/core/exportimport/instruments/importer.py:815
 msgid "Attached file '{filename}' to worksheet {worksheet}"
-msgstr ""
+msgstr "Bestand '{filename}' gekoppeld aan werkblad {worksheet}"
 
 #: senaite/core/extender/label.py:62
 msgid "Attached labels"
-msgstr ""
+msgstr "Gekoppelde labels"
 
 #: senaite/core/exportimport/instruments/importer.py:854
 msgid "Attaching '{attachment}' to Analysis '{analysis}'"
-msgstr ""
+msgstr "'{attachment}' wordt gekoppeld aan analyse '{analysis}'"
 
 #: bika/lims/content/analysisrequest.py:1025
 #: bika/lims/content/attachment.py:52
@@ -644,7 +644,7 @@ msgstr "Bijlage"
 
 #: senaite/core/exportimport/instruments/importer.py:860
 msgid "Attachment '{attachment}' was already linked to analysis {analysis}"
-msgstr ""
+msgstr "Bijlage '{attachment}' was al gekoppeld aan analyse {analysis}"
 
 #: bika/lims/content/attachment.py:91
 msgid "Attachment Keys"
@@ -660,31 +660,31 @@ msgstr "Bijlagentypen"
 
 #: senaite/core/browser/attachment/attachment.py:215
 msgid "Attachment added to all '{}' analyses"
-msgstr ""
+msgstr "Bijlage toegevoegd aan alle '{}'-analyses"
 
 #: senaite/core/browser/attachment/attachment.py:182
 msgid "Attachment added to analysis '{}'"
-msgstr ""
+msgstr "Bijlage toegevoegd aan analyse '{}'"
 
 #: senaite/core/browser/attachment/attachment.py:281
 msgid "Attachment added to the current sample"
-msgstr ""
+msgstr "Bijlage toegevoegd aan het huidige monster"
 
 #: senaite/core/browser/widgets/services_widget.py:326
 msgid "Attachment required"
-msgstr ""
+msgstr "Bijlage vereist"
 
 #: bika/lims/content/abstractbaseanalysis.py:348
 msgid "Attachment required for verification"
-msgstr ""
+msgstr "Bijlage vereist voor verificatie"
 
 #: senaite/core/browser/attachment/attachment.py:349
 msgid "Attachment(s) deleted"
-msgstr ""
+msgstr "Bijlage(n) verwijderd"
 
 #: senaite/core/browser/attachment/attachment.py:138
 msgid "Attachment(s) updated"
-msgstr ""
+msgstr "Bijlage(n) bijgewerkt"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:10
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:10
@@ -694,215 +694,215 @@ msgstr "Bijlagen"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Audit Log"
-msgstr ""
+msgstr "Auditlogboek"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:215
 msgid "Authorized by"
-msgstr ""
+msgstr "Geautoriseerd door"
 
 #: senaite/core/exportimport/import.pt:56
 msgid "Auto Import"
-msgstr ""
+msgstr "Automatisch importeren"
 
 #: bika/lims/browser/instrument.py:759
 msgid "Auto Import Logs of %s"
-msgstr ""
+msgstr "Logboeken automatisch importeren van %s"
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Auto-Generate ID Behavior for Dexterity Contents"
-msgstr ""
+msgstr "Gedrag voor automatisch genereren van ID voor Dexterity-inhoud"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Auto-Import Logs"
-msgstr ""
+msgstr "Logboeken automatisch importeren"
 
 # senaite.app.listing: Saved filter presets — star action tooltip
 msgid "Auto-apply on open"
-msgstr ""
+msgstr "Automatisch toepassen bij openen"
 
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
-msgstr ""
+msgstr "Automatisch partitioneren bij ontvangst"
 
 #: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
-msgstr ""
+msgstr "Monsters automatisch ontvangen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:166
 msgid "Autofill"
-msgstr ""
+msgstr "Automatisch invullen"
 
 #: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
-msgstr ""
+msgstr "Automatisch stickers afdrukken"
 
 #: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
-msgstr ""
+msgstr "Automatisch afmelden"
 
 #: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
-msgstr ""
+msgstr "Automatische verificatie van monsters"
 
 #: bika/lims/content/artemplate.py:242
 msgid "Automatically redirect the user to the partitions creation view when Sample is received."
-msgstr ""
+msgstr "Leid de gebruiker automatisch naar de weergave voor het aanmaken van partities wanneer het monster wordt ontvangen."
 
 #: bika/lims/content/analysisservice.py:76
 msgid "Available instruments based on the selected methods."
-msgstr ""
+msgstr "Beschikbare instrumenten op basis van de geselecteerde methoden."
 
 #: bika/lims/content/analysisservice.py:61
 msgid "Available methods to perform the test"
-msgstr ""
+msgstr "Beschikbare methoden om de test uit te voeren"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:119
 msgid "Available templates"
-msgstr ""
+msgstr "Beschikbare sjablonen"
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:46
 msgid "Back"
-msgstr ""
+msgstr "Terug"
 
 #: bika/lims/content/organisation.py:154
 msgid "Bank branch"
-msgstr ""
+msgstr "Bankfiliaal"
 
 #: bika/lims/content/organisation.py:146
 msgid "Bank name"
-msgstr ""
+msgstr "Banknaam"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:138
 msgid "Base configuration"
-msgstr ""
+msgstr "Basisconfiguratie"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:44
 #: bika/lims/browser/templates/referencesample_analyses.pt:42
 msgid "Basis"
-msgstr ""
+msgstr "Basis"
 
 #: bika/lims/browser/publish/reports_listing.py:76
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/vocabularies/__init__.py:128
 msgid "Batch"
-msgstr ""
+msgstr "Batch"
 
 #: bika/lims/profiles/default/types/Batch.xml
 msgid "Batch Book"
-msgstr ""
+msgstr "Batchboek"
 
 #: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
-msgstr ""
+msgstr "Batch-ID"
 
 #: senaite/core/profiles/default/types/BatchLabel.xml
 msgid "Batch Label"
-msgstr ""
+msgstr "Batchlabel"
 
 #: senaite/core/profiles/default/types/BatchLabels.xml
 msgid "Batch Labels"
-msgstr ""
+msgstr "Batchlabels"
 
 #: bika/lims/browser/batchfolder.py:49
 #: bika/lims/profiles/default/types/BatchFolder.xml
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Batches"
-msgstr ""
+msgstr "Batches"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:19
 msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges defined in the Specifications list below."
-msgstr ""
+msgstr "Houd er rekening mee dat de bereiken die in het spreadsheetbestand van de dynamische specificatie worden opgegeven, de bereiken die in de onderstaande Specificatielijst zijn gedefinieerd, kunnen overschrijven."
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:19
 msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges manually defined in the list below."
-msgstr ""
+msgstr "Houd er rekening mee dat de bereiken die in het spreadsheetbestand van de dynamische specificatie worden opgegeven, de bereiken die handmatig in de onderstaande lijst zijn gedefinieerd, kunnen overschrijven."
 
 #: bika/lims/browser/fields/coordinatefield.py:39
 msgid "Bearing"
-msgstr ""
+msgstr "Richting"
 
 #: senaite/core/browser/dashboard/dashboard.py:139
 msgid "Biannual"
-msgstr ""
+msgstr "Halfjaarlijks"
 
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
-msgstr ""
+msgstr "Factuuradres"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:593
 msgid "Blank"
-msgstr ""
+msgstr "Blanco"
 
 #: bika/lims/config.py:88
 msgid "Blank QC analyses"
-msgstr ""
+msgstr "Blanco QC-analyses"
 
 #: bika/lims/controlpanel/bika_instruments.py:80
 msgid "Brand"
-msgstr ""
+msgstr "Merk"
 
 #: bika/lims/browser/clientfolder.py:90
 msgid "Bulk Discount"
-msgstr ""
+msgstr "Bulkkorting"
 
 #: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
-msgstr ""
+msgstr "Bulkkorting is van toepassing"
 
 #: bika/lims/content/abstractbaseanalysis.py:561
 msgid "Bulk price (excluding VAT)"
-msgstr ""
+msgstr "Bulkprijs (exclusief btw)"
 
 #: senaite/core/browser/clients/client/contacts/view.py:78
 #: senaite/core/browser/controlpanel/contacts/view.py:66
 msgid "Business Phone"
-msgstr ""
+msgstr "Zakelijk telefoonnummer"
 
 #: senaite/core/z3cform/widgets/address.py:123
 msgid "Business address"
-msgstr ""
+msgstr "Zakelijk adres"
 
 #: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
-msgstr ""
+msgstr "Op 'Weergavewaarde' oplopend"
 
 #: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
-msgstr ""
+msgstr "Op 'Weergavewaarde' aflopend"
 
 #: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
-msgstr ""
+msgstr "Op 'Resultaatwaarde' oplopend"
 
 #: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
-msgstr ""
+msgstr "Op 'Resultaatwaarde' aflopend"
 
 #: bika/lims/content/analysisrequest.py:348
 msgid "CBID"
-msgstr ""
+msgstr "CBID"
 
 #: bika/lims/content/client.py:133
 msgid "CC Contacts"
-msgstr ""
+msgstr "CC-contactpersonen"
 
 #: bika/lims/content/analysisrequest.py:236
 #: bika/lims/content/client.py:166
 msgid "CC Emails"
-msgstr ""
+msgstr "CC-e-mails"
 
 #: bika/lims/content/abstractbaseanalysis.py:663
 msgid "Calculate Precision from Uncertainties"
-msgstr ""
+msgstr "Precisie berekenen op basis van onzekerheden"
 
 #: senaite/core/profiles/default/types/Calculation.xml
 msgid "Calculation"
-msgstr ""
+msgstr "Berekening"
 
 #: senaite/core/browser/form/adapters/method.py:100
 msgid "Calculation '{}' is used by service '{}'"
-msgstr ""
+msgstr "Berekening '{}' wordt gebruikt door dienst '{}'"
 
 #: bika/lims/content/calculation.py:132
 msgid "Calculation Formula"
@@ -915,7 +915,7 @@ msgstr "Berekeningvelden Interim"
 
 #: bika/lims/content/analysisservice.py:106
 msgid "Calculation to be assigned to this content."
-msgstr ""
+msgstr "Berekening die aan deze inhoud moet worden toegewezen."
 
 #: senaite/core/profiles/default/types/Calculations.xml
 msgid "Calculations"
@@ -923,40 +923,40 @@ msgstr "Berekeningen"
 
 #: bika/lims/content/instrumentscheduledtask.py:118
 msgid "Calibration"
-msgstr ""
+msgstr "Kalibratie"
 
 #: bika/lims/browser/instrument.py:637
 #: bika/lims/browser/templates/instrument_certifications.pt:40
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Calibration Certificates"
-msgstr ""
+msgstr "Kalibratiecertificaten"
 
 #: bika/lims/content/instrumentcalibration.py:69
 msgid "Calibration report date"
-msgstr ""
+msgstr "Datum kalibratierapport"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Calibrations"
-msgstr ""
+msgstr "Kalibraties"
 
 #: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentcalibration.py:96
 msgid "Calibrator"
-msgstr ""
+msgstr "Kalibrator"
 
 #: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
-msgstr ""
+msgstr "Kan verifiëren, maar ingediend door huidige gebruiker"
 
 #: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
-msgstr ""
+msgstr "Kan verifiëren, maar al geverifieerd door huidige gebruiker"
 
 #: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
 msgid "Cancel"
-msgstr ""
+msgstr "Annuleren"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
 #: senaite/core/browser/samples/dispose_samples.py:70
@@ -966,48 +966,48 @@ msgstr "Geannuleerd"
 
 #: bika/lims/content/calculation.py:460
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
-msgstr ""
+msgstr "Kan berekening niet activeren, omdat de volgende dienstafhankelijkheden inactief zijn: ${inactive_services}"
 
 #: bika/lims/content/calculation.py:480
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
-msgstr ""
+msgstr "Kan berekening niet deactiveren, omdat deze in gebruik is door de volgende diensten: ${calc_services}"
 
 #: senaite/core/browser/samples/invalidate_samples.py:93
 msgid "Cannot invalidate ${sample_id}: ${error}"
-msgstr ""
+msgstr "Kan ${sample_id} niet ongeldig maken: ${error}"
 
 #: senaite/core/browser/samples/invalidate_samples.py:262
 msgid "Cannot send email for ${sample_id}: ${error}"
-msgstr ""
+msgstr "Kan geen e-mail verzenden voor ${sample_id}: ${error}"
 
 #: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
-msgstr ""
+msgstr "Kan niet verifiëren, laatst geverifieerd door huidige gebruiker"
 
 #: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
-msgstr ""
+msgstr "Kan niet verifiëren, ingediend door huidige gebruiker"
 
 #: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
-msgstr ""
+msgstr "Kan niet verifiëren, is geverifieerd door huidige gebruiker"
 
 #: senaite/core/content/samplecontainer.py:78
 msgid "Capacity"
-msgstr ""
+msgstr "Capaciteit"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:112
 msgid "Captured"
-msgstr ""
+msgstr "Vastgelegd"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:45
 #: bika/lims/browser/templates/referencesample_analyses.pt:43
 msgid "Cardinal"
-msgstr ""
+msgstr "Hoofdrichting"
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Catalog Dexterity contents in multiple catalogs"
-msgstr ""
+msgstr "Dexterity-inhoud in meerdere catalogi catalogiseren"
 
 #: bika/lims/browser/templates/referencesample_view.pt:57
 #: bika/lims/content/referencesample.py:151
@@ -1016,7 +1016,7 @@ msgstr "Catalogusnummer"
 
 #: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
-msgstr ""
+msgstr "Analysediensten categoriseren"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:59
 #: bika/lims/browser/worksheet/views/add_analyses.py:107
@@ -1026,99 +1026,99 @@ msgstr "Categorie"
 
 #: bika/lims/content/analysiscategory.py:118
 msgid "Category cannot be deactivated because it contains Analysis Services"
-msgstr ""
+msgstr "Categorie kan niet worden gedeactiveerd omdat deze analysediensten bevat"
 
 #: bika/lims/browser/instrument.py:659
 msgid "Cert. Num"
-msgstr ""
+msgstr "Cert.nr."
 
 #: bika/lims/content/instrumentcertification.py:209
 msgid "Certificate Code"
-msgstr ""
+msgstr "Certificaatcode"
 
 #: bika/lims/browser/auditlog.py:96
 #: bika/lims/controlpanel/auditlog.py:103
 msgid "Changes"
-msgstr ""
+msgstr "Wijzigingen"
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:64
 msgid "Changes Saved"
-msgstr ""
+msgstr "Wijzigingen opgeslagen"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
 #: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
-msgstr ""
+msgstr "Wijzigingen opgeslagen."
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
-msgstr ""
+msgstr "Wijzigingen worden doorgevoerd naar partities"
 
 #: bika/lims/content/method.py:67
 msgid "Check if the method has been accredited"
-msgstr ""
+msgstr "Aanvinken als de methode is geaccrediteerd"
 
 #: bika/lims/content/abstractbaseanalysis.py:495
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
-msgstr ""
+msgstr "Vink dit vakje aan als de analysedienst is opgenomen in het overzicht van geaccrediteerde analyses van het laboratorium"
 
 #: bika/lims/content/samplepoint.py:122
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
-msgstr ""
+msgstr "Vink dit vakje aan als de monsters die op dit punt worden genomen 'samengesteld' zijn en zijn samengesteld uit meer dan één deelmonster, bijv. meerdere oppervlaktemonsters van een stuwmeer die samen zijn gemengd tot een representatief monster voor het stuwmeer. De standaardinstelling, niet aangevinkt, duidt op 'grijpmonsters'"
 
 #: senaite/core/content/samplecontainer.py:86
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
-msgstr ""
+msgstr "Vink dit vakje aan als deze container al geconserveerd is. Hiermee wordt de conserveringsworkflow voor monsterpartities die in deze container zijn opgeslagen, overgeslagen."
 
 #: bika/lims/content/laboratory.py:112
 msgid "Check this box if your laboratory is accredited"
-msgstr ""
+msgstr "Vink dit vakje aan als uw laboratorium geaccrediteerd is"
 
 #: bika/lims/content/analysisservice.py:130
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
-msgstr ""
+msgstr "Vink dit vakje aan om ervoor te zorgen dat er een aparte monstercontainer wordt gebruikt voor deze analysedienst"
 
 #: bika/lims/content/analysisservice.py:260
 msgid "Checkbox"
-msgstr ""
+msgstr "Selectievakje"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:55
 #: bika/lims/content/analysisservice.py:223
 msgid "Choices"
-msgstr ""
+msgstr "Keuzes"
 
 #: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
-msgstr ""
+msgstr "Kies het standaardsjabloon voor 'grote' stickers. Let op: monsterspecifieke 'grote' stickers worden geconfigureerd op basis van hun monstertype."
 
 #: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
-msgstr ""
+msgstr "Kies het standaardsjabloon voor 'grote' stickers.<br/><strong>Let op:</strong> monsterspecifieke 'grote' stickers worden geconfigureerd op basis van hun monstertype."
 
 #: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
-msgstr ""
+msgstr "Kies het standaardsjabloon voor 'kleine' stickers. Let op: monsterspecifieke 'kleine' stickers worden geconfigureerd op basis van hun monstertype."
 
 #: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
-msgstr ""
+msgstr "Kies het standaardsjabloon voor 'kleine' stickers.<br/><strong>Let op:</strong> monsterspecifieke 'kleine' stickers worden geconfigureerd op basis van hun monstertype."
 
 #: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
-msgstr ""
+msgstr "Kies het type meervoudige verificatie voor dezelfde gebruiker. Met deze instelling kan meer dan één keer verifiëren/achtereenvolgens verifiëren voor dezelfde gebruiker worden in-/uitgeschakeld."
 
 #: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
-msgstr ""
+msgstr "Kies wanneer stickers automatisch moeten worden afgedrukt:<br/><ul><li><strong>Registreren:</strong> Stickers worden automatisch afgedrukt wanneer nieuwe monsters worden aangemaakt.</li><li><strong>Ontvangen:</strong> Stickers worden automatisch afgedrukt wanneer monsters worden ontvangen.</li><li><strong>Geen:</strong> Schakelt automatisch afdrukken van stickers uit.</li></ul>"
 
 #: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
-msgstr ""
+msgstr "Kies wanneer stickers automatisch moeten worden afgedrukt:<br/><ul><li><strong>Registreren:</strong> Stickers worden automatisch afgedrukt wanneer nieuwe monsters worden aangemaakt.</li><li><strong>Ontvangen:</strong> Stickers worden automatisch afgedrukt wanneer monsters worden ontvangen.</li><li><strong>Geen:</strong> Schakelt automatisch afdrukken van stickers uit.</li></ul>"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:113
 #: senaite/core/z3cform/widgets/address.py:225
 msgid "City"
-msgstr ""
+msgstr "Plaats"
 
 #: bika/lims/config.py:125
 msgid "Classic"
@@ -1126,29 +1126,29 @@ msgstr "Classic"
 
 # senaite.app.listing: Column-filter row — clear button tooltip
 msgid "Clear filter"
-msgstr ""
+msgstr "Filter wissen"
 
 # senaite.app.listing: Search box — undo button tooltip when only clearing
 # search
 msgid "Clear search"
-msgstr ""
+msgstr "Zoekopdracht wissen"
 
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
-msgstr ""
+msgstr "Selectie wissen"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
-msgstr ""
+msgstr "Klik om deze categorie uit te vouwen"
 
 # senaite.app.listing: Saved filter presets — release button tooltip on the
 # applied preset
 msgid "Click to release this filter"
-msgstr ""
+msgstr "Klik om deze filter op te heffen"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
-msgstr ""
+msgstr "Klik om de zichtbaarheid te wisselen of sleep om de volgorde te wijzigen"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
 #: senaite/core/browser/samples/view.py:191
@@ -1159,7 +1159,7 @@ msgstr "Client"
 #: bika/lims/browser/batchfolder.py:84
 #: bika/lims/content/batch.py:101
 msgid "Client Batch ID"
-msgstr ""
+msgstr "Client-batch-ID"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
@@ -1169,21 +1169,21 @@ msgstr "Client-ID"
 
 #: bika/lims/profiles/default/registry.xml
 msgid "Client Landing Page"
-msgstr ""
+msgstr "Client-landingspagina"
 
 #: senaite/core/behaviors/clientshareable.py:85
 msgid "Client Name"
-msgstr ""
+msgstr "Clientnaam"
 
 #: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
-msgstr ""
+msgstr "Clientorder"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:115
 #: bika/lims/browser/batch/batchbook.py:81
 #: bika/lims/content/analysisrequest.py:817
 msgid "Client Order Number"
-msgstr ""
+msgstr "Clientordernummer"
 
 #: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
@@ -1204,11 +1204,11 @@ msgstr "Client Monster-ID"
 
 #: senaite/core/registry/schema.py:39
 msgid "Client Settings"
-msgstr ""
+msgstr "Clientinstellingen"
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "ClientShareableBehavior"
-msgstr ""
+msgstr "ClientShareableBehavior"
 
 #: senaite/core/behaviors/clientshareable.py:58
 msgid "Clients"
@@ -1216,81 +1216,81 @@ msgstr "Klanten"
 
 #: senaite/core/behaviors/clientshareable.py:59
 msgid "Clients with whom this content will be shared across. This content will become available on searches to users that belong to any of the selected clients thanks to the role 'ClientGuest'"
-msgstr ""
+msgstr "Klanten met wie deze inhoud wordt gedeeld. Deze inhoud wordt beschikbaar in zoekopdrachten voor gebruikers die tot een van de geselecteerde klanten behoren dankzij de rol 'ClientGuest'"
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:13
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 msgid "Close"
-msgstr ""
+msgstr "Sluiten"
 
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 msgid "Closed"
-msgstr ""
+msgstr "Gesloten"
 
 #: bika/lims/content/storagelocation.py:59
 msgid "Code for the location"
-msgstr ""
+msgstr "Code voor de locatie"
 
 #: bika/lims/content/storagelocation.py:44
 msgid "Code for the site"
-msgstr ""
+msgstr "Code voor de site"
 
 #: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
-msgstr ""
+msgstr "Code voor de plank"
 
 #: senaite/core/registry/schema.py:133
 msgid "Collapse field analysis table"
-msgstr ""
+msgstr "Veldanalysetabel inklappen"
 
 #: senaite/core/registry/schema.py:134
 msgid "Collapse field analysis table in sample view"
-msgstr ""
+msgstr "Veldanalysetabel inklappen in monsterweergave"
 
 #: senaite/core/registry/schema.py:140
 msgid "Collapse lab analysis table"
-msgstr ""
+msgstr "Labanalysetabel inklappen"
 
 #: senaite/core/registry/schema.py:141
 msgid "Collapse lab analysis table in sample view"
-msgstr ""
+msgstr "Labanalysetabel inklappen in monsterweergave"
 
 #: senaite/core/registry/schema.py:147
 msgid "Collapse qc analysis table"
-msgstr ""
+msgstr "QC-analysetabel inklappen"
 
 #: senaite/core/registry/schema.py:148
 msgid "Collapse qc analysis table in sample view"
-msgstr ""
+msgstr "QC-analysetabel inklappen in monsterweergave"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:117
 msgid "Collected"
-msgstr ""
+msgstr "Verzameld"
 
 #: senaite/core/content/dynamicanalysisspec.py:94
 msgid "Column '{}' is missing"
-msgstr ""
+msgstr "Kolom '{}' ontbreekt"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
 msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
-msgstr ""
+msgstr "Kolom {} van de koprij heeft geen naam. Verwijder lege kolommen uit de spreadsheet en upload deze opnieuw."
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
-msgstr ""
+msgstr "Komma (,)"
 
 #: bika/lims/content/analysiscategory.py:51
 msgid "Comments"
-msgstr ""
+msgstr "Opmerkingen"
 
 #: bika/lims/content/analysisrequest.py:1368
 msgid "Comments or results interpretation"
-msgstr ""
+msgstr "Opmerkingen of interpretatie van resultaten"
 
 #: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
-msgstr ""
+msgstr "Commerciële ID"
 
 #: bika/lims/content/analysisrequest.py:957
 #: bika/lims/content/samplepoint.py:121
@@ -1299,43 +1299,43 @@ msgstr "Composiet"
 
 #: bika/lims/content/artemplate.py:109
 msgid "Composite sample"
-msgstr ""
+msgstr "Samengesteld monster"
 
 #: bika/lims/content/analysisservice.py:267
 msgid "Conditions to ask for this analysis on sample registration. For instance, laboratory may want the user to input the temperature, the ramp and flow when a thermogravimetric (TGA) analysis is selected on sample registration. The information provided will be later considered by the laboratory personnel when performing the test."
-msgstr ""
+msgstr "Condities om voor deze analyse op te vragen bij monsterregistratie. Zo kan het laboratorium bijvoorbeeld willen dat de gebruiker de temperatuur, de opwarmsnelheid en de flow invoert wanneer een thermogravimetrische (TGA-)analyse wordt geselecteerd bij monsterregistratie. De verstrekte informatie wordt later door het laboratoriumpersoneel in aanmerking genomen bij het uitvoeren van de test."
 
 #: bika/lims/content/laboratory.py:99
 msgid "Confidence Level %"
-msgstr ""
+msgstr "Betrouwbaarheidsniveau %"
 
 # senaite.app.listing: Configuration
 msgid "Configuration"
-msgstr ""
+msgstr "Configuratie"
 
 #: senaite/core/registry/schema.py:227
 msgid "Configuration for Generic Setup"
-msgstr ""
+msgstr "Configuratie voor Generic Setup"
 
 #: senaite/core/registry/schema.py:161
 msgid "Configuration for the sample header information"
-msgstr ""
+msgstr "Configuratie voor de kopinformatie van het monster"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:119
 msgid "Configuration restored to default values."
-msgstr ""
+msgstr "Configuratie hersteld naar standaardwaarden."
 
 # senaite.app.listing: Column config — trigger button label
 msgid "Configure"
-msgstr ""
+msgstr "Configureren"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
-msgstr ""
+msgstr "Tabelkolommen configureren"
 
 #: bika/lims/content/artemplate.py:173
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
-msgstr ""
+msgstr "Configureer de monsterpartities en conserveringen voor dit sjabloon. Wijs analyses toe aan de verschillende partities op het tabblad Analyses van het sjabloon"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:253
 msgid "Confirm password"
@@ -1345,7 +1345,7 @@ msgstr "Bevestig wachtwoord"
 #: bika/lims/content/instrumentmaintenancetask.py:93
 #: bika/lims/content/instrumentscheduledtask.py:86
 msgid "Considerations"
-msgstr ""
+msgstr "Overwegingen"
 
 #: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
@@ -1354,11 +1354,11 @@ msgstr "Contact"
 
 #: bika/lims/browser/analysisrequest/add2.py:2066
 msgid "Contact does not belong to the selected client"
-msgstr ""
+msgstr "Contactpersoon behoort niet tot de geselecteerde client"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:118
 msgid "Contact is deactivated. User cannot be unlinked."
-msgstr ""
+msgstr "Contactpersoon is gedeactiveerd. Gebruiker kan niet worden ontkoppeld."
 
 #: senaite/core/browser/clients/client/contacts/view.py:65
 #: senaite/core/profiles/default/types/Contacts.xml
@@ -1368,726 +1368,726 @@ msgstr "Contactpersonen"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:72
 msgid "Contained Samples"
-msgstr ""
+msgstr "Bevatte monsters"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:175
 msgid "Container"
-msgstr ""
+msgstr "Container"
 
 #: senaite/core/content/samplecontainer.py:70
 #: senaite/core/profiles/default/types/ContainerType.xml
 msgid "Container Type"
-msgstr ""
+msgstr "Containertype"
 
 #: senaite/core/profiles/default/types/ContainerTypes.xml
 msgid "Container Types"
-msgstr ""
+msgstr "Containertypen"
 
 #: bika/lims/controlpanel/bika_containers.py:58
 msgid "Containers"
-msgstr ""
+msgstr "Containers"
 
 #: bika/lims/browser/dynamic_analysisspec.py:45
 msgid "Contents of the file {}"
-msgstr ""
+msgstr "Inhoud van het bestand {}"
 
 #: senaite/core/content/senaitesetup.py:224
 msgid "Context"
-msgstr ""
+msgstr "Context"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:590
 msgid "Control"
-msgstr ""
+msgstr "Controle"
 
 #: bika/lims/config.py:89
 msgid "Control QC analyses"
-msgstr ""
+msgstr "Controle-QC-analyses"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:56
 #: bika/lims/content/analysisservice.py:222
 msgid "Control type"
-msgstr ""
+msgstr "Controletype"
 
 #: bika/lims/validators.py:441
 msgid "Control type is not supported for empty choices"
-msgstr ""
+msgstr "Controletype wordt niet ondersteund voor lege keuzes"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:54
 msgid "Copy"
-msgstr ""
+msgstr "Kopiëren"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:11
 msgid "Copy analysis services"
-msgstr ""
+msgstr "Analysediensten kopiëren"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:49
 msgid "Copy from"
-msgstr ""
+msgstr "Kopiëren van"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
-msgstr ""
+msgstr "Kopieer de momenteel weergegeven kolomwaarde naar de andere kolommen rechts"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
-msgstr ""
+msgstr "Kopieer de waarde van het eerste monster naar de andere"
 
 #: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
-msgstr ""
+msgstr "Kopiëren naar nieuw"
 
 #: senaite/core/browser/idserver/view.py:131
 msgid "Could not convert {} value(s) to integer: {}"
-msgstr ""
+msgstr "Kon {} waarde(n) niet naar een geheel getal converteren: {}"
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
-msgstr ""
+msgstr "Kon de volgende monster(s) niet aanmaken vanwege transactieconflicten, probeer ze opnieuw: ${rows}"
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:228
 msgid "Could not link User: ${error}"
-msgstr ""
+msgstr "Kon gebruiker niet koppelen: ${error}"
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
-msgstr ""
+msgstr "Kon PDF voor monster {} niet laden"
 
 #: bika/lims/browser/publish/emailview.py:558
 msgid "Could not send email to {0} ({1})"
-msgstr ""
+msgstr "Kon geen e-mail verzenden naar {0} ({1})"
 
 #: bika/lims/browser/workflow/analysisrequest.py:217
 msgid "Could not transition samples to the sampled state"
-msgstr ""
+msgstr "Kon monsters niet overzetten naar de status bemonsterd"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:103
 msgid "Counter <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Teller <span class=\"sort-indicator\" />"
 
 #: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
-msgstr ""
+msgstr "Tellerreferentie"
 
 #: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
-msgstr ""
+msgstr "Tellertype"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:28
 #: senaite/core/z3cform/widgets/address.py:222
 msgid "Country"
-msgstr ""
+msgstr "Land"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Create Invoice PDF"
-msgstr ""
+msgstr "Factuur-PDF aanmaken"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
-msgstr ""
+msgstr "Partities aanmaken"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:214
 msgid "Create SENAITE Site"
-msgstr ""
+msgstr "SENAITE-site aanmaken"
 
 #: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
-msgstr ""
+msgstr "Werkblad aanmaken"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:134
 msgid "Create a new SENAITE site"
-msgstr ""
+msgstr "Een nieuwe SENAITE-site aanmaken"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:215
 msgid "Create a new User"
-msgstr ""
+msgstr "Een nieuwe gebruiker aanmaken"
 
 #: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
-msgstr ""
+msgstr "Een nieuw werkblad aanmaken voor de geselecteerde monsters"
 
 #: senaite/core/browser/worksheets/templates/view.pt:26
 msgid "Create new worksheet"
-msgstr ""
+msgstr "Nieuw werkblad aanmaken"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Create partitions"
-msgstr ""
+msgstr "Partities aanmaken"
 
 #: senaite/core/browser/clients/client/attachments/view.py:71
 msgid "Created"
-msgstr ""
+msgstr "Aangemaakt"
 
 #: bika/lims/browser/instrument.py:404
 msgid "Created by"
-msgstr ""
+msgstr "Aangemaakt door"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:46
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:46
 msgid "Created on"
-msgstr ""
+msgstr "Aangemaakt op"
 
 #: senaite/core/browser/samples/partition_magic.py:113
 msgid "Created {} partitions: {}"
-msgstr ""
+msgstr "{} partities aangemaakt: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
 #: senaite/core/browser/samples/view.py:148
 msgid "Creator"
-msgstr ""
+msgstr "Aanmaker"
 
 #: bika/lims/browser/instrument.py:403
 #: bika/lims/content/instrumentscheduledtask.py:76
 msgid "Criteria"
-msgstr ""
+msgstr "Criteria"
 
 #: bika/lims/content/bikasetup.py:254
 msgid "Currency"
-msgstr ""
+msgstr "Valuta"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Current"
-msgstr ""
+msgstr "Huidig"
 
 # senaite.app.listing: Saved filter presets — dirty tag hover tooltip
 msgid "Current view differs from saved"
-msgstr ""
+msgstr "Huidige weergave verschilt van de opgeslagen weergave"
 
 #: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
-msgstr ""
+msgstr "Aangepast decimaalteken"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
-msgstr ""
+msgstr "DL"
 
 #: senaite/core/browser/dashboard/dashboard.py:135
 msgid "Daily"
-msgstr ""
+msgstr "Dagelijks"
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
-msgstr ""
+msgstr "Data-interface"
 
 #: bika/lims/content/instrument.py:291
 msgid "Data Interface Options"
-msgstr ""
+msgstr "Data-interface-opties"
 
 #: senaite/core/browser/form/adapters/data_import.py:72
 msgid "Data import successful"
-msgstr ""
+msgstr "Data-import geslaagd"
 
 #: bika/lims/browser/batchfolder.py:76
 #: bika/lims/browser/instrument.py:661
 #: bika/lims/content/abstractbaseanalysis.py:700
 msgid "Date"
-msgstr ""
+msgstr "Datum"
 
 #: bika/lims/browser/analyses/view.py:126
 msgid "Date Created"
-msgstr ""
+msgstr "Aanmaakdatum"
 
 #: bika/lims/content/referencesample.py:204
 msgid "Date Disposed"
-msgstr ""
+msgstr "Datum afgevoerd"
 
 #: bika/lims/content/referencesample.py:197
 msgid "Date Expired"
-msgstr ""
+msgstr "Vervaldatum"
 
 #: bika/lims/content/attachment.py:100
 msgid "Date Loaded"
-msgstr ""
+msgstr "Datum geladen"
 
 #: bika/lims/browser/auditlog.py:82
 #: bika/lims/controlpanel/auditlog.py:76
 msgid "Date Modified"
-msgstr ""
+msgstr "Datum gewijzigd"
 
 #: bika/lims/browser/referencesample.py:364
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:98
 msgid "Date Opened"
-msgstr ""
+msgstr "Datum geopend"
 
 #: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
-msgstr ""
+msgstr "Datum geconserveerd"
 
 #: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
-msgstr ""
+msgstr "Datum afgedrukt"
 
 #: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
-msgstr ""
+msgstr "Datum gepubliceerd"
 
 #: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
-msgstr ""
+msgstr "Datum ontvangen"
 
 #: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
-msgstr ""
+msgstr "Datum geregistreerd"
 
 #: bika/lims/browser/worksheet/views/add_duplicate.py:76
 msgid "Date Requested"
-msgstr ""
+msgstr "Datum aangevraagd"
 
 #: bika/lims/content/analysisrequest.py:1075
 msgid "Date Sample Received"
-msgstr ""
+msgstr "Datum monster ontvangen"
 
 #: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
-msgstr ""
+msgstr "Datum bemonsterd"
 
 #: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
-msgstr ""
+msgstr "Datum geverifieerd"
 
 #: bika/lims/content/instrumentcalibration.py:79
 msgid "Date from which the instrument is under calibration"
-msgstr ""
+msgstr "Datum vanaf wanneer het instrument in kalibratie is"
 
 #: bika/lims/content/instrumentmaintenancetask.py:66
 msgid "Date from which the instrument is under maintenance"
-msgstr ""
+msgstr "Datum vanaf wanneer het instrument in onderhoud is"
 
 #: bika/lims/content/instrumentvalidation.py:61
 msgid "Date from which the instrument is under validation"
-msgstr ""
+msgstr "Datum vanaf wanneer het instrument in validatie is"
 
 #: bika/lims/content/instrumentcertification.py:100
 msgid "Date granted"
-msgstr ""
+msgstr "Datum verleend"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:112
 msgid "Date received"
-msgstr ""
+msgstr "Datum ontvangen"
 
 #: bika/lims/content/instrumentcertification.py:137
 msgid "Date until the certificate is valid"
-msgstr ""
+msgstr "Datum tot wanneer het certificaat geldig is"
 
 #: bika/lims/content/instrumentcalibration.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:76
 #: bika/lims/content/instrumentvalidation.py:71
 msgid "Date until the instrument will not be available"
-msgstr ""
+msgstr "Datum tot wanneer het instrument niet beschikbaar is"
 
 #: bika/lims/content/instrumentcertification.py:101
 msgid "Date when the calibration certificate was granted"
-msgstr ""
+msgstr "Datum waarop het kalibratiecertificaat werd verleend"
 
 #: bika/lims/content/instrumentcertification.py:127
 msgid "Date when the certificate is valid"
-msgstr ""
+msgstr "Datum waarop het certificaat geldig is"
 
 #: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
-msgstr ""
+msgstr "Datum waarop het rapport werd afgedrukt"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:101
 #: bika/lims/content/abstractbaseanalysis.py:701
 msgid "Datetime"
-msgstr ""
+msgstr "Datum-tijd"
 
 #: bika/lims/browser/fields/durationfield.py:36
 msgid "Days"
-msgstr ""
+msgstr "Dagen"
 
 #: bika/lims/content/instrument.py:186
 msgid "De-activate until next calibration test"
-msgstr ""
+msgstr "Deactiveren tot de volgende kalibratietest"
 
 #: senaite/core/profiles/default/workflows/senaite_client_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
 msgid "Deactivate"
-msgstr ""
+msgstr "Deactiveren"
 
 #: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
-msgstr ""
+msgstr "Decimaalteken dat gebruikt wordt in de rapporten van deze client."
 
 #: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
-msgstr ""
+msgstr "Standaard CC-contactpersonen voor nieuwe monsters. Indien ingesteld, worden deze contactpersonen automatisch geselecteerd in het formulier voor het toevoegen van monsters."
 
 #: bika/lims/content/analysisservice.py:165
 msgid "Default Container"
-msgstr ""
+msgstr "Standaard container"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:80
 msgid "Default Department"
-msgstr ""
+msgstr "Standaard afdeling"
 
 #: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
-msgstr ""
+msgstr "Standaard e-mailadressen om alle gepubliceerde monsters voor deze client in CC te zetten"
 
 #: bika/lims/content/abstractbaseanalysis.py:414
 msgid "Default Instrument"
-msgstr ""
+msgstr "Standaard instrument"
 
 #: bika/lims/content/abstractbaseanalysis.py:430
 msgid "Default Method"
-msgstr ""
+msgstr "Standaard methode"
 
 #: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
-msgstr ""
+msgstr "Standaard aantal kopieën"
 
 #: bika/lims/content/analysisservice.py:145
 msgid "Default Preservation"
-msgstr ""
+msgstr "Standaard conservering"
 
 #: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
-msgstr ""
+msgstr "Standaard stickersjabloon"
 
 #: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
-msgstr ""
+msgstr "Standaard contactpersoon voor nieuwe monsters. Indien ingesteld, wordt deze contactpersoon automatisch geselecteerd in het formulier voor het toevoegen van monsters."
 
 #: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
-msgstr ""
+msgstr "Standaard aantal toe te voegen monsters."
 
 #: bika/lims/content/bikasetup.py:312
 #: bika/lims/content/client.py:229
 msgid "Default decimal mark"
-msgstr ""
+msgstr "Standaard decimaalteken"
 
 #: bika/lims/content/abstractbaseanalysis.py:415
 msgid "Default instrument used for analyses of this type"
-msgstr ""
+msgstr "Standaard instrument dat gebruikt wordt voor analyses van dit type"
 
 #: bika/lims/content/sampletype.py:208
 msgid "Default large sticker"
-msgstr ""
+msgstr "Standaard grote sticker"
 
 #: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
-msgstr ""
+msgstr "Standaard lay-out in werkbladweergave"
 
 #: bika/lims/content/abstractbaseanalysis.py:431
 msgid "Default method used for analyses of this type"
-msgstr ""
+msgstr "Standaard methode die gebruikt wordt voor analyses van dit type"
 
 #: senaite/core/registry/schema.py:110
 msgid "Default printing templates order for worksheet"
-msgstr ""
+msgstr "Standaardvolgorde van afdruksjablonen voor werkblad"
 
 #: bika/lims/content/analysisservice.py:195
 msgid "Default result"
-msgstr ""
+msgstr "Standaard resultaat"
 
 #: bika/lims/validators.py:1379
 msgid "Default result is not a valid date"
-msgstr ""
+msgstr "Standaard resultaat is geen geldige datum"
 
 #: bika/lims/validators.py:1383
 msgid "Default result is not numeric"
-msgstr ""
+msgstr "Standaard resultaat is niet numeriek"
 
 #: bika/lims/validators.py:1389
 msgid "Default result must be one of the following result options: {}"
-msgstr ""
+msgstr "Standaard resultaat moet een van de volgende resultaatopties zijn: {}"
 
 #: bika/lims/content/analysisservice.py:196
 msgid "Default result to display on result entry"
-msgstr ""
+msgstr "Standaard resultaat om weer te geven bij resultaatinvoer"
 
 #: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
-msgstr ""
+msgstr "Standaard bewaartermijn voor monsters"
 
 #: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
-msgstr ""
+msgstr "Standaard wetenschappelijke notatie-indeling voor rapporten"
 
 #: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
-msgstr ""
+msgstr "Standaard wetenschappelijke notatie-indeling voor resultaten"
 
 #: bika/lims/content/sampletype.py:206
 msgid "Default small sticker"
-msgstr ""
+msgstr "Standaard kleine sticker"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:97
 msgid "Default timezone"
-msgstr ""
+msgstr "Standaard tijdzone"
 
 #: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
-msgstr ""
+msgstr "Standaard doorlooptijd voor analyses."
 
 #: bika/lims/browser/fields/interimfieldsfield.py:54
 #: bika/lims/content/analysisservice.py:224
 msgid "Default value"
-msgstr ""
+msgstr "Standaardwaarde"
 
 #: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-msgstr ""
+msgstr "Standaardwaarde van het 'Aantal monsters' wanneer gebruikers op de knop 'TOEVOEGEN' klikken om nieuwe monsters aan te maken"
 
 #: bika/lims/content/method.py:57
 msgid "Define an identifier code for the method. It must be unique."
-msgstr ""
+msgstr "Definieer een identificatiecode voor de methode. Deze moet uniek zijn."
 
 #: bika/lims/content/calculation.py:60
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
-msgstr ""
+msgstr "Definieer tussenvelden zoals vaatmassa of verdunningsfactoren, mocht uw berekening deze nodig hebben. De hier opgegeven veldtitel wordt gebruikt als kolomkop en veldbeschrijving waar de tussenvelden worden weergegeven. Als 'Breed toepassen' is ingeschakeld, wordt het veld weergegeven in een keuzevak bovenaan het werkblad, zodat een specifieke waarde op alle overeenkomstige velden op het blad kan worden toegepast."
 
 #: bika/lims/content/abstractbaseanalysis.py:177
 msgid "Define the number of decimals to be used for this result."
-msgstr ""
+msgstr "Definieer het aantal decimalen dat voor dit resultaat gebruikt moet worden."
 
 #: bika/lims/content/abstractbaseanalysis.py:191
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
-msgstr ""
+msgstr "Definieer de precisie bij het omzetten van waarden naar exponentnotatie.  De standaardwaarde is 7."
 
 #: bika/lims/content/analysisrequest.py:494
 msgid "Define the sampler supposed to do the sample in the scheduled date"
-msgstr ""
+msgstr "Definieer de monsternemer die het monster op de geplande datum moet nemen"
 
 #: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
-msgstr ""
+msgstr "Definieer het sjabloon voor de e-mailtekst die automatisch wordt verstuurd naar primaire contactpersonen en laboratoriummanagers wanneer een monster ongeldig wordt verklaard. De volgende plaatshouders worden ondersteund: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 
 #: bika/lims/content/sampletype.py:232
 msgid "Defines the stickers to use for this sample type."
-msgstr ""
+msgstr "Definieert de stickers die voor dit monstertype gebruikt moeten worden."
 
 #: bika/lims/browser/fields/coordinatefield.py:36
 msgid "Degrees"
-msgstr ""
+msgstr "Graden"
 
 #: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
-msgstr ""
+msgstr "Verwijderen"
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Delete filter"
-msgstr ""
+msgstr "Filter verwijderen"
 
 #: senaite/core/api/remarks.py:484
 msgid "Delete this remark?"
-msgstr ""
+msgstr "Deze opmerking verwijderen?"
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
 msgid "Department"
-msgstr ""
+msgstr "Afdeling"
 
 #: senaite/core/browser/controlpanel/departments/view.py:68
 msgid "Department ID"
-msgstr ""
+msgstr "Afdelings-ID"
 
 #: senaite/core/content/department.py:134
 msgid "Department ID must be unique"
-msgstr ""
+msgstr "Afdelings-ID moet uniek zijn"
 
 #: bika/lims/content/abstractbaseanalysis.py:601
 #: bika/lims/content/analysiscategory.py:72
 msgid "Department Name"
-msgstr ""
+msgstr "Afdelingsnaam"
 
 #: senaite/core/profiles/default/types/Departments.xml
 msgid "Departments"
-msgstr ""
+msgstr "Afdelingen"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:201
 msgid "Dependent Analyses"
-msgstr ""
+msgstr "Afhankelijke analyses"
 
 #: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
 #: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
-msgstr ""
+msgstr "Beschrijving"
 
 #: bika/lims/content/instrumentcalibration.py:119
 msgid "Description of the actions made during the calibration"
-msgstr ""
+msgstr "Beschrijving van de tijdens de kalibratie uitgevoerde acties"
 
 #: bika/lims/content/instrumentmaintenancetask.py:104
 msgid "Description of the actions made during the maintenance process"
-msgstr ""
+msgstr "Beschrijving van de tijdens het onderhoudsproces uitgevoerde acties"
 
 #: bika/lims/content/instrumentvalidation.py:101
 msgid "Description of the actions made during the validation"
-msgstr ""
+msgstr "Beschrijving van de tijdens de validatie uitgevoerde acties"
 
 #: bika/lims/content/storagelocation.py:64
 msgid "Description of the location"
-msgstr ""
+msgstr "Beschrijving van de locatie"
 
 #: bika/lims/content/storagelocation.py:84
 msgid "Description of the shelf"
-msgstr ""
+msgstr "Beschrijving van de plank"
 
 #: bika/lims/content/storagelocation.py:49
 msgid "Description of the site"
-msgstr ""
+msgstr "Beschrijving van de site"
 
 msgid "Deselect all"
-msgstr ""
+msgstr "Alles deselecteren"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Detach"
-msgstr ""
+msgstr "Loskoppelen"
 
 #: senaite/core/browser/modals/analysis/schema.py:105
 msgid "Detection Limit"
-msgstr ""
+msgstr "Detectielimiet"
 
 # senaite.app.listing: Disable auto fetch transitions
 msgid "Disable auto fetch transitions"
-msgstr ""
+msgstr "Automatisch ophalen van overgangen uitschakelen"
 
 #: senaite/core/vocabularies/setup.py:180
 msgid "Disable multi-verification for the same user"
-msgstr ""
+msgstr "Meervoudige verificatie voor dezelfde gebruiker uitschakelen"
 
 # senaite.app.listing: Saved filter presets — Revert action tooltip
 msgid "Discard edits and restore preset"
-msgstr ""
+msgstr "Bewerkingen verwerpen en voorinstelling herstellen"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
-msgstr ""
+msgstr "Korting"
 
 #: bika/lims/content/pricelist.py:66
 msgid "Discount %"
-msgstr ""
+msgstr "Korting %"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:78
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatch"
-msgstr ""
+msgstr "Verzenden"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:15
 msgid "Dispatch samples"
-msgstr ""
+msgstr "Monsters verzenden"
 
 #: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
-msgstr ""
+msgstr "Verzonden"
 
 # bika.lims.bikalisting.js
 msgid "Display Columns"
-msgstr ""
+msgstr "Kolommen weergeven"
 
 #: bika/lims/content/abstractbaseanalysis.py:727
 msgid "Display Value"
-msgstr ""
+msgstr "Weergavewaarde"
 
 #: bika/lims/validators.py:675
 msgid "Display Value is required"
-msgstr ""
+msgstr "Weergavewaarde is vereist"
 
 #: bika/lims/validators.py:687
 msgid "Display Value must be unique"
-msgstr ""
+msgstr "Weergavewaarde moet uniek zijn"
 
 #: bika/lims/content/abstractbaseanalysis.py:316
 msgid "Display a Detection Limit selector"
-msgstr ""
+msgstr "Een detectielimietselector weergeven"
 
 #: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
-msgstr ""
+msgstr "Monsterpartities aan clients tonen"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
-msgstr ""
+msgstr "Afvoeren"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:15
 msgid "Dispose samples"
-msgstr ""
+msgstr "Monsters afvoeren"
 
 #: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
-msgstr ""
+msgstr "Afgevoerd"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:87
 #: senaite/core/z3cform/widgets/address.py:224
 msgid "District"
-msgstr ""
+msgstr "District"
 
 #: bika/lims/browser/instrument.py:664
 #: bika/lims/content/multifile.py:47
 msgid "Document"
-msgstr ""
+msgstr "Document"
 
 #: bika/lims/browser/instrument.py:809
 #: bika/lims/content/multifile.py:39
 msgid "Document ID"
-msgstr ""
+msgstr "Document-ID"
 
 #: bika/lims/browser/instrument.py:812
 #: bika/lims/content/multifile.py:63
 msgid "Document Location"
-msgstr ""
+msgstr "Documentlocatie"
 
 #: bika/lims/browser/instrument.py:813
 #: bika/lims/content/multifile.py:73
 msgid "Document Type"
-msgstr ""
+msgstr "Documenttype"
 
 #: bika/lims/browser/instrument.py:811
 #: bika/lims/content/multifile.py:55
 msgid "Document Version"
-msgstr ""
+msgstr "Documentversie"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Documents"
-msgstr ""
+msgstr "Documenten"
 
 #: senaite/core/exportimport/instruments/importer.py:375
 msgid "Don't override analysis results"
-msgstr ""
+msgstr "Analyseresultaten niet overschrijven"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:79
 msgid "Done"
-msgstr ""
+msgstr "Klaar"
 
 #: senaite/core/vocabularies/setup.py:113
 msgid "Dot (.)"
-msgstr ""
+msgstr "Punt (.)"
 
 #: bika/lims/browser/instrument.py:87
 msgid "Down from"
-msgstr ""
+msgstr "Omlaag vanaf"
 
 #: bika/lims/browser/instrument.py:88
 msgid "Down to"
-msgstr ""
+msgstr "Omlaag tot"
 
 #: bika/lims/browser/publish/reports_listing.py:150
 msgid "Download"
-msgstr ""
+msgstr "Downloaden"
 
 #: bika/lims/browser/publish/reports_listing.py:80
 msgid "Download PDF"
-msgstr ""
+msgstr "PDF downloaden"
 
 #: bika/lims/browser/publish/reports_listing.py:145
 msgid "Download selected reports"
-msgstr ""
+msgstr "Geselecteerde rapporten downloaden"
 
 # senaite.app.listing: Column config — drag handle tooltip / aria-label
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Sleep om te herordenen"
 
 #: senaite/core/browser/samples/view.py:327
 msgid "Due"
@@ -2096,76 +2096,76 @@ msgstr "Verschuldigd"
 #: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
-msgstr ""
+msgstr "Vervaldatum"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:199
 msgid "Dup Var"
-msgstr ""
+msgstr "Dup Var"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:556
 msgid "Duplicate"
-msgstr ""
+msgstr "Dupliceren"
 
 #: bika/lims/profiles/default/types/DuplicateAnalysis.xml
 msgid "Duplicate Analysis"
-msgstr ""
+msgstr "Duplicaatanalyse"
 
 #: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
-msgstr ""
+msgstr "Dubbele ID-indeling voor portaltype '${pt}' (rijen ${a} en ${b}). Alleen de eerste rij wordt gebruikt; verwijder of voeg het duplicaat samen."
 
 #: bika/lims/content/worksheettemplate.py:59
 msgid "Duplicate Of"
-msgstr ""
+msgstr "Duplicaat van"
 
 #: bika/lims/config.py:90
 msgid "Duplicate QC analyses"
-msgstr ""
+msgstr "QC-analyses dupliceren"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr ""
+msgstr "Monster dupliceren"
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
-msgstr ""
+msgstr "Duplicaatvariatie %"
 
 #: bika/lims/validators.py:461
 msgid "Duplicate keys in choices field"
-msgstr ""
+msgstr "Dubbele sleutels in keuzeveld"
 
 #: bika/lims/browser/workflow/analysisrequest.py:443
 msgid "Duplicated samples: {}"
-msgstr ""
+msgstr "Gedupliceerde monsters: {}"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpec.xml
 msgid "Dynamic Analysis Specification"
-msgstr ""
+msgstr "Dynamische analysespecificatie"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpecs.xml
 msgid "Dynamic Analysis Specifications"
-msgstr ""
+msgstr "Dynamische analysespecificaties"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:82
 msgid "Dynamic Specification"
-msgstr ""
+msgstr "Dynamische specificatie"
 
 #: bika/lims/content/laboratory.py:122
 msgid "E.g. SANAS, APLAC, etc."
-msgstr ""
+msgstr "Bijv. SANAS, APLAC, enz."
 
 #: senaite/core/exportimport/import.pt:165
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
-msgstr ""
+msgstr "Elke import-interface kan een map definiëren waar het systeem naar de resultaatbestanden zoekt bij het automatisch importeren van resultaten wanneer de <code>auto_import_results</code>-weergave wordt aangeroepen."
 
 #: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
-msgstr ""
+msgstr "Bewerken"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:15
 msgid "Edit Multiple Analyses Results"
-msgstr ""
+msgstr "Resultaten van meerdere analyses bewerken"
 
 #: bika/lims/content/samplepoint.py:74
 msgid "Elevation"
@@ -2185,202 +2185,202 @@ msgstr "E-mailadres"
 
 #: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
-msgstr ""
+msgstr "E-mailbijlagen"
 
 #: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
-msgstr ""
+msgstr "E-mailtekst"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:96
 msgid "Email Log"
-msgstr ""
+msgstr "E-maillogboek"
 
 #: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
-msgstr ""
+msgstr "E-mailontvangers"
 
 #: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
-msgstr ""
+msgstr "E-mailverantwoordelijken"
 
 #: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
-msgstr ""
+msgstr "Verzenddatum e-mail"
 
 #: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
-msgstr ""
+msgstr "E-mailonderwerp"
 
 #: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
-msgstr ""
+msgstr "E-mailtekst voor meldingen van monsterongeldigverklaring"
 
 #: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
-msgstr ""
+msgstr "E-mailtekst voor meldingen van monsterafwijzing"
 
 #: bika/lims/browser/publish/emailview.py:158
 msgid "Email cancelled"
-msgstr ""
+msgstr "E-mail geannuleerd"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:126
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:129
 msgid "Email notification"
-msgstr ""
+msgstr "E-mailmelding"
 
 #: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
-msgstr ""
+msgstr "E-mailmelding bij monsterafwijzing"
 
 #: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
-msgstr ""
+msgstr "Logboek van verzonden e-mails"
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
-msgstr ""
+msgstr "E-mail verzonden"
 
 #: bika/lims/api/snapshot.py:585
 msgid "Empty"
-msgstr ""
+msgstr "Leeg"
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
-msgstr ""
+msgstr "Lege sleutels worden niet ondersteund"
 
 #: bika/lims/content/worksheettemplate.py:140
 msgid "Enable Multiple Use of Instrument in Worksheets."
-msgstr ""
+msgstr "Meervoudig gebruik van instrument in werkbladen inschakelen."
 
 #: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
-msgstr ""
+msgstr "Monsterconservering inschakelen"
 
 #: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
-msgstr ""
+msgstr "Monsterspecificaties inschakelen"
 
 #: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
-msgstr ""
+msgstr "Monstername inschakelen"
 
 #: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
-msgstr ""
+msgstr "Planning van monstername inschakelen"
 
 #: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
-msgstr ""
+msgstr "Globaal auditlogboek inschakelen"
 
 #: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
-msgstr ""
+msgstr "Globaal auditlogboek inschakelen"
 
 #: bika/lims/content/artemplate.py:119
 msgid "Enable sampling workflow for the created sample"
-msgstr ""
+msgstr "Monsternameworkflow inschakelen voor het aangemaakte monster"
 
 #: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
-msgstr ""
+msgstr "De workflow voor het afdrukken van resultaatrapporten inschakelen"
 
 #: senaite/core/content/senaitesetup.py:1000
 msgid "Enable the Sample Dispatch workflow"
-msgstr ""
+msgstr "De workflow voor monsterverzending inschakelen"
 
 #: senaite/core/content/senaitesetup.py:990
 msgid "Enable the Sample Dispose workflow"
-msgstr ""
+msgstr "De workflow voor monsterafvoer inschakelen"
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
-msgstr ""
+msgstr "Einddatum"
 
 #: bika/lims/content/instrumentmaintenancetask.py:165
 #: bika/lims/content/instrumentscheduledtask.py:119
 msgid "Enhancement"
-msgstr ""
+msgstr "Verbetering"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:231
 msgid "Enter a user name, usually something like 'jsmith'. No spaces or special characters. Usernames and passwords are case sensitive, make sure the caps lock key is not enabled. This is the name used to log in."
-msgstr ""
+msgstr "Voer een gebruikersnaam in, meestal iets als 'jsmith'. Geen spaties of speciale tekens. Gebruikersnamen en wachtwoorden zijn hoofdlettergevoelig; zorg ervoor dat Caps Lock niet is ingeschakeld. Dit is de naam die wordt gebruikt om aan te melden."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:268
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
-msgstr ""
+msgstr "Voer een e-mailadres in. Dit is nodig voor het geval het wachtwoord verloren gaat. Wij respecteren uw privacy en geven het adres niet door aan derden en maken het nergens openbaar."
 
 #: bika/lims/content/pricelist.py:67
 msgid "Enter discount percentage value"
-msgstr ""
+msgstr "Voer de kortingspercentagewaarde in"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
-msgstr ""
+msgstr "Voer voor dit veld individuele waarden per monster in"
 
 #: bika/lims/content/abstractbaseanalysis.py:576
 #: bika/lims/content/labproduct.py:48
 msgid "Enter percentage value eg. 14.0"
-msgstr ""
+msgstr "Voer de percentagewaarde in, bijv. 14.0"
 
 #: bika/lims/content/analysisprofile.py:123
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
-msgstr ""
+msgstr "Voer de percentagewaarde in, bijv. 14.0. Dit percentage wordt alleen op het analyseprofiel toegepast en overschrijft de systeem-btw"
 
 #: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
-msgstr ""
+msgstr "Voer de percentagewaarde in, bijv. 14.0. Dit percentage wordt systeembreed toegepast, maar kan op individuele items worden overschreven"
 
 #: bika/lims/content/analysisrequest.py:1120
 msgid "Enter percentage value eg. 33.0"
-msgstr ""
+msgstr "Voer de percentagewaarde in, bijv. 33.0"
 
 #: bika/lims/content/samplepoint.py:57
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
-msgstr ""
+msgstr "Voer de breedtegraad van het monsterpunt in graden 0-90, minuten 0-59, seconden 0-59 en N/Z-indicator in"
 
 #: bika/lims/content/samplepoint.py:66
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
-msgstr ""
+msgstr "Voer de lengtegraad van het monsterpunt in graden 0-180, minuten 0-59, seconden 0-59 en O/W-indicator in"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:18
 msgid "Enter the details of each of the analysis services you want to copy."
-msgstr ""
+msgstr "Voer de gegevens in van elke analysedienst die u wilt kopiëren."
 
 #: bika/lims/content/laboratory.py:176
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
-msgstr ""
+msgstr "Voer hier de gegevens van de dienstaccreditaties van uw lab in. De volgende velden zijn beschikbaar:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
 #: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
-msgstr ""
+msgstr "Voer het resultaat in decimale of wetenschappelijke notatie in, bijv. 0.00005 of 1e-5, 10000 of 1e5"
 
 #: bika/lims/content/analysisrequest.py:939
 msgid "Environmental conditions"
-msgstr ""
+msgstr "Omgevingscondities"
 
 #: senaite/core/browser/samples/invalidate_samples.py:282
 msgid "Erroneous result publication: ${sample_id}"
-msgstr ""
+msgstr "Foutieve resultaatpublicatie: ${sample_id}"
 
 #: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
-msgstr ""
+msgstr "Evolutie van analyses"
 
 #: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
-msgstr ""
+msgstr "Evolutie van monsters"
 
 #: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
-msgstr ""
+msgstr "Evolutie van werkbladen"
 
 #: senaite/core/exportimport/import.pt:172
 msgid "Example Cronjob to execute the auto import every 10 minutes"
-msgstr ""
+msgstr "Voorbeeld-cronjob om de automatische import elke 10 minuten uit te voeren"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:125
 msgid "Example content"
-msgstr ""
+msgstr "Voorbeeldinhoud"
 
 #: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
@@ -2394,15 +2394,15 @@ msgstr "Verwachte resultaat"
 
 #: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
-msgstr ""
+msgstr "Verwachte monsternamedatum"
 
 #: bika/lims/content/referencesample.py:214
 msgid "Expected Values"
-msgstr ""
+msgstr "Verwachte waarden"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Expire"
-msgstr ""
+msgstr "Verlopen"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Expired"
@@ -2416,27 +2416,27 @@ msgstr "Vervaldatum"
 
 #: bika/lims/content/abstractbaseanalysis.py:190
 msgid "Exponential format precision"
-msgstr ""
+msgstr "Precisie van exponentiële notatie"
 
 #: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
-msgstr ""
+msgstr "Drempel van exponentiële notatie"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Export"
-msgstr ""
+msgstr "Exporteren"
 
 #: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
-msgstr ""
+msgstr "Kon sticker niet laden"
 
 #: bika/lims/browser/publish/emailview.py:150
 msgid "Failed to send Email(s)"
-msgstr ""
+msgstr "Kon e-mail(s) niet verzenden"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:101
 msgid "Failed to update registry records. Please check the server log for details."
-msgstr ""
+msgstr "Kon registerrecords niet bijwerken. Raadpleeg het serverlogboek voor details."
 
 #: bika/lims/browser/clientfolder.py:86
 #: bika/lims/content/organisation.py:66
@@ -2446,7 +2446,7 @@ msgstr "Fax"
 
 #: bika/lims/content/person.py:118
 msgid "Fax (business)"
-msgstr ""
+msgstr "Fax (zakelijk)"
 
 #: bika/lims/config.py:77
 msgid "Female"
@@ -2454,7 +2454,7 @@ msgstr "Vrouw"
 
 # senaite.app.listing: Fetch transitions
 msgid "Fetch Transitions"
-msgstr ""
+msgstr "Overgangen ophalen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:191
 msgid "Field"
@@ -2462,7 +2462,7 @@ msgstr "Veld"
 
 #: bika/lims/browser/analysisrequest/add2.py:2122
 msgid "Field '{}' is required"
-msgstr ""
+msgstr "Veld '{}' is vereist"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:125
 #: senaite/core/browser/viewlets/sampleanalyses.py:69
@@ -2471,11 +2471,11 @@ msgstr "Veld Analyses"
 
 #: senaite/core/registry/schema.py:214
 msgid "Field Name"
-msgstr ""
+msgstr "Veldnaam"
 
 #: bika/lims/config.py:56
 msgid "Field Preservation"
-msgstr ""
+msgstr "Veldconservering"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:53
 msgid "Field Title"
@@ -2483,11 +2483,11 @@ msgstr "Veld Titel"
 
 #: bika/lims/browser/analysisrequest/add2.py:1460
 msgid "Field flushed"
-msgstr ""
+msgstr "Veld leeggemaakt"
 
 #: senaite/core/registry/schema.py:212
 msgid "Field visibility"
-msgstr ""
+msgstr "Veldzichtbaarheid"
 
 #: bika/lims/browser/instrument.py:814
 msgid "File"
@@ -2495,55 +2495,55 @@ msgstr "Bestand"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:194
 msgid "File Deleted"
-msgstr ""
+msgstr "Bestand verwijderd"
 
 #: bika/lims/content/analysisservice.py:262
 msgid "File upload"
-msgstr ""
+msgstr "Bestand uploaden"
 
 #: bika/lims/content/multifile.py:48
 msgid "File upload "
-msgstr ""
+msgstr "Bestand uploaden "
 
 #: senaite/core/browser/clients/client/attachments/view.py:59
 msgid "Filename"
-msgstr ""
+msgstr "Bestandsnaam"
 
 #: bika/lims/browser/publish/reports_listing.py:82
 msgid "Filesize"
-msgstr ""
+msgstr "Bestandsgrootte"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
-msgstr ""
+msgstr "Analyses op naam filteren..."
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:190
 msgid "Filter by template method"
-msgstr ""
+msgstr "Filteren op sjabloonmethode"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:175
 msgid "Filter by template services"
-msgstr ""
+msgstr "Filteren op sjabloondiensten"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
-msgstr ""
+msgstr "Sleutels filteren (regex ondersteund)"
 
 # senaite.app.listing: Saved filter presets — inline editor placeholder
 msgid "Filter name"
-msgstr ""
+msgstr "Filternaam"
 
 #: senaite/core/browser/samples/view.py:601
 msgid "Filter samples by this analysis"
-msgstr ""
+msgstr "Monsters op deze analyse filteren"
 
 # senaite.app.listing: Column-filter row — text-input placeholder
 msgid "Filter..."
-msgstr ""
+msgstr "Filteren..."
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
-msgstr ""
+msgstr "Het eerste blad bevat geen geldige kolomdefinitie"
 
 #: bika/lims/content/person.py:51
 msgid "Firstname"
@@ -2553,15 +2553,15 @@ msgstr "Voornaam"
 #: bika/lims/content/analysiscategory.py:83
 #: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
-msgstr ""
+msgstr "Kommagetal van 0.0 - 1000.0 dat de sorteervolgorde aangeeft. Dubbele waarden worden alfabetisch geordend."
 
 #: senaite/core/content/senaitesetup.py:212
 msgid "Format"
-msgstr ""
+msgstr "Indeling"
 
 #: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
-msgstr ""
+msgstr "Opmaakconfiguratie"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:183
 #: bika/lims/controlpanel/bika_calculations.py:79
@@ -2570,21 +2570,21 @@ msgstr "Formule"
 
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:239
 msgid "Found Dynamic Analysis Specification for '{}' in '{}'"
-msgstr ""
+msgstr "Dynamische analysespecificatie gevonden voor '{}' in '{}'"
 
 #: senaite/core/vocabularies/setup.py:160
 msgid "Friday"
-msgstr ""
+msgstr "Vrijdag"
 
 #: bika/lims/browser/publish/templates/email.pt:47
 #: bika/lims/content/instrumentcalibration.py:78
 #: bika/lims/content/instrumentmaintenancetask.py:65
 msgid "From"
-msgstr ""
+msgstr "Van"
 
 #: senaite/core/browser/dashboard/dashboard.py:134
 msgid "From ${from} to ${to} (updated every 2 hours)"
-msgstr ""
+msgstr "Van ${from} tot ${to} (elke 2 uur bijgewerkt)"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
@@ -2594,95 +2594,95 @@ msgstr "Volledige naam"
 
 #: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
-msgstr ""
+msgstr "Volledige naam"
 
 #: bika/lims/content/calculation.py:100
 msgid "Function"
-msgstr ""
+msgstr "Functie"
 
 #: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
-msgstr ""
+msgstr "Monster met datum in de toekomst"
 
 #: senaite/core/browser/dexterity/views.py:206
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:27
 msgid "General"
-msgstr ""
+msgstr "Algemeen"
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Generates an ID with the IDServer"
-msgstr ""
+msgstr "Genereert een ID met de IDServer"
 
 #: senaite/core/registry/schema.py:226
 msgid "Generic Setup"
-msgstr ""
+msgstr "Generieke instellingen"
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:11
 msgid "Global Audit Log is disabled"
-msgstr ""
+msgstr "Globaal auditlogboek is uitgeschakeld"
 
 #: senaite/core/profiles/default/types/Contacts.xml
 msgid "Global contacts container"
-msgstr ""
+msgstr "Globale contactpersonencontainer"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:44
 msgid "Go to your instance"
-msgstr ""
+msgstr "Ga naar uw instantie"
 
 #: bika/lims/content/person.py:43
 msgid "Greeting title eg. Mr, Mrs, Dr"
-msgstr ""
+msgstr "Aanhef, bijv. Dhr., Mevr., Dr."
 
 #: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
-msgstr ""
+msgstr "Groepeer analysediensten per categorie in de LIMS-tabellen, handig wanneer de lijst lang is"
 
 #: bika/lims/content/arreport.py:134
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: bika/lims/content/referencesample.py:105
 #: bika/lims/content/sampletype.py:127
 msgid "Hazardous"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #: bika/lims/browser/analyses/view.py:203
 #: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
-msgstr ""
+msgstr "Verborgen"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:60
 msgid "Hidden Field"
-msgstr ""
+msgstr "Verborgen veld"
 
 #: senaite/core/browser/modals/analysis/schema.py:114
 msgid "Hidden from report"
-msgstr ""
+msgstr "Verborgen in rapport"
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
-msgstr ""
+msgstr "Aanvullende velden verbergen"
 
 # senaite.app.listing: Column config — bulk action button
 msgid "Hide all"
-msgstr ""
+msgstr "Alles verbergen"
 
 #: senaite/core/api/remarks.py:487
 msgid "Hide history"
-msgstr ""
+msgstr "Geschiedenis verbergen"
 
 # senaite.app.listing: Column config — eye-slash button tooltip / aria-label
 msgid "Hide this column"
-msgstr ""
+msgstr "Deze kolom verbergen"
 
 #: bika/lims/config.py:140
 msgid "High"
-msgstr ""
+msgstr "Hoog"
 
 #: bika/lims/config.py:139
 msgid "Highest"
-msgstr ""
+msgstr "Hoogst"
 
 #: bika/lims/browser/fields/durationfield.py:37
 msgid "Hours"
@@ -2690,7 +2690,7 @@ msgstr "Uur"
 
 #: bika/lims/content/supplier.py:75
 msgid "IBN"
-msgstr ""
+msgstr "IBN"
 
 #: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_view.pt:43
@@ -2699,474 +2699,474 @@ msgstr "ID"
 
 #: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
-msgstr ""
+msgstr "ID-server"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:17
 msgid "ID Server Settings"
-msgstr ""
+msgstr "ID-serverinstellingen"
 
 #: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
-msgstr ""
+msgstr "ID-serverwaarden"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:113
 msgid "ID Template <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "ID-sjabloon <span class=\"sort-indicator\" />"
 
 #: bika/lims/content/samplepoint.py:84
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
-msgstr ""
+msgstr "Als er periodiek een monster wordt genomen op dit monsterpunt, voer hier de frequentie in, bijv. wekelijks"
 
 #: bika/lims/content/abstractbaseanalysis.py:317
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
-msgstr ""
+msgstr "Indien aangevinkt, wordt er een keuzelijst weergegeven naast het resultaatveld van de analyse in de resultaatinvoerweergaven. Met deze selector kan de analist de waarde instellen als detectielimiet (LDL of UDL) in plaats van een gewoon resultaat"
 
 #: bika/lims/content/instrument.py:187
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
-msgstr ""
+msgstr "Indien aangevinkt, is het instrument niet beschikbaar totdat de volgende geldige kalibratie is uitgevoerd. Dit selectievakje wordt automatisch uitgevinkt."
 
 #: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
-msgstr ""
+msgstr "Indien ingeschakeld, wordt er een vrijetekstveld weergegeven bij elke analyse in de resultaatinvoerweergave"
 
 #: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
-msgstr ""
+msgstr "Indien ingeschakeld, kan een gebruiker die een resultaat voor deze analyse heeft ingediend het ook verifiëren. Deze instelling geldt voor gebruikers met een toegewezen rol waarmee zij resultaten mogen verifiëren (standaard managers, labmanagers en verifiëerders). De hier ingestelde optie heeft voorrang op de optie die is ingesteld in Bika Setup"
 
 #: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-msgstr ""
+msgstr "Indien ingeschakeld, kan een gebruiker die een resultaat heeft ingediend het ook verifiëren. Deze instelling geldt alleen voor gebruikers met een toegewezen rol waarmee zij resultaten mogen verifiëren (standaard managers, labmanagers en verifiëerders). Deze instelling kan voor een bepaalde analyse worden overschreven in de bewerkweergave van de analysedienst. Standaard uitgeschakeld."
 
 #: bika/lims/content/abstractbaseanalysis.py:96
 msgid "If enabled, the name of the analysis will be written in italics."
-msgstr ""
+msgstr "Indien ingeschakeld, wordt de naam van de analyse cursief weergegeven."
 
 #: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
-msgstr ""
+msgstr "Indien ingeschakeld, worden deze analyse en de resultaten ervan standaard niet weergegeven in rapporten. Deze instelling kan worden overschreven in het analyseprofiel en/of monster"
 
 #: bika/lims/content/batch.py:138
 msgid "If no Title value is entered, the Batch ID will be used."
-msgstr ""
+msgstr "Als er geen titelwaarde wordt ingevoerd, wordt de batch-ID gebruikt."
 
 #: bika/lims/content/batch.py:134
 msgid "If no value is entered, the Batch ID will be auto-generated."
-msgstr ""
+msgstr "Als er geen waarde wordt ingevoerd, wordt de batch-ID automatisch gegenereerd."
 
 #: bika/lims/content/method.py:128
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
-msgstr ""
+msgstr "Selecteer indien nodig een berekening voor de analysediensten die aan deze methode zijn gekoppeld. Berekeningen kunnen worden geconfigureerd onder het item berekeningen in de LIMS-instellingen"
 
 #: senaite/core/content/interpretationtemplate.py:72
 msgid "If set, this interpretation template will only be available for selection on samples from these types"
-msgstr ""
+msgstr "Indien ingesteld, is dit interpretatiesjabloon alleen selecteerbaar voor monsters van deze types"
 
 #: senaite/core/content/interpretationtemplate.py:60
 msgid "If set, this interpretation template will only be available for selection on samples that have assigned any of these analysis templates"
-msgstr ""
+msgstr "Indien ingesteld, is dit interpretatiesjabloon alleen selecteerbaar voor monsters waaraan een van deze analysesjablonen is toegewezen"
 
 #: bika/lims/content/abstractbaseanalysis.py:69
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
-msgstr ""
+msgstr "Als hier tekst wordt ingevoerd, wordt deze in plaats van de titel gebruikt wanneer de dienst in kolomkoppen wordt vermeld. HTML-opmaak is toegestaan."
 
 #: senaite/core/exportimport/import.pt:74
 msgid "If the system doesn't find any match (Sample, Reference Analysis or Duplicate), it will use the record's identifier to find matches for Reference Sample IDs. <br /> If a Reference Sample ID is found, the system will automatically create a Calibration Test (Reference Analysis) and will link it to the selected Instrument."
-msgstr ""
+msgstr "Als het systeem geen overeenkomst vindt (monster, referentieanalyse of duplicaat), gebruikt het de identificatie van het record om overeenkomsten voor referentiemonster-ID's te vinden. <br /> Als er een referentiemonster-ID wordt gevonden, maakt het systeem automatisch een kalibratietest (referentieanalyse) aan en koppelt het deze aan het geselecteerde instrument."
 
 #: bika/lims/content/worksheettemplate.py:141
 msgid "If unchecked, Lab Managers won't be able to assign the same Instrument more than one Analyses while creating a Worksheet."
-msgstr ""
+msgstr "Indien niet aangevinkt, kunnen labmanagers hetzelfde instrument niet aan meer dan één analyse toewijzen bij het aanmaken van een werkblad."
 
 #: bika/lims/content/calculation.py:112
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
-msgstr ""
+msgstr "Als uw formule een speciale functie uit een externe Python-bibliotheek nodig heeft, kunt u die hier importeren. Bijvoorbeeld als u de functie 'floor' uit de Python-module 'math' wilt gebruiken, voegt u 'math' toe aan het veld Module en 'floor' aan het functieveld. Het equivalent in Python zou 'from math import floor' zijn. In uw berekening zou u dan 'floor([Ca] + [Mg])' kunnen gebruiken. "
 
 #: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
-msgstr ""
+msgstr "Directe invoer van resultaten"
 
 #: senaite/core/exportimport/import.pt:14
 #: senaite/core/profiles/default/actions.xml
 msgid "Import"
-msgstr ""
+msgstr "Importeren"
 
 #: bika/lims/content/instrument.py:235
 msgid "Import Data Interface"
-msgstr ""
+msgstr "Data-interface voor import"
 
 #: senaite/core/exportimport/instruments/importer.py:548
 msgid "Import finished successfully: {updated_ars} Samples and {updated_results} results updated"
-msgstr ""
+msgstr "Import succesvol voltooid: {updated_ars} Monsters en {updated_results} resultaten bijgewerkt"
 
 #: senaite/core/exportimport/instruments/importer.py:541
 msgid "Import finished successfully: {updated_ars} Samples, {updated_instruments} Instruments and {updated_results} results updated"
-msgstr ""
+msgstr "Import succesvol voltooid: {updated_ars} Monsters, {updated_instruments} Instrumenten en {updated_results} resultaten bijgewerkt"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:59
 msgid "Imported File"
-msgstr ""
+msgstr "Geïmporteerd bestand"
 
 #: bika/lims/content/instrument.py:200
 msgid "In-lab calibration procedure"
-msgstr ""
+msgstr "Kalibratieprocedure in het lab"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
 #: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
-msgstr ""
+msgstr "Inactief"
 
 #: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
-msgstr ""
+msgstr "Prijsinformatie opnemen en weergeven"
 
 #: bika/lims/content/pricelist.py:75
 msgid "Include descriptions"
-msgstr ""
+msgstr "Beschrijvingen opnemen"
 
 #: senaite/core/content/supplier.py:170
 msgid "Incorrect IBAN number: %s"
-msgstr ""
+msgstr "Onjuist IBAN-nummer: %s"
 
 #: senaite/core/content/supplier.py:132
 msgid "Incorrect NIB number: %s"
-msgstr ""
+msgstr "Onjuist NIB-nummer: %s"
 
 #: bika/lims/content/analysisrequest.py:1404
 msgid "Indicates if the last SampleReport is printed,"
-msgstr ""
+msgstr "Geeft aan of het laatste SampleReport is afgedrukt,"
 
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:22
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Initialize"
-msgstr ""
+msgstr "Initialiseren"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:13
 msgid "Install SENAITE LIMS"
-msgstr ""
+msgstr "SENAITE LIMS installeren"
 
 #: bika/lims/content/instrument.py:356
 msgid "Installation Certificate"
-msgstr ""
+msgstr "Installatiecertificaat"
 
 #: bika/lims/content/instrument.py:357
 msgid "Installation certificate upload"
-msgstr ""
+msgstr "Installatiecertificaat uploaden"
 
 #: bika/lims/content/instrument.py:347
 msgid "InstallationDate"
-msgstr ""
+msgstr "InstallationDate"
 
 #: bika/lims/content/method.py:77
 msgid "Instructions"
-msgstr ""
+msgstr "Instructies"
 
 #: bika/lims/content/instrument.py:201
 msgid "Instructions for in-lab regular calibration routines intended for analysts"
-msgstr ""
+msgstr "Instructies voor reguliere kalibratieroutines in het lab, bedoeld voor analisten"
 
 #: bika/lims/content/instrument.py:213
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
-msgstr ""
+msgstr "Instructies voor reguliere preventieve en onderhoudsroutines, bedoeld voor analisten"
 
 #: senaite/core/browser/modals/analysis/schema.py:78
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:107
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:64
 msgid "Instrument"
-msgstr ""
+msgstr "Instrument"
 
 #: senaite/core/browser/form/adapters/method.py:74
 msgid "Instrument '{}' is used by service '{}'"
-msgstr ""
+msgstr "Instrument '{}' wordt gebruikt door dienst '{}'"
 
 #: bika/lims/browser/instrument.py:193
 msgid "Instrument Calibrations"
-msgstr ""
+msgstr "Instrumentkalibraties"
 
 #: bika/lims/browser/instrument.py:791
 msgid "Instrument Files"
-msgstr ""
+msgstr "Instrumentbestanden"
 
 #: senaite/core/exportimport/import.pt:37
 msgid "Instrument Import"
-msgstr ""
+msgstr "Instrumentimport"
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 msgid "Instrument Location"
-msgstr ""
+msgstr "Instrumentlocatie"
 
 #: senaite/core/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
-msgstr ""
+msgstr "Instrumentlocaties"
 
 #: bika/lims/browser/instrument.py:65
 msgid "Instrument Maintenance"
-msgstr ""
+msgstr "Instrumentonderhoud"
 
 #: bika/lims/browser/instrument.py:382
 msgid "Instrument Scheduled Tasks"
-msgstr ""
+msgstr "Geplande instrumenttaken"
 
 #: bika/lims/browser/instrument.py:290
 msgid "Instrument Validations"
-msgstr ""
+msgstr "Instrumentvalidaties"
 
 #: bika/lims/content/abstractbaseanalysis.py:392
 msgid "Instrument assignment is allowed"
-msgstr ""
+msgstr "Instrumenttoewijzing is toegestaan"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:35
 msgid "Instrument disabled until successful calibration:"
-msgstr ""
+msgstr "Instrument uitgeschakeld tot succesvolle kalibratie:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:54
 msgid "Instrument disposed until new calibration tests being done:"
-msgstr ""
+msgstr "Instrument afgevoerd tot nieuwe kalibratietests zijn uitgevoerd:"
 
 #: bika/lims/browser/worksheet/views/export.py:53
 msgid "Instrument exporter not found"
-msgstr ""
+msgstr "Instrumentexporteur niet gevonden"
 
 #: bika/lims/browser/workflow/analysis.py:141
 msgid "Instrument failed reference test"
-msgstr ""
+msgstr "Instrument is niet geslaagd voor referentietest"
 
 #: bika/lims/browser/worksheet/views/export.py:40
 msgid "Instrument has no data interface selected"
-msgstr ""
+msgstr "Voor het instrument is geen data-interface geselecteerd"
 
 #: senaite/core/browser/form/adapters/data_import.py:96
 msgid "Instrument import finished"
-msgstr ""
+msgstr "Instrumentimport voltooid"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:92
 msgid "Instrument in calibration progress:"
-msgstr ""
+msgstr "Instrument in kalibratieproces:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:73
 msgid "Instrument in validation progress:"
-msgstr ""
+msgstr "Instrument in validatieproces:"
 
 #: senaite/core/exportimport/instruments/importer.py:402
 msgid "Instrument not found"
-msgstr ""
+msgstr "Instrument niet gevonden"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:16
 msgid "Instrument's calibration certificate expired:"
-msgstr ""
+msgstr "Kalibratiecertificaat van instrument verlopen:"
 
 #: senaite/core/profiles/default/types/InstrumentType.xml
 msgid "InstrumentType"
-msgstr ""
+msgstr "InstrumentType"
 
 #: senaite/core/profiles/default/types/InstrumentTypes.xml
 msgid "InstrumentTypes"
-msgstr ""
+msgstr "InstrumentTypes"
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 #: senaite/core/profiles/default/types/InstrumentType.xml
 #: senaite/core/profiles/default/types/Manufacturer.xml
 msgid "Instruments"
-msgstr ""
+msgstr "Instrumenten"
 
 #: senaite/core/exportimport/import.pt:162
 msgid "Instruments can be configured with one or multiple import data interfaces."
-msgstr ""
+msgstr "Instrumenten kunnen worden geconfigureerd met één of meerdere data-interfaces voor import."
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:39
 msgid "Instruments disabled until successful calibration:"
-msgstr ""
+msgstr "Instrumenten uitgeschakeld tot succesvolle kalibratie:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:58
 msgid "Instruments disposed until new calibration tests being done:"
-msgstr ""
+msgstr "Instrumenten afgevoerd tot nieuwe kalibratietests zijn uitgevoerd:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:96
 msgid "Instruments in calibration progress:"
-msgstr ""
+msgstr "Instrumenten in kalibratieproces:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:77
 msgid "Instruments in validation progress:"
-msgstr ""
+msgstr "Instrumenten in validatieproces:"
 
 #: bika/lims/content/method.py:103
 msgid "Instruments supporting this method"
-msgstr ""
+msgstr "Instrumenten die deze methode ondersteunen"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:20
 msgid "Instruments' calibration certificates expired:"
-msgstr ""
+msgstr "Kalibratiecertificaten van instrumenten verlopen:"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:55
 msgid "Interface"
-msgstr ""
+msgstr "Interface"
 
 #: bika/lims/browser/instrument.py:494
 msgid "Internal Calibration Tests"
-msgstr ""
+msgstr "Interne kalibratietests"
 
 #: bika/lims/content/instrumentcertification.py:84
 msgid "Internal Certificate"
-msgstr ""
+msgstr "Intern certificaat"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
 #: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
-msgstr ""
+msgstr "Intern gebruik"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:42
 #: bika/lims/browser/templates/referencesample_analyses.pt:40
 msgid "Interpolation"
-msgstr ""
+msgstr "Interpolatie"
 
 #: senaite/core/profiles/default/types/InterpretationTemplate.xml
 msgid "Interpretation Template"
-msgstr ""
+msgstr "Interpretatiesjabloon"
 
 #: senaite/core/profiles/default/types/InterpretationTemplates.xml
 msgid "Interpretation Templates"
-msgstr ""
+msgstr "Interpretatiesjablonen"
 
 #: bika/lims/content/instrumentcertification.py:110
 msgid "Interval"
-msgstr ""
+msgstr "Interval"
 
 #: senaite/core/browser/dashboard/dashboard.py:168
 #: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
-msgstr ""
+msgstr "Ongeldig"
 
 #: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
-msgstr ""
+msgstr "Ongeldig ID-formaat op rij ${i} ('${pt}'): ${err}"
 
 #: senaite/core/content/person.py:236
 msgid "Invalid email address"
-msgstr ""
+msgstr "Ongeldig e-mailadres"
 
 #: senaite/core/content/dynamicanalysisspec.py:65
 msgid "Invalid specifications file detected. Please upload an Excel spreadsheet with at least the following columns defined: '{}', "
-msgstr ""
+msgstr "Ongeldig specificatiebestand gedetecteerd. Upload een Excel-spreadsheet waarin ten minste de volgende kolommen zijn gedefinieerd: '{}', "
 
 #: bika/lims/validators.py:1324
 msgid "Invalid value: Please enter a value without spaces."
-msgstr ""
+msgstr "Ongeldige waarde: Voer een waarde zonder spaties in."
 
 #: bika/lims/validators.py:528
 msgid "Invalid wildcards found: ${wildcards}"
-msgstr ""
+msgstr "Ongeldige jokertekens gevonden: ${wildcards}"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:152
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalidate"
-msgstr ""
+msgstr "Ongeldig maken"
 
 #: bika/lims/browser/workflow/analysisrequest.py:162
 msgid "Invalidated items: {}"
-msgstr ""
+msgstr "Ongeldig gemaakte items: {}"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:90
 msgid "Invalidation reason"
-msgstr ""
+msgstr "Reden voor ongeldigverklaring"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:18
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 #: bika/lims/profiles/default/types/Invoice.xml
 msgid "Invoice"
-msgstr ""
+msgstr "Factuur"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:55
 msgid "Invoice Date"
-msgstr ""
+msgstr "Factuurdatum"
 
 #: bika/lims/content/analysisrequest.py:973
 msgid "Invoice Exclude"
-msgstr ""
+msgstr "Uitsluiten van facturatie"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:44
 msgid "Invoice ID"
-msgstr ""
+msgstr "Factuur-ID"
 
 #: bika/lims/content/invoice.py:41
 msgid "Invoice PDF"
-msgstr ""
+msgstr "Factuur-PDF"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:35
 msgid "Invoice To"
-msgstr ""
+msgstr "Factureren aan"
 
 #: bika/lims/browser/analysisrequest/invoice.py:187
 msgid "Invoice {} created"
-msgstr ""
+msgstr "Factuur {} aangemaakt"
 
 #: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
-msgstr ""
+msgstr "InvoiceBatch heeft geen einddatum"
 
 #: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
-msgstr ""
+msgstr "InvoiceBatch heeft geen startdatum"
 
 #: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
-msgstr ""
+msgstr "InvoiceBatch heeft geen titel"
 
 #: senaite/core/config/widgets.py:60
 msgid "Job Title"
-msgstr ""
+msgstr "Functietitel"
 
 #: bika/lims/content/person.py:141
 msgid "Job title"
-msgstr ""
+msgstr "Functietitel"
 
 #: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
-msgstr ""
+msgstr "Volgorde hierboven behouden"
 
 #: bika/lims/content/instrument.py:287
 msgid "Key"
-msgstr ""
+msgstr "Sleutel"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:98
 msgid "Key <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Sleutel <span class=\"sort-indicator\" />"
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
 msgid "Keyword"
-msgstr ""
+msgstr "Sleutelwoord"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:51
 msgid "Keyword is used in active analyses and can not be changed anymore"
-msgstr ""
+msgstr "Sleutelwoord wordt gebruikt in actieve analyses en kan niet meer worden gewijzigd"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:187
 msgid "Keyword required"
-msgstr ""
+msgstr "Sleutelwoord vereist"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
-msgstr ""
+msgstr "Sleutelwoorden"
 
 #: senaite/core/browser/samples/view.py:249
 msgid "Keywords of the analyses contained in the sample"
-msgstr ""
+msgstr "Sleutelwoorden van de analyses in het monster"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
 #: bika/lims/content/analysisspec.py:142
 msgid "Lab"
-msgstr ""
+msgstr "Lab"
 
 #: bika/lims/content/supplier.py:98
 msgid "Lab Account Number"
-msgstr ""
+msgstr "Lab-rekeningnummer"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:134
 msgid "Lab Analyses"
@@ -3174,7 +3174,7 @@ msgstr "Lab Analyses"
 
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
-msgstr ""
+msgstr "Labcontact"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:65
 #: bika/lims/profiles/default/types/LabContacts.xml
@@ -3187,11 +3187,11 @@ msgstr "Lab afdelingen"
 
 #: bika/lims/config.py:57
 msgid "Lab Preservation"
-msgstr ""
+msgstr "Labconservering"
 
 #: senaite/core/profiles/default/types/LabProduct.xml
 msgid "Lab Product"
-msgstr ""
+msgstr "Labproduct"
 
 #: senaite/core/profiles/default/types/LabProducts.xml
 msgid "Lab Products"
@@ -3205,29 +3205,29 @@ msgstr "Lab URL"
 #: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
-msgstr ""
+msgstr "Label"
 
 #: senaite/core/registry/schema.py:69
 msgid "Label configuration"
-msgstr ""
+msgstr "Labelconfiguratie"
 
 #: senaite/core/content/label.py:93
 msgid "Label names must be unique"
-msgstr ""
+msgstr "Labelnamen moeten uniek zijn"
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Label schema extender"
-msgstr ""
+msgstr "Labelschema-uitbreider"
 
 #: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
-msgstr ""
+msgstr "Gelabelde objecten"
 
 #: senaite/core/browser/controlpanel/labels/view.py:52
 #: senaite/core/browser/label/labeled_objects.py:66
 #: senaite/core/browser/samples/view.py:875
 msgid "Labels"
-msgstr ""
+msgstr "Labels"
 
 #: senaite/core/content/laboratory.py:244
 #: senaite/core/profiles/default/types/Laboratory.xml
@@ -3240,27 +3240,27 @@ msgstr "Geaccrediteerd laboratorium"
 
 #: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
-msgstr ""
+msgstr "Werkdagen laboratorium"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:74
 msgid "Language"
-msgstr ""
+msgstr "Taal"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Large Sticker"
-msgstr ""
+msgstr "Grote sticker"
 
 #: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
-msgstr ""
+msgstr "Sjabloon grote sticker"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:42
 msgid "Last Auto-Import Logs"
-msgstr ""
+msgstr "Logboeken laatste automatische import"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:97
 msgid "Last Login Time"
-msgstr ""
+msgstr "Tijdstip laatste aanmelding"
 
 #: senaite/core/browser/samples/view.py:469
 msgid "Late"
@@ -3280,106 +3280,106 @@ msgstr "Latitude"
 
 #: senaite/core/schema/gpscoordinatesfield.py:103
 msgid "Latitude must be within -90 and 90 degrees"
-msgstr ""
+msgstr "Breedtegraad moet tussen -90 en 90 graden liggen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:104
 msgid "Layout"
-msgstr ""
+msgstr "Lay-out"
 
 #: bika/lims/browser/worksheet/views/results.py:68
 msgid "Layout view '{}' not found. Set '{}' as layout view."
-msgstr ""
+msgstr "Lay-outweergave '{}' niet gevonden. Stel '{}' in als lay-outweergave."
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:63
 msgid "Legacy LIMS Setup"
-msgstr ""
+msgstr "Verouderde LIMS-instellingen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:153
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:120
 msgid "Legend: Results in <em>italic</em> font are pending, results in <strong>bold</strong> font are verified."
-msgstr ""
+msgstr "Legenda: Resultaten in <em>cursief</em> zijn in behandeling, resultaten in <strong>vet</strong> zijn geverifieerd."
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:46
 #: bika/lims/browser/templates/referencesample_analyses.pt:44
 msgid "Linear"
-msgstr ""
+msgstr "Lineair"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:203
 msgid "Link User"
-msgstr ""
+msgstr "Gebruiker koppelen"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:144
 msgid "Link an existing User"
-msgstr ""
+msgstr "Een bestaande gebruiker koppelen"
 
 #: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
-msgstr ""
+msgstr "Alle objecten met labels weergeven"
 
 #: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
-msgstr ""
+msgstr "Lijst van mogelijke eindresultaten. Indien ingesteld, is geen aangepast resultaat toegestaan bij de resultaatinvoer en moet de gebruiker uit deze waarden kiezen"
 
 #: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
-msgstr ""
+msgstr "Lijst van vooraf gedefinieerde afwijzingsredenen. Voer één reden per regel in."
 
 #: senaite/core/exportimport/import.pt:47
 msgid "Load Setup Data"
-msgstr ""
+msgstr "Instellingsgegevens laden"
 
 #: bika/lims/content/method.py:89
 msgid "Load documents describing the method here"
-msgstr ""
+msgstr "Laad hier documenten die de methode beschrijven"
 
 #: senaite/core/exportimport/import.pt:121
 msgid "Load from file"
-msgstr ""
+msgstr "Laden uit bestand"
 
 #: bika/lims/content/instrumentcertification.py:195
 msgid "Load the certificate document here"
-msgstr ""
+msgstr "Laad hier het certificaatdocument"
 
 # senaite.core: Sidebar loading state
 msgid "Loading navigation..."
-msgstr ""
+msgstr "Navigatie laden..."
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
-msgstr ""
+msgstr "Laden..."
 
 #: senaite/core/browser/clients/client/attachments/view.py:79
 #: senaite/core/browser/controlpanel/contacts/view.py:70
 msgid "Location"
-msgstr ""
+msgstr "Locatie"
 
 #: bika/lims/content/storagelocation.py:58
 msgid "Location Code"
-msgstr ""
+msgstr "Locatiecode"
 
 #: bika/lims/content/storagelocation.py:63
 msgid "Location Description"
-msgstr ""
+msgstr "Locatiebeschrijving"
 
 #: bika/lims/content/storagelocation.py:53
 msgid "Location Title"
-msgstr ""
+msgstr "Locatietitel"
 
 #: bika/lims/content/storagelocation.py:68
 msgid "Location Type"
-msgstr ""
+msgstr "Locatietype"
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
-msgstr ""
+msgstr "Locatie waar de documentenset is opgeborgen"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Lock"
-msgstr ""
+msgstr "Vergrendelen"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Locked"
-msgstr ""
+msgstr "Vergrendeld"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3396,7 +3396,7 @@ msgstr "Lengtegraad"
 
 #: senaite/core/schema/gpscoordinatesfield.py:110
 msgid "Longitude must be within -180 and 180 degrees"
-msgstr ""
+msgstr "Lengtegraad moet tussen -180 en 180 graden liggen"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:62
@@ -3406,11 +3406,11 @@ msgstr "Lotnummer"
 
 #: bika/lims/config.py:142
 msgid "Low"
-msgstr ""
+msgstr "Laag"
 
 #: bika/lims/config.py:143
 msgid "Lowest"
-msgstr ""
+msgstr "Laagste"
 
 #: bika/lims/config.py:82
 msgid "Mailing address"
@@ -3419,20 +3419,20 @@ msgstr "Mailing adres"
 #: bika/lims/browser/instrument.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:83
 msgid "Maintainer"
-msgstr ""
+msgstr "Beheerder"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Maintenance"
-msgstr ""
+msgstr "Onderhoud"
 
 #. Default: "Type"
 #: bika/lims/content/instrumentmaintenancetask.py:55
 msgid "Maintenance type"
-msgstr ""
+msgstr "Type"
 
 #: bika/lims/content/abstractbaseanalysis.py:349
 msgid "Make attachments mandatory for verification"
-msgstr ""
+msgstr "Bijlagen verplicht maken voor verificatie"
 
 #: bika/lims/config.py:76
 msgid "Male"
@@ -3441,43 +3441,43 @@ msgstr "Mannetje"
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:14
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Manage Analyses"
-msgstr ""
+msgstr "Analyses beheren"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
-msgstr ""
+msgstr "Formuliervelden beheren"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:12
 msgid "Manage Number Generator"
-msgstr ""
+msgstr "Nummergenerator beheren"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:21
 msgid "Manage Partitions"
-msgstr ""
+msgstr "Partities beheren"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Manage Results"
-msgstr ""
+msgstr "Resultaten beheren"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:10
 msgid "Manage Sample Form Fields"
-msgstr ""
+msgstr "Monsterformuliervelden beheren"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:41
 msgid "Manage linked User"
-msgstr ""
+msgstr "Gekoppelde gebruiker beheren"
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
-msgstr ""
+msgstr "Monstervelden beheren"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:38
 msgid "Manage the order and visibility of the fields displayed in analysis request add forms."
-msgstr ""
+msgstr "Beheer de volgorde en zichtbaarheid van de velden die worden weergegeven in de toevoegformulieren voor analyseaanvragen."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:16
 msgid "Manage the order and visibility of the sample fields."
-msgstr ""
+msgstr "Beheer de volgorde en zichtbaarheid van de monstervelden."
 
 #: senaite/core/browser/controlpanel/departments/view.py:75
 msgid "Manager"
@@ -3493,20 +3493,20 @@ msgstr "Manager telefoon"
 
 #: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
-msgstr ""
+msgstr "Handmatig"
 
 #: bika/lims/content/abstractbaseanalysis.py:378
 #: bika/lims/content/method.py:148
 msgid "Manual entry of results"
-msgstr ""
+msgstr "Handmatige invoer van resultaten"
 
 #: bika/lims/browser/publish/reports_listing.py:161
 msgid "Manually publish all contained samples of the selected reports."
-msgstr ""
+msgstr "Publiceer handmatig alle monsters in de geselecteerde rapporten."
 
 #: senaite/core/exportimport/import.pt:192
 msgid "Manually trigger auto import"
-msgstr ""
+msgstr "Automatische import handmatig starten"
 
 #: senaite/core/profiles/default/types/Manufacturer.xml
 msgid "Manufacturer"
@@ -3514,11 +3514,11 @@ msgstr "Fabrikant"
 
 #: senaite/core/profiles/default/types/Manufacturers.xml
 msgid "Manufacturers"
-msgstr ""
+msgstr "Fabrikanten"
 
 #: bika/lims/content/analysisrequest.py:1417
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
-msgstr ""
+msgstr "Markeer het monster als uitsluitend voor intern gebruik. Dit betekent dat het alleen toegankelijk is voor labpersoneel en niet voor klanten."
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
@@ -3533,25 +3533,25 @@ msgstr "Max tijd"
 #: bika/lims/browser/fields/resultrangefield.py:36
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:121
 msgid "Max operator"
-msgstr ""
+msgstr "Max-operator"
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
-msgstr ""
+msgstr "Max-waarschuwing"
 
 #: senaite/core/content/samplecontainer.py:79
 msgid "Maximum possible size or volume of samples"
-msgstr ""
+msgstr "Maximaal mogelijke grootte of volume van monsters"
 
 #: bika/lims/content/container.py:75
 msgid "Maximum possible size or volume of samples."
-msgstr ""
+msgstr "Maximaal mogelijke grootte of volume van monsters."
 
 #: bika/lims/content/abstractbaseanalysis.py:443
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
-msgstr ""
+msgstr "Maximaal toegestane tijd voor het voltooien van de analyse. Er wordt een waarschuwing voor een te late analyse gegeven wanneer deze periode verstrijkt"
 
 #: bika/lims/content/abstractbaseanalysis.py:442
 msgid "Maximum turn-around time"
@@ -3559,15 +3559,15 @@ msgstr "Maximale turn-around tijd"
 
 #: bika/lims/config.py:141
 msgid "Medium"
-msgstr ""
+msgstr "Gemiddeld"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:153
 msgid "Meet the community, browse the code and get support on"
-msgstr ""
+msgstr "Ontmoet de community, bekijk de code en krijg ondersteuning op"
 
 #: bika/lims/browser/clientfolder.py:94
 msgid "Member Discount"
-msgstr ""
+msgstr "Ledenkorting"
 
 #: bika/lims/content/analysisrequest.py:1119
 #: bika/lims/content/bikasetup.py:282
@@ -3580,15 +3580,15 @@ msgstr "Lid korting geldt"
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
-msgstr ""
+msgstr "Lid geregistreerd en gekoppeld aan het huidige contact."
 
 #: bika/lims/browser/publish/emailview.py:146
 msgid "Message sent to {}, "
-msgstr ""
+msgstr "Bericht verzonden naar {}, "
 
 #: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
-msgstr ""
+msgstr "Metadata"
 
 #: senaite/core/browser/modals/analysis/schema.py:69
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:103
@@ -3601,3671 +3601,3674 @@ msgstr "Methode Document"
 
 #: bika/lims/content/method.py:56
 msgid "Method ID"
-msgstr ""
+msgstr "Methode-ID"
 
 #: bika/lims/browser/methodfolder.py:48
 #: bika/lims/browser/templates/analysisservice_info.pt:119
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:80
 msgid "Methods"
-msgstr ""
+msgstr "Methoden"
 
 #: bika/lims/content/person.py:59
 msgid "Middle initial"
-msgstr ""
+msgstr "Tweede voorletter"
 
 #: bika/lims/content/person.py:67
 msgid "Middle name"
-msgstr ""
+msgstr "Tweede naam"
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
-msgstr ""
+msgstr "Min"
 
 #: bika/lims/browser/fields/resultrangefield.py:34
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:106
 msgid "Min operator"
-msgstr ""
+msgstr "Min-operator"
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
-msgstr ""
+msgstr "Min-waarschuwing"
 
 #: bika/lims/browser/worksheet/views/folder.py:183
 msgid "Mine"
-msgstr ""
+msgstr "Van mij"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:245
 msgid "Minimum 5 characters."
-msgstr ""
+msgstr "Minimaal 5 tekens."
 
 #: bika/lims/content/sampletype.py:165
 msgid "Minimum Volume"
-msgstr ""
+msgstr "Minimumvolume"
 
 #: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
-msgstr ""
+msgstr "Minimumaantal resultaten voor QC-statistiekberekeningen"
 
 #: bika/lims/browser/fields/coordinatefield.py:37
 #: bika/lims/browser/fields/durationfield.py:38
 msgid "Minutes"
-msgstr ""
+msgstr "Minuten"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:92
 msgid "Mobile Phone"
-msgstr ""
+msgstr "Mobiele telefoon"
 
 #: senaite/core/browser/clients/client/contacts/view.py:80
 #: senaite/core/browser/controlpanel/contacts/view.py:68
 msgid "MobilePhone"
-msgstr ""
+msgstr "MobilePhone"
 
 #: bika/lims/content/instrument.py:137
 #: bika/lims/controlpanel/bika_instruments.py:84
 msgid "Model"
-msgstr ""
+msgstr "Model"
 
 #: bika/lims/content/calculation.py:100
 msgid "Module"
-msgstr ""
+msgstr "Module"
 
 #: senaite/core/vocabularies/setup.py:156
 msgid "Monday"
-msgstr ""
+msgstr "Maandag"
 
 #: senaite/core/browser/dashboard/dashboard.py:137
 msgid "Monthly"
-msgstr ""
+msgstr "Maandelijks"
 
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
-msgstr ""
+msgstr "Meer dan één analyse gevonden voor {sid} en sleutelwoord '{keyword}'"
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Multi Catalog Behavior for Dexterity Contents"
-msgstr ""
+msgstr "Multi-catalogusgedrag voor Dexterity-inhoud"
 
 #: senaite/core/browser/samples/multi_results_transposed.py:66
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Multi Results"
-msgstr ""
+msgstr "Meerdere resultaten"
 
 #: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
-msgstr ""
+msgstr "Type multi-verificatie"
 
 #: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
-msgstr ""
+msgstr "Multi-verificatie vereist"
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "Multifile"
-msgstr ""
+msgstr "Meerdere bestanden"
 
 #: senaite/core/config/vocabularies.py:60
 msgid "Multiple choices"
-msgstr ""
+msgstr "Meerdere keuzes"
 
 #: senaite/core/config/vocabularies.py:58
 msgid "Multiple selection"
-msgstr ""
+msgstr "Meervoudige selectie"
 
 #: senaite/core/config/vocabularies.py:59
 msgid "Multiple selection (with duplicates)"
-msgstr ""
+msgstr "Meervoudige selectie (met duplicaten)"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:108
 msgid "Multiple values"
-msgstr ""
+msgstr "Meerdere waarden"
 
 #: bika/lims/validators.py:469
 msgid "Multiple values control type is not supported for choices"
-msgstr ""
+msgstr "Het besturingstype met meerdere waarden wordt niet ondersteund voor keuzes"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Organization"
-msgstr ""
+msgstr "Mijn organisatie"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Profile"
-msgstr ""
+msgstr "Mijn profiel"
 
 # senaite.app.listing: Saved filter presets — default name when saving
 msgid "My filter"
-msgstr ""
+msgstr "Mijn filter"
 
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
-msgstr ""
+msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
 #: senaite/core/content/contact.py:146
 msgid "Name"
-msgstr ""
+msgstr "Naam"
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:67
 msgid "New LIMS Setup"
-msgstr ""
+msgstr "Nieuwe LIMS-instellingen"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
-msgstr ""
+msgstr "Nieuwe bereiken worden noch op nieuwe noch op huidige analyses toegepast. Wijs de specificatie opnieuw toe als u de laatste wijzigingen wilt toepassen."
 
 #: senaite/core/api/remarks.py:490
 msgid "Newest first"
-msgstr ""
+msgstr "Nieuwste eerst"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Volgende ID <span class=\"sort-indicator\" />"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:168
 #: senaite/core/browser/widgets/services_widget.py:305
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:9
 msgid "No"
-msgstr ""
+msgstr "Nee"
 
 #: senaite/core/exportimport/instruments/eltra/cs/cs2000.py:51
 msgid "No Analysis Services defined"
-msgstr ""
+msgstr "Geen analysediensten gedefinieerd"
 
 #: bika/lims/browser/publish/templates/email.pt:70
 msgid "No Email Address"
-msgstr ""
+msgstr "Geen e-mailadres"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:43
 msgid "No Method selected for this Service"
-msgstr ""
+msgstr "Geen methode geselecteerd voor deze dienst"
 
 #: senaite/core/exportimport/instruments/importer.py:415
 msgid "No Sample found for {sid}"
-msgstr ""
+msgstr "Geen monster gevonden voor {sid}"
 
 #: senaite/core/exportimport/instruments/importer.py:403
 msgid "No Sample with '{allowed_ar_states}' statesfound, and no QC analyses found for {sid}, "
-msgstr ""
+msgstr "Geen monster met status '{allowed_ar_states}' gevonden, en geen QC-analyses gevonden voor {sid}, "
 
 #: bika/lims/browser/analysisrequest/add2.py:2189
 msgid "No Samples could be created."
-msgstr ""
+msgstr "Er konden geen monsters worden aangemaakt."
 
 #: bika/lims/browser/batch/batchbook.py:175
 msgid "No Subgroup"
-msgstr ""
+msgstr "Geen subgroep"
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
-msgstr ""
+msgstr "Geen actie gedefinieerd."
 
 #: senaite/core/browser/dashboard/dashboard.py:131
 msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
-msgstr ""
+msgstr "Geen acties beschikbaar. Neem contact op met uw laboratoriummanager om rechten toegewezen te krijgen."
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
-msgstr ""
+msgstr "Geen analyses gevonden voor {sid} en sleutelwoord '{keyword}'"
 
 #: senaite/core/exportimport/instruments/importer.py:434
 msgid "No analyses found for {sid} in the states '{allowed_sample_states}' , "
-msgstr ""
+msgstr "Geen analyses gevonden voor {sid} in de statussen '{allowed_sample_states}' , "
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:75
 msgid "No analyses were added"
-msgstr ""
+msgstr "Er zijn geen analyses toegevoegd"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:152
 msgid "No analyses were added to this worksheet."
-msgstr ""
+msgstr "Er zijn geen analyses aan dit werkblad toegevoegd."
 
 #: senaite/core/browser/attachment/attachment.py:219
 msgid "No analysis found for service '{}'"
-msgstr ""
+msgstr "Geen analyse gevonden voor dienst '{}'"
 
 #: senaite/core/exportimport/instruments/biodrop/ulite/ulite.py:53
 #: senaite/core/exportimport/instruments/lifetechnologies/qubit/qubit.py:54
 msgid "No analysis selected"
-msgstr ""
+msgstr "Geen analyse geselecteerd"
 
 #: senaite/core/exportimport/instruments/thermoscientific/multiskan/go.py:51
 msgid "No analysis service selected"
-msgstr ""
+msgstr "Geen analysedienst geselecteerd"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:27
 msgid "No analysis services were selected."
-msgstr ""
+msgstr "Er zijn geen analysediensten geselecteerd."
 
 #: senaite/core/browser/idserver/view.py:135
 msgid "No changes"
-msgstr ""
+msgstr "Geen wijzigingen"
 
 #: senaite/core/browser/workflow/worksheet.py:50
 msgid "No changes made"
-msgstr ""
+msgstr "Geen wijzigingen aangebracht"
 
 #: bika/lims/browser/workflow/__init__.py:166
 #: bika/lims/browser/workflow/analysisrequest.py:94
 msgid "No changes made."
-msgstr ""
+msgstr "Geen wijzigingen aangebracht."
 
 #: senaite/core/browser/dashboard/dashboard.py:130
 msgid "No data for the selected period"
-msgstr ""
+msgstr "Geen gegevens voor de geselecteerde periode"
 
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
-msgstr ""
+msgstr "Geen datum ingesteld"
 
 #: bika/lims/browser/workflow/analysisrequest.py:435
 msgid "No duplicate created"
-msgstr ""
+msgstr "Geen duplicaat aangemaakt"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:135
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:138
 msgid "No email recipients available for this sample"
-msgstr ""
+msgstr "Geen e-mailontvangers beschikbaar voor dit monster"
 
 #: bika/lims/browser/publish/emailview.py:167
 msgid "No email recipients selected"
-msgstr ""
+msgstr "Geen e-mailontvangers geselecteerd"
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:47
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:59
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:47
 msgid "No file selected"
-msgstr ""
+msgstr "Geen bestand geselecteerd"
 
 #: senaite/core/browser/form/adapters/data_import.py:81
 msgid "No importer not found for interface '{}'"
-msgstr ""
+msgstr "Geen importeur gevonden voor interface '{}'"
 
 #: senaite/core/browser/form/adapters/data_import.py:126
 msgid "No instrument import interfaces available for {}"
-msgstr ""
+msgstr "Geen instrumentimportinterfaces beschikbaar voor {}"
 
 #: bika/lims/browser/workflow/client.py:120
 msgid "No items published"
-msgstr ""
+msgstr "Geen items gepubliceerd"
 
 #: senaite/core/browser/samples/partition_magic.py:64
 #: senaite/core/browser/samples/rejection/reject_samples.py:78
 msgid "No items selected"
-msgstr ""
+msgstr "Geen items geselecteerd"
 
 #: bika/lims/browser/workflow/__init__.py:129
 msgid "No items selected."
-msgstr ""
+msgstr "Geen items geselecteerd."
 
 # senaite.app.listing: Column config — empty state for hidden section with
 # search
 msgid "No matches in hidden columns."
-msgstr ""
+msgstr "Geen overeenkomsten in verborgen kolommen."
 
 # senaite.app.listing: Column config — empty state for visible section with
 # search
 msgid "No matches in visible columns."
-msgstr ""
+msgstr "Geen overeenkomsten in zichtbare kolommen."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
-msgstr ""
+msgstr "Er zijn geen nieuwe items aangemaakt."
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
-msgstr ""
+msgstr "Er zijn geen partities aangemaakt"
 
 #: senaite/core/api/remarks.py:493
 msgid "No remarks yet"
-msgstr ""
+msgstr "Nog geen opmerkingen"
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
-msgstr ""
+msgstr "Geen rapporten gevonden"
 
 #: senaite/core/browser/samples/invalidate_samples.py:110
 msgid "No samples were invalidated. Please ensure samples are selected and meet the criteria for invalidation."
-msgstr ""
+msgstr "Er zijn geen monsters ongeldig gemaakt. Zorg ervoor dat er monsters zijn geselecteerd die aan de criteria voor ongeldigverklaring voldoen."
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:112
 msgid "No samples were rejected"
-msgstr ""
+msgstr "Er zijn geen monsters afgewezen"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
-msgstr ""
+msgstr "Geen monsternameworkflow"
 
 # senaite.app.listing: Saved filter presets — empty state
 msgid "No saved filters yet."
-msgstr ""
+msgstr "Nog geen opgeslagen filters."
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
-msgstr ""
+msgstr "Er konden geen diensten worden gevonden voor de verwerkte sleutelwoorden"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:133
 msgid "No user exists for ${contact_fullname} and they will not be able to log in. Fill in the form below to create one for them."
-msgstr ""
+msgstr "Er bestaat geen gebruiker voor ${contact_fullname} en deze zal niet kunnen aanmelden. Vul het onderstaande formulier in om er een voor hen aan te maken."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:49
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
-msgstr ""
+msgstr "Er kon geen gebruikersprofiel worden gevonden voor de gekoppelde gebruiker. Neem contact op met de labbeheerder voor verdere ondersteuning of probeer de gebruiker opnieuw te koppelen."
 
 #: bika/lims/browser/analysisrequest/add2.py:2057
 msgid "No valid contact"
-msgstr ""
+msgstr "Geen geldig contact"
 
 #: bika/lims/validators.py:448
 msgid "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
-msgstr ""
+msgstr "Geen geldig formaat in het keuzeveld. Ondersteund formaat is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:115
 msgid "No visible analyses for this sample"
-msgstr ""
+msgstr "Geen zichtbare analyses voor dit monster"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
 #: senaite/core/content/senaitesetup.py:1141
 msgid "None"
-msgstr ""
+msgstr "Geen"
 
 #: bika/lims/browser/publish/emailview.py:216
 msgid "Not all contacts are equal for the selected Reports. Please manually select recipients for this email."
-msgstr ""
+msgstr "Niet alle contacten zijn gelijk voor de geselecteerde rapporten. Selecteer de ontvangers voor deze e-mail handmatig."
 
 #: senaite/core/browser/modals/conditions.py:133
 msgid "Not allowed to update conditions: {}"
-msgstr ""
+msgstr "Niet toegestaan om voorwaarden bij te werken: {}"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:86
 msgid "Not defined"
-msgstr ""
+msgstr "Niet gedefinieerd"
 
 #: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
-msgstr ""
+msgstr "Niet afgedrukt"
 
 #: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
-msgstr ""
+msgstr "Niet ingesteld"
 
 #: bika/lims/content/worksheet.py:291
 msgid "Not specified"
-msgstr ""
+msgstr "Niet gespecificeerd"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:42
 msgid "Note: The settings apply to all Sample Add forms; Required fields can not be deselected."
-msgstr ""
+msgstr "Let op: De instellingen gelden voor alle formulieren voor het toevoegen van monsters; Verplichte velden kunnen niet worden gedeselecteerd."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:19
 msgid "Note: The settings are global and apply to all sample views."
-msgstr ""
+msgstr "Let op: De instellingen zijn globaal en gelden voor alle monsterweergaven."
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:168
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
-msgstr ""
+msgstr "Let op: U kunt de bijlagerijen ook slepen en neerzetten om de volgorde waarin ze in het rapport verschijnen te wijzigen."
 
 #: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
-msgstr ""
+msgstr "Meldingen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:126
 msgid "Num columns"
-msgstr ""
+msgstr "Aantal kolommen"
 
 #: bika/lims/content/analysisservice.py:259
 msgid "Number"
-msgstr ""
+msgstr "Nummer"
 
 #: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
-msgstr ""
+msgstr "Aantal analyses"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:82
 msgid "Number of Partitions to create"
-msgstr ""
+msgstr "Aantal aan te maken partities"
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:39
 msgid "Number of copies"
-msgstr ""
+msgstr "Aantal exemplaren"
 
 #: senaite/core/registry/schema.py:180
 msgid "Number of prominent columns"
-msgstr ""
+msgstr "Aantal prominente kolommen"
 
 #: bika/lims/content/abstractbaseanalysis.py:839
 #: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
-msgstr ""
+msgstr "Aantal vereiste verificaties"
 
 #: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-msgstr ""
+msgstr "Aantal vereiste verificaties voordat een bepaald resultaat als 'geverifieerd' wordt beschouwd. Deze instelling kan voor elke analyse worden overschreven in de bewerkingsweergave van de analysedienst. Standaard 1"
 
 #: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
-msgstr ""
+msgstr "Aantal vereiste verificaties van verschillende gebruikers met voldoende rechten voordat een bepaald resultaat voor deze analyse als 'geverifieerd' wordt beschouwd. De hier ingestelde optie heeft voorrang op de optie die in Bika Setup is ingesteld"
 
 #: senaite/core/registry/schema.py:189
 msgid "Number of standard columns"
-msgstr ""
+msgstr "Aantal standaardkolommen"
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
-msgstr ""
+msgstr "Numeriek"
 
 #: senaite/core/api/remarks.py:491
 msgid "Oldest first"
-msgstr ""
+msgstr "Oudste eerst"
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
-msgstr ""
+msgstr "Na conservering moet het monster binnen deze periode worden afgevoerd. Indien niet gespecificeerd, wordt de bewaartermijn van het monstertype gebruikt."
 
 #: senaite/core/content/dynamicanalysisspec.py:51
 msgid "Only Excel files supported"
-msgstr ""
+msgstr "Alleen Excel-bestanden worden ondersteund"
 
 #: bika/lims/content/attachment.py:81
 msgid "Only images can be rendered in the report directly"
-msgstr ""
+msgstr "Alleen afbeeldingen kunnen direct in het rapport worden weergegeven"
 
 #: senaite/core/exportimport/import.pt:95
 msgid "Only instruments that have an import interface configured are displayed"
-msgstr ""
+msgstr "Alleen instrumenten waarvoor een importinterface is geconfigureerd, worden weergegeven"
 
 #: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
-msgstr ""
+msgstr "Alleen werkdagen van het laboratorium worden meegenomen bij de berekening van de doorlooptijd van de analyse."
 
 #: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
-msgstr ""
+msgstr "Alleen werkdagen van het laboratorium worden meegenomen bij de berekening van de doorlooptijd van de analyse. "
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:216
 msgid "Only to empty or zero fields"
-msgstr ""
+msgstr "Alleen op lege of nulvelden"
 
 #: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
-msgstr ""
+msgstr "Openen"
 
 #: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
-msgstr ""
+msgstr "Open / Te verifiëren / Geverifieerd / Totaal"
 
 #: bika/lims/profiles.zcml:15
 msgid "Open Source Web based Laboratory Information Management System"
-msgstr ""
+msgstr "Open source webgebaseerd laboratoriuminformatiemanagementsysteem"
 
 #: senaite/core/browser/dashboard/dashboard.py:97
 msgid "Open Worksheets"
-msgstr ""
+msgstr "Open werkbladen"
 
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
-msgstr ""
+msgstr "Open het e-mailformulier om de geselecteerde rapporten naar de ontvangers te verzenden. Hiermee worden ook de in de rapporten opgenomen monsters gepubliceerd nadat de e-mail succesvol is verzonden."
 
 #: senaite/core/browser/dashboard/dashboard.py:522
 msgid "Open worksheets with analyses awaiting results"
-msgstr ""
+msgstr "Open werkbladen met analyses die op resultaten wachten"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
-msgstr ""
+msgstr "Volgorde"
 
 #: bika/lims/content/instrumentcertification.py:93
 msgid "Organization responsible of granting the calibration certificate"
-msgstr ""
+msgstr "Organisatie die verantwoordelijk is voor het verlenen van het kalibratiecertificaat"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:51
 msgid "Orientation"
-msgstr ""
+msgstr "Oriëntatie"
 
 #: senaite/core/z3cform/widgets/address.py:124
 msgid "Other address"
-msgstr ""
+msgstr "Ander adres"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:100
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:70
 msgid "Other reasons"
-msgstr ""
+msgstr "Andere redenen"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:22
 msgid "Other reasons:"
-msgstr ""
+msgstr "Andere redenen:"
 
 #: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
-msgstr ""
+msgstr "Andere status"
 
 #: senaite/core/browser/widgets/selectotherwidget.py:114
 #: senaite/core/z3cform/widgets/selectother/widget.py:138
 msgid "Other..."
-msgstr ""
+msgstr "Andere..."
 
 #: bika/lims/browser/instrument.py:733
 #: bika/lims/controlpanel/bika_instruments.py:170
 msgid "Out of date"
-msgstr ""
+msgstr "Verouderd"
 
 #: senaite/core/exportimport/instruments/importer.py:377
 msgid "Override non-empty analysis results"
-msgstr ""
+msgstr "Niet-lege analyseresultaten overschrijven"
 
 #: senaite/core/exportimport/instruments/importer.py:379
 msgid "Override non-empty analysis results, also with empty"
-msgstr ""
+msgstr "Niet-lege analyseresultaten overschrijven, ook met lege"
 
 #: senaite/core/content/resultsreport.py:198
 msgid "PDF"
-msgstr ""
+msgstr "PDF"
 
 #: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
-msgstr ""
+msgstr "PDF-bestand van het rapport"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:42
 msgid "Paperformat"
-msgstr ""
+msgstr "Papierformaat"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:130
 msgid "Partition"
-msgstr ""
+msgstr "Partitie"
 
 #: senaite/core/browser/samples/partition_magic.py:120
 msgid "Partitioning canceled"
-msgstr ""
+msgstr "Partitionering geannuleerd"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:242
 msgid "Password"
-msgstr ""
+msgstr "Wachtwoord"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:50
 msgid "Path identifier"
-msgstr ""
+msgstr "Padidentificatie"
 
 #: bika/lims/browser/fields/referenceresultsfield.py:36
 #: bika/lims/browser/referencesample.py:228
 #: bika/lims/browser/widgets/referenceresultswidget.py:71
 msgid "Permitted Error %"
-msgstr ""
+msgstr "Toegestane fout %"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:23
 msgid "Persistent counters used by the ID Server. Adjust a counter to change the next ID that will be issued for the matching prefix. Setting a counter to 0 removes the entry from the storage."
-msgstr ""
+msgstr "Persistente tellers die door de ID-server worden gebruikt. Pas een teller aan om de volgende ID te wijzigen die voor de overeenkomende prefix wordt uitgegeven. Een teller op 0 zetten verwijdert de vermelding uit de opslag."
 
 #: bika/lims/browser/clientfolder.py:81
 #: bika/lims/browser/templates/batch_publish.pt:68
 #: bika/lims/content/organisation.py:59
 msgid "Phone"
-msgstr ""
+msgstr "Telefoon"
 
 #: bika/lims/content/person.py:110
 msgid "Phone (business)"
-msgstr ""
+msgstr "Telefoon (zakelijk)"
 
 #: bika/lims/content/person.py:126
 msgid "Phone (home)"
-msgstr ""
+msgstr "Telefoon (thuis)"
 
 #: bika/lims/content/person.py:134
 msgid "Phone (mobile)"
-msgstr ""
+msgstr "Telefoon (mobiel)"
 
 #: bika/lims/content/instrument.py:338
 msgid "Photo image file"
-msgstr ""
+msgstr "Foto-afbeeldingsbestand"
 
 #: bika/lims/content/instrument.py:339
 msgid "Photo of the instrument"
-msgstr ""
+msgstr "Foto van het instrument"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:87
 #: senaite/core/z3cform/widgets/address.py:120
 msgid "Physical address"
-msgstr ""
+msgstr "Fysiek adres"
 
 #: bika/lims/browser/publish/emailview.py:170
 msgid "Please add an email subject"
-msgstr ""
+msgstr "Voeg een e-mailonderwerp toe"
 
 #: bika/lims/browser/publish/emailview.py:173
 msgid "Please add an email text"
-msgstr ""
+msgstr "Voeg een e-mailtekst toe"
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:11
 msgid "Please check that the sample has been physically collected and the value for \"Sampled Date\" field has been set in accordance."
-msgstr ""
+msgstr "Controleer of het monster fysiek is verzameld en of de waarde voor het veld \"Monsternamedatum\" hierop is afgestemd."
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:165
 msgid "Please click the update button after your changes."
-msgstr ""
+msgstr "Klik op de bijwerkknop na uw wijzigingen."
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:11
 msgid "Please find attached the analysis result(s) for ${client_name}"
-msgstr ""
+msgstr "In de bijlage vindt u het analyseresultaat/de analyseresultaten voor ${client_name}"
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:44
 msgid "Please follow the link to the retest ${retest_id}."
-msgstr ""
+msgstr "Volg de link naar de hertest ${retest_id}."
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:95
 msgid "Please provide a comment explaining the reason for invalidating the sample. If the email notification option is selected, the sample contact will be informed, and this comment will be included in the email content."
-msgstr ""
+msgstr "Geef een opmerking met de reden voor het ongeldig verklaren van het monster. Als de optie voor e-mailmelding is geselecteerd, wordt het contact van het monster geïnformeerd en wordt deze opmerking in de e-mailinhoud opgenomen."
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:109
 msgid "Please provide the reason for invalidating the sample."
-msgstr ""
+msgstr "Geef de reden op voor het ongeldig verklaren van het monster."
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
-msgstr ""
+msgstr "Selecteer een gebruiker uit de lijst"
 
 #: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
-msgstr ""
+msgstr "Selecteer een stickersjabloon"
 
 #: senaite/core/browser/attachment/attachment.py:224
 msgid "Please select an analysis or service for the attachment"
-msgstr ""
+msgstr "Selecteer een analyse of dienst voor de bijlage"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:111
 msgid "Please select number of partitions to create and press the preview button"
-msgstr ""
+msgstr "Selecteer het aantal aan te maken partities en klik op de voorbeeldknop"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
 #: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
-msgstr ""
+msgstr "Geef een reden op"
 
 #: bika/lims/content/analysisservice.py:183
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
-msgstr ""
+msgstr "Geef hier de conserveringen op die afwijken van de standaardconservering van de analysedienst per monstertype."
 
 #: bika/lims/content/laboratory.py:163
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
-msgstr ""
+msgstr "Upload het logo dat u van uw accreditatie-instantie op uw website en resultaatrapporten mag gebruiken. Maximale grootte is 175 x 175 pixels."
 
 #: bika/lims/content/analysisservice.py:229
 msgid "Please use the following format for select options: key1:value1|key2:value2|...|keyN:valueN"
-msgstr ""
+msgstr "Gebruik het volgende formaat voor keuzeopties: key1:value1|key2:value2|...|keyN:valueN"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:71
 msgid "Please write a comment where the listed sample(s) are dispatched"
-msgstr ""
+msgstr "Schrijf een opmerking waar de vermelde monster(s) naartoe worden verzonden"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:73
 msgid "Please write a comment where the listed sample(s) are disposed"
-msgstr ""
+msgstr "Schrijf een opmerking waar de vermelde monster(s) worden afgevoerd"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
-msgstr ""
+msgstr "Verzamelpunt"
 
 #: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
-msgstr ""
+msgstr "Portaaltype"
 
 #: bika/lims/content/identifiertype.py:39
 msgid "Portal Types"
-msgstr ""
+msgstr "Portaaltypes"
 
 #: senaite/core/browser/samples/multi_results_transposed.py:97
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:75
 #: senaite/core/browser/worksheets/worksheet/analyses_transposed_listing.py:89
 msgid "Position"
-msgstr ""
+msgstr "Positie"
 
 #: senaite/core/z3cform/widgets/address.py:121
 msgid "Postal address"
-msgstr ""
+msgstr "Postadres"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:125
 #: senaite/core/z3cform/widgets/address.py:226
 msgid "Postal code"
-msgstr ""
+msgstr "Postcode"
 
 #: senaite/core/content/samplecontainer.py:85
 msgid "Pre-preserved"
-msgstr ""
+msgstr "Voorgeconserveerd"
 
 #: senaite/core/content/samplecontainer.py:100
 msgid "Pre-preserved containers must have a preservation selected"
-msgstr ""
+msgstr "Voorgeconserveerde containers moeten een conservering geselecteerd hebben"
 
 #: bika/lims/content/abstractbaseanalysis.py:176
 msgid "Precision as number of decimals"
-msgstr ""
+msgstr "Precisie als aantal decimalen"
 
 #: bika/lims/content/abstractbaseanalysis.py:664
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
-msgstr ""
+msgstr "Precisie als het aantal significante cijfers volgens de onzekerheid. De decimale positie wordt bepaald door het eerste cijfer dat verschilt van nul in de onzekerheid; op die positie rondt het systeem de onzekerheid en resultaten af. Bij een resultaat van 5.243 en een onzekerheid van 0.22 toont het systeem bijvoorbeeld correct 5.2+-0.2. Als er geen onzekerheidsbereik voor het resultaat is ingesteld, gebruikt het systeem de ingestelde vaste precisie."
 
 #: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
-msgstr ""
+msgstr "Voorgedefinieerde resultaten"
 
 #: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
-msgstr ""
+msgstr "Voorkeursdecimaalteken voor rapporten."
 
 #: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
-msgstr ""
+msgstr "Voorkeursdecimaalteken voor resultaten"
 
 #: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-msgstr ""
+msgstr "Voorkeursindeling van de resultaatinvoertabel in de werkbladweergave. De klassieke indeling toont de monsters in rijen en de analyses in kolommen. De getransponeerde indeling toont de monsters in kolommen en de analyses in rijen."
 
 #: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
-msgstr ""
+msgstr "Voorkeursformaat voor wetenschappelijke notatie voor rapporten"
 
 #: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
-msgstr ""
+msgstr "Voorkeursformaat voor wetenschappelijke notatie voor resultaten"
 
 #: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
-msgstr ""
+msgstr "Prefix"
 
 #: bika/lims/content/sampletype.py:157
 msgid "Prefixes can not contain spaces."
-msgstr ""
+msgstr "Prefixen mogen geen spaties bevatten."
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Prepublish"
-msgstr ""
+msgstr "Voorpubliceren"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:195
 #: senaite/core/content/samplecontainer.py:114
 msgid "Preservation"
-msgstr ""
+msgstr "Conservering"
 
 #: bika/lims/content/preservation.py:45
 msgid "Preservation Category"
-msgstr ""
+msgstr "Conserveringscategorie"
 
 #: senaite/core/content/samplecontainer.py:117
 msgid "Preservation method of this container"
-msgstr ""
+msgstr "Conserveringsmethode van deze container"
 
 #: bika/lims/content/analysisservice.py:182
 msgid "Preservation per sample type"
-msgstr ""
+msgstr "Conservering per monstertype"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Preserve"
-msgstr ""
+msgstr "Conserveren"
 
 #: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
-msgstr ""
+msgstr "Conserveerder"
 
 #: senaite/core/browser/viewlets/templates/toolbar.pt:44
 msgid "Press Ctrl+Space to trigger the Spotlight search"
-msgstr ""
+msgstr "Druk op Ctrl+Space om de Spotlight-zoekopdracht te starten"
 
 #: bika/lims/content/instrumentmaintenancetask.py:163
 #: bika/lims/content/instrumentscheduledtask.py:120
 msgid "Preventive"
-msgstr ""
+msgstr "Preventief"
 
 #: bika/lims/content/instrument.py:212
 msgid "Preventive maintenance procedure"
-msgstr ""
+msgstr "Preventieve onderhoudsprocedure"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
-msgstr ""
+msgstr "Voorbeeld"
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
-msgstr ""
+msgstr "Prijs"
 
 #: bika/lims/content/abstractbaseanalysis.py:551
 #: bika/lims/content/analysisprofile.py:112
 msgid "Price (excluding VAT)"
-msgstr ""
+msgstr "Prijs (exclusief btw)"
 
 #: bika/lims/content/labproduct.py:54
 msgid "Price excluding VAT"
-msgstr ""
+msgstr "Prijs exclusief btw"
 
 #: bika/lims/profiles/default/types/Pricelist.xml
 msgid "Pricelist"
-msgstr ""
+msgstr "Prijslijst"
 
 #: bika/lims/content/pricelist.py:51
 msgid "Pricelist for"
-msgstr ""
+msgstr "Prijslijst voor"
 
 #: bika/lims/browser/pricelist.py:51
 #: bika/lims/profiles/default/types/PricelistFolder.xml
 msgid "Pricelists"
-msgstr ""
+msgstr "Prijslijsten"
 
 #: bika/lims/content/client.py:98
 msgid "Primary Contact"
-msgstr ""
+msgstr "Primair contact"
 
 #: bika/lims/browser/publish/reports_listing.py:73
 #: bika/lims/browser/templates/analysisreport_info.pt:60
 msgid "Primary Sample"
-msgstr ""
+msgstr "Primair monster"
 
 #: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
-msgstr ""
+msgstr "Afdrukken"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Print Invoice"
-msgstr ""
+msgstr "Factuur afdrukken"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:135
 msgid "Print Worksheet"
-msgstr ""
+msgstr "Werkblad afdrukken"
 
 #: bika/lims/browser/templates/batch_publish.pt:124
 msgid "Print date:"
-msgstr ""
+msgstr "Afdrukdatum:"
 
 #: bika/lims/profiles/default/types/Pricelist.xml
 msgid "Print pricelist"
-msgstr ""
+msgstr "Prijslijst afdrukken"
 
 #: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
-msgstr ""
+msgstr "Stickers afdrukken"
 
 #: senaite/core/browser/samples/view.py:259
 msgid "Printed"
-msgstr ""
+msgstr "Afgedrukt"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:53
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:53
 msgid "Printed on"
-msgstr ""
+msgstr "Afgedrukt op"
 
 #: bika/lims/content/analysisrequest.py:925
 msgid "Priority"
-msgstr ""
+msgstr "Prioriteit"
 
 #: senaite/core/browser/samples/view.py:238
 msgid "Profile"
-msgstr ""
+msgstr "Profiel"
 
 #: bika/lims/content/analysisprofile.py:64
 msgid "Profile Analyses"
-msgstr ""
+msgstr "Profielanalyses"
 
 #: bika/lims/content/analysisrequest.py:432
 msgid "Profile Key"
-msgstr ""
+msgstr "Profielsleutel"
 
 #: bika/lims/content/analysisprofile.py:51
 msgid "Profile Keyword"
-msgstr ""
+msgstr "Profielsleutelwoord"
 
 #: bika/lims/content/analysisrequest.py:431
 msgid "Profile Name"
-msgstr ""
+msgstr "Profielnaam"
 
 #: senaite/core/content/analysisprofile.py:216
 msgid "Profile keyword must be unique"
-msgstr ""
+msgstr "Profielsleutelwoord moet uniek zijn"
 
 #: senaite/core/browser/samples/view.py:134
 msgid "Progress"
-msgstr ""
+msgstr "Voortgang"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:103
 #: senaite/core/registry/schema.py:198
 msgid "Prominent fields"
-msgstr ""
+msgstr "Prominente velden"
 
 #: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
-msgstr ""
+msgstr "Protocol-ID"
 
 #: bika/lims/browser/clientfolder.py:75
 msgid "Province"
-msgstr ""
+msgstr "Provincie"
 
 #: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
-msgstr ""
+msgstr "Publicatiemodi"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Publish"
-msgstr ""
+msgstr "Publiceren"
 
 #: senaite/core/browser/dashboard/dashboard.py:112
 msgid "Publish Reports"
-msgstr ""
+msgstr "Rapporten publiceren"
 
 #: senaite/core/browser/dashboard/dashboard.py:150
 #: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
-msgstr ""
+msgstr "Gepubliceerd"
 
 #: bika/lims/browser/publish/reports_listing.py:86
 msgid "Published By"
-msgstr ""
+msgstr "Gepubliceerd door"
 
 #: bika/lims/browser/publish/reports_listing.py:84
 msgid "Published Date"
-msgstr ""
+msgstr "Publicatiedatum"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
-msgstr ""
+msgstr "Gepubliceerde resultaten"
 
 #: senaite/core/browser/dashboard/dashboard.py:448
 msgid "Published samples whose reports have not been printed yet"
-msgstr ""
+msgstr "Gepubliceerde monsters waarvan de rapporten nog niet zijn afgedrukt"
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
-msgstr ""
+msgstr "Gepubliceerd {}, "
 
 #: senaite/core/browser/viewlets/sampleanalyses.py:76
 msgid "QC Analyses"
-msgstr ""
+msgstr "QC-analyses"
 
 #: bika/lims/browser/referencesample.py:143
 msgid "QC Analysis ID"
-msgstr ""
+msgstr "QC-analyse-ID"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "QC Results"
-msgstr ""
+msgstr "QC-resultaten"
 
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
-msgstr ""
+msgstr "QC-monster-ID"
 
 #: senaite/core/browser/dashboard/dashboard.py:138
 msgid "Quarterly"
-msgstr ""
+msgstr "Per kwartaal"
 
 #: senaite/core/browser/dashboard/dashboard.py:128
 msgid "Quick Actions"
-msgstr ""
+msgstr "Snelle acties"
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
-msgstr ""
+msgstr "Bereik max"
 
 #: bika/lims/content/abstractbaseanalysis.py:620
 msgid "Range min"
-msgstr ""
+msgstr "Bereik min"
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:18
 msgid "Ranges for some analyses are different from the Specification"
-msgstr ""
+msgstr "Bereiken voor sommige analyses verschillen van de specificatie"
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:29
 msgid "Re-assign the Specification if you want to restore analysis ranges."
-msgstr ""
+msgstr "Wijs de specificatie opnieuw toe als u de analysebereiken wilt herstellen."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:256
 msgid "Re-enter the password. Make sure the passwords are identical."
-msgstr ""
+msgstr "Voer het wachtwoord opnieuw in. Zorg ervoor dat de wachtwoorden identiek zijn."
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:145
 msgid "Reasons for rejection"
-msgstr ""
+msgstr "Redenen voor afwijzing"
 
 #: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
-msgstr ""
+msgstr "Opnieuw toewijzen"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:445
 msgid "Reassignable Slot"
-msgstr ""
+msgstr "Opnieuw toewijsbaar slot"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr ""
+msgstr "Opnieuw koppelen"
 
 #: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
-msgstr ""
+msgstr "Herberekenen"
 
 #: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
-msgstr ""
+msgstr "Ontvangen"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
 #: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
-msgstr ""
+msgstr "Ontvangen"
 
 #: senaite/core/browser/dashboard/dashboard.py:420
 msgid "Received samples with analyses awaiting results"
-msgstr ""
+msgstr "Ontvangen monsters met analyses die op resultaten wachten"
 
 #: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
-msgstr ""
+msgstr "Ontvangst in behandeling"
 
 #: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
-msgstr ""
+msgstr "Ontvanger"
 
 #: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
-msgstr ""
+msgstr "Ontvangers"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
 #: bika/lims/content/worksheettemplate.py:57
 msgid "Reference"
-msgstr ""
+msgstr "Referentie"
 
 #: bika/lims/browser/referencesample.py:83
 msgid "Reference Analyses"
-msgstr ""
+msgstr "Referentieanalyses"
 
 #: bika/lims/profiles/default/types/ReferenceAnalysis.xml
 msgid "Reference Analysis"
-msgstr ""
+msgstr "Referentieanalyse"
 
 #: bika/lims/browser/referencesample.py:353
 #: bika/lims/browser/templates/referencesample_view.pt:67
 #: bika/lims/profiles/default/types/ReferenceDefinition.xml
 msgid "Reference Definition"
-msgstr ""
+msgstr "Referentiedefinitie"
 
 #: bika/lims/controlpanel/bika_referencedefinitions.py:63
 #: bika/lims/profiles/default/types/ReferenceDefinitions.xml
 msgid "Reference Definitions"
-msgstr ""
+msgstr "Referentiedefinities"
 
 #: bika/lims/content/referencesample.py:64
 msgid "Reference ID"
-msgstr ""
+msgstr "Referentie-ID"
 
 #: bika/lims/browser/instrument.py:558
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:12
 #: bika/lims/browser/worksheet/views/referencesamples.py:72
 msgid "Reference Sample"
-msgstr ""
+msgstr "Referentiemonster"
 
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Reference Samples"
-msgstr ""
+msgstr "Referentiemonsters"
 
 #: bika/lims/browser/referencesample.py:202
 #: bika/lims/profiles/default/types/ReferenceSample.xml
 msgid "Reference Values"
-msgstr ""
+msgstr "Referentiewaarden"
 
 #: bika/lims/content/referencesample.py:98
 msgid "Reference sample values are zero or 'blank'"
-msgstr ""
+msgstr "Referentiemonsterwaarden zijn nul of 'blanco'"
 
 #: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
-msgstr ""
+msgstr "Registreren"
 
 #: senaite/core/browser/dashboard/dashboard.py:105
 msgid "Register Samples"
-msgstr ""
+msgstr "Monsters registreren"
 
 #: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
-msgstr ""
+msgstr "Geregistreerd"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_cancellable_type_workflow/definition.xml
 msgid "Reinstate"
-msgstr ""
+msgstr "Herstellen"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:149
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reject"
-msgstr ""
+msgstr "Afwijzen"
 
 #: bika/lims/profiles/default/types/RejectAnalysis.xml
 msgid "Reject Analysis"
-msgstr ""
+msgstr "Analyse afwijzen"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:17
 msgid "Reject samples"
-msgstr ""
+msgstr "Monsters afwijzen"
 
 #: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
 #: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
-msgstr ""
+msgstr "Afgewezen"
 
 #: bika/lims/browser/workflow/analysisrequest.py:98
 msgid "Rejected items: {}"
-msgstr ""
+msgstr "Afgewezen items: {}"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:13
 msgid "Rejected sample"
-msgstr ""
+msgstr "Afgewezen monster"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:114
 msgid "Rejected {} samples: {}"
-msgstr ""
+msgstr "{} monsters afgewezen: {}"
 
 #: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
-msgstr ""
+msgstr "Afwijzingsredenen"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:121
 msgid "Rejection cancelled"
-msgstr ""
+msgstr "Afwijzing geannuleerd"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:84
 msgid "Rejection reasons"
-msgstr ""
+msgstr "Afwijzingsredenen"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:70
 msgid "Rejection workflow is not enabled"
-msgstr ""
+msgstr "Afwijzingsworkflow is niet ingeschakeld"
 
 # senaite.app.listing: Reload
 msgid "Reload"
-msgstr ""
+msgstr "Opnieuw laden"
 
 #: senaite/core/browser/modals/analysis/schema.py:122
 #: senaite/core/browser/viewlets/remarks.py:31
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:242
 msgid "Remarks"
-msgstr ""
+msgstr "Opmerkingen"
 
 #: bika/lims/content/analysisrequest.py:1103
 msgid "Remarks and comments for this request"
-msgstr ""
+msgstr "Opmerkingen en commentaar voor deze aanvraag"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:672
 msgid "Remarks of {}"
-msgstr ""
+msgstr "Opmerkingen van {}"
 
 #: bika/lims/content/instrumentcalibration.py:108
 msgid "Remarks to take into account before calibration"
-msgstr ""
+msgstr "Opmerkingen om rekening mee te houden vóór kalibratie"
 
 #: bika/lims/content/instrumentscheduledtask.py:87
 msgid "Remarks to take into account before performing the task"
-msgstr ""
+msgstr "Opmerkingen om rekening mee te houden voordat de taak wordt uitgevoerd"
 
 #: bika/lims/content/instrumentvalidation.py:90
 msgid "Remarks to take into account before validation"
-msgstr ""
+msgstr "Opmerkingen om rekening mee te houden vóór validatie"
 
 #: bika/lims/content/instrumentmaintenancetask.py:94
 msgid "Remarks to take into account for maintenance process"
-msgstr ""
+msgstr "Opmerkingen om rekening mee te houden voor het onderhoudsproces"
 
 #: bika/lims/browser/auditlog.py:90
 #: bika/lims/controlpanel/auditlog.py:92
 msgid "Remote IP"
-msgstr ""
+msgstr "Extern IP"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:72
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Remove"
-msgstr ""
+msgstr "Verwijderen"
 
 #: senaite/core/browser/samples/view.py:597
 msgid "Remove this analysis from the filter"
-msgstr ""
+msgstr "Verwijder deze analyse uit de filter"
 
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
-msgstr ""
+msgstr "{} sleutel(s) verwijderd: {}"
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Rename filter"
-msgstr ""
+msgstr "Filter hernoemen"
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
-msgstr ""
+msgstr "Bijlage weergeven in rapport"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:68
 msgid "Render in Report"
-msgstr ""
+msgstr "Weergeven in rapport"
 
 #: bika/lims/content/instrumentmaintenancetask.py:164
 #: bika/lims/content/instrumentscheduledtask.py:121
 msgid "Repair"
-msgstr ""
+msgstr "Repareren"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:59
 #: bika/lims/content/analysisservice.py:226
 msgid "Report"
-msgstr ""
+msgstr "Rapport"
 
 #: bika/lims/content/instrumentcalibration.py:68
 #: bika/lims/content/instrumentvalidation.py:50
 msgid "Report Date"
-msgstr ""
+msgstr "Rapportdatum"
 
 #: bika/lims/content/instrumentcalibration.py:150
 #: bika/lims/content/instrumentvalidation.py:132
 msgid "Report ID"
-msgstr ""
+msgstr "Rapport-ID"
 
 #: bika/lims/content/instrumentcalibration.py:151
 #: bika/lims/content/instrumentvalidation.py:133
 msgid "Report identification number"
-msgstr ""
+msgstr "Rapportidentificatienummer"
 
 #: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
-msgstr ""
+msgstr "Rapportmetadata"
 
 #: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
-msgstr ""
+msgstr "Rapportontvangers"
 
 #: bika/lims/content/instrumentcertification.py:194
 msgid "Report upload"
-msgstr ""
+msgstr "Rapport uploaden"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Republish"
-msgstr ""
+msgstr "Opnieuw publiceren"
 
 #: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
-msgstr ""
+msgstr "Opnieuw gepubliceerd na laatste afdruk"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:71
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:70
 msgid "Request ID"
-msgstr ""
+msgstr "Aanvraag-ID"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
-msgstr ""
+msgstr "Nieuwe analyses aanvragen"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:227
 msgid "Required"
-msgstr ""
+msgstr "Vereist"
 
 #: bika/lims/browser/fields/partitionsetupfield.py:118
 msgid "Required Volume"
-msgstr ""
+msgstr "Vereist volume"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:198
 msgid "Reset"
-msgstr ""
+msgstr "Resetten"
 
 # senaite.app.listing: Reset-columns button tooltip
 msgid "Reset column visibility and order to the defaults"
-msgstr ""
+msgstr "Kolomzichtbaarheid en -volgorde terugzetten naar de standaardwaarden"
 
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
-msgstr ""
+msgstr "Kolommen resetten"
 
 # senaite.app.listing: Column config — reset link tooltip
 msgid "Reset to default columns and order"
-msgstr ""
+msgstr "Terugzetten naar standaardkolommen en -volgorde"
 
 # senaite.app.listing: Search box — undo / reset-view button tooltip
 msgid "Reset view"
-msgstr ""
+msgstr "Weergave resetten"
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
-msgstr ""
+msgstr "Verantwoordelijken"
 
 #: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
-msgstr ""
+msgstr "Herstellen"
 
 #: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
-msgstr ""
+msgstr "Werkbladtoegang beperken tot toegewezen analisten"
 
 #: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
-msgstr ""
+msgstr "Werkbladbeheer beperken tot labmanagers"
 
 #: senaite/core/browser/modals/analysis/schema.py:53
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:86
 msgid "Result"
-msgstr ""
+msgstr "Resultaat"
 
 #: senaite/core/browser/modals/analysis/schema.py:130
 msgid "Result Capture Date"
-msgstr ""
+msgstr "Datum resultaatvastlegging"
 
 #: bika/lims/content/abstractbaseanalysis.py:726
 msgid "Result Value"
-msgstr ""
+msgstr "Resultaatwaarde"
 
 #: bika/lims/validators.py:642
 msgid "Result Value must be a number"
-msgstr ""
+msgstr "Resultaatwaarde moet een getal zijn"
 
 #: bika/lims/validators.py:657
 msgid "Result Value must be unique"
-msgstr ""
+msgstr "Resultaatwaarde moet uniek zijn"
 
 #: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
-msgstr ""
+msgstr "Resultaat in schouderbereik"
 
 #: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
-msgstr ""
+msgstr "Resultaat buiten bereik"
 
 #: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
-msgstr ""
+msgstr "Resultaatbereik verschilt van specificatie: {}"
 
 #: bika/lims/content/abstractbaseanalysis.py:711
 msgid "Result type"
-msgstr ""
+msgstr "Resultaattype"
 
 #: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
-msgstr ""
+msgstr "Resultaatwaarden met ten minste dit aantal significante cijfers worden weergegeven in wetenschappelijke notatie met de letter 'e' om de exponent aan te geven.  De precisie kan worden geconfigureerd in individuele analysediensten."
 
 #: bika/lims/content/analysisservice.py:116
 msgid "Result variables"
-msgstr ""
+msgstr "Resultaatvariabelen"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:63
 msgid "Results"
-msgstr ""
+msgstr "Resultaten"
 
 #: bika/lims/content/analysisrequest.py:1369
 msgid "Results Interpretation"
-msgstr ""
+msgstr "Resultaatinterpretatie"
 
 #: senaite/core/browser/dashboard/dashboard.py:85
 msgid "Results Pending"
-msgstr ""
+msgstr "Resultaten in behandeling"
 
 #: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
-msgstr ""
+msgstr "Resultaatrapport"
 
 #: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
-msgstr ""
+msgstr "Resultaatrapporten"
 
 #: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
-msgstr ""
+msgstr "Resultaten zijn ingetrokken"
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:39
 msgid "Results interpretation"
-msgstr ""
+msgstr "Resultaatinterpretatie"
 
 #: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
-msgstr ""
+msgstr "Resultaten in behandeling"
 
 #: bika/lims/content/analysisrequest.py:660
 #: bika/lims/content/preservation.py:52
 #: bika/lims/content/sampletype.py:116
 msgid "Retention Period"
-msgstr ""
+msgstr "Bewaartermijn"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Retest"
-msgstr ""
+msgstr "Hertest"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:96
 msgid "Retested"
-msgstr ""
+msgstr "Hertest"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Retract"
-msgstr ""
+msgstr "Intrekken"
 
 #: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
-msgstr ""
+msgstr "Ingetrokken"
 
 #: bika/lims/browser/templates/analyses_retractedlist.pt:11
 msgid "Retracted analyses"
-msgstr ""
+msgstr "Ingetrokken analyses"
 
 #: bika/lims/browser/instrument.py:561
 msgid "Retractions"
-msgstr ""
+msgstr "Intrekkingen"
 
 #: bika/lims/browser/publish/reports_listing.py:78
 msgid "Review State"
-msgstr ""
+msgstr "Beoordelingsstatus"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:171
 msgid "Reviewed by"
-msgstr ""
+msgstr "Beoordeeld door"
 
 #: bika/lims/browser/auditlog.py:88
 #: bika/lims/controlpanel/auditlog.py:88
 msgid "Roles"
-msgstr ""
+msgstr "Rollen"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Rollback"
-msgstr ""
+msgstr "Terugdraaien"
 
 #: bika/lims/browser/worksheet/views/folder.py:110
 msgid "Routine Analyses"
-msgstr ""
+msgstr "Routineanalyses"
 
 #: bika/lims/api/snapshot.py:555
 msgid "Row ${num}"
-msgstr ""
+msgstr "Rij ${num}"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
-msgstr ""
+msgstr "SENAITE CORE"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE Add-on"
-msgstr ""
+msgstr "SENAITE CORE-add-on"
 
 #: bika/lims/profiles.zcml:15
 msgid "SENAITE Core 1.x (do not install)"
-msgstr ""
+msgstr "SENAITE Core 1.x (niet installeren)"
 
 #: senaite/core/browser/frontpage/templates/frontpage.pt:6
 msgid "SENAITE LIMS"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE LIMS front-page"
-msgstr ""
+msgstr "SENAITE LIMS-voorpagina"
 
 #: senaite/core/profiles/default/controlpanel.xml
 #: senaite/core/registry/controlpanel.py:81
 msgid "SENAITE Registry"
-msgstr ""
+msgstr "SENAITE Registry"
 
 #: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
-msgstr ""
+msgstr "SENAITE Instellingen"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE front-page"
-msgstr ""
+msgstr "SENAITE-voorpagina"
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
-msgstr ""
+msgstr "SMTP-server verbroken. Aanmaken van gebruiker afgebroken."
 
 #: bika/lims/content/supplier.py:87
 msgid "SWIFT code"
-msgstr ""
+msgstr "SWIFT-code"
 
 #: bika/lims/content/person.py:42
 msgid "Salutation"
-msgstr ""
+msgstr "Aanhef"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
 #: senaite/core/content/resultsreport.py:151
 msgid "Sample"
-msgstr ""
+msgstr "Monster"
 
 #: bika/lims/browser/analysisrequest/add2.py:2195
 msgid "Sample ${AR} was successfully created."
-msgstr ""
+msgstr "Monster ${AR} is succesvol aangemaakt."
 
 #: senaite/core/browser/samples/invalidate_samples.py:149
 msgid "Sample ${sample_id} has been successfully invalidated."
-msgstr ""
+msgstr "Monster ${sample_id} is succesvol ongeldig verklaard."
 
 #: senaite/core/browser/samples/invalidate_samples.py:139
 msgid "Sample ${sample_id} was successfully invalidated, and a notification email has been sent to the following recipients: ${recipients}."
-msgstr ""
+msgstr "Monster ${sample_id} is succesvol ongeldig verklaard en er is een meldingsmail verzonden naar de volgende ontvangers: ${recipients}."
 
 #: senaite/core/profiles/default/types/SampleCondition.xml
 msgid "Sample Condition"
-msgstr ""
+msgstr "Monsterconditie"
 
 #: senaite/core/profiles/default/types/SampleConditions.xml
 msgid "Sample Conditions"
-msgstr ""
+msgstr "Monstercondities"
 
 #: senaite/core/profiles/default/types/SampleContainer.xml
 msgid "Sample Container"
-msgstr ""
+msgstr "Monstercontainer"
 
 #: senaite/core/profiles/default/types/SampleContainers.xml
 msgid "Sample Containers"
-msgstr ""
+msgstr "Monstercontainers"
 
 #: senaite/core/registry/schema.py:160
 msgid "Sample Header"
-msgstr ""
+msgstr "Monsterkop"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
 #: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
-msgstr ""
+msgstr "Monster-ID"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:17
 msgid "Sample Invalidation"
-msgstr ""
+msgstr "Ongeldigverklaring monster"
 
 #: senaite/core/profiles/default/types/SampleMatrices.xml
 msgid "Sample Matrices"
-msgstr ""
+msgstr "Monstermatrices"
 
 #: senaite/core/profiles/default/types/SampleMatrix.xml
 msgid "Sample Matrix"
-msgstr ""
+msgstr "Monstermatrix"
 
 #: bika/lims/content/artemplate.py:172
 msgid "Sample Partitions"
-msgstr ""
+msgstr "Monsterpartities"
 
 #: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
-msgstr ""
+msgstr "Monsterpunt"
 
 #: senaite/core/profiles/default/types/SamplePoints.xml
 msgid "Sample Points"
-msgstr ""
+msgstr "Monsterpunten"
 
 #: senaite/core/profiles/default/types/SamplePreservation.xml
 msgid "Sample Preservation"
-msgstr ""
+msgstr "Monsterconservering"
 
 #: senaite/core/profiles/default/types/SamplePreservations.xml
 msgid "Sample Preservations"
-msgstr ""
+msgstr "Monsterconserveringen"
 
 #: bika/lims/content/analysisrequest.py:671
 msgid "Sample Rejection"
-msgstr ""
+msgstr "Monsterafwijzing"
 
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Sample Templates"
-msgstr ""
+msgstr "Monstersjablonen"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
 #: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
-msgstr ""
+msgstr "Monstertype"
 
 #: bika/lims/content/sampletype.py:156
 msgid "Sample Type Prefix"
-msgstr ""
+msgstr "Monstertypeprefix"
 
 #: senaite/core/registry/schema.py:124
 msgid "Sample View"
-msgstr ""
+msgstr "Monsterweergave"
 
 #: bika/lims/content/artemplate.py:118
 msgid "Sample collected by the laboratory"
-msgstr ""
+msgstr "Monster verzameld door het laboratorium"
 
 #: bika/lims/browser/analysisrequest/add2.py:1992
 msgid "Sample creation cancelled"
-msgstr ""
+msgstr "Aanmaken van monster geannuleerd"
 
 #: bika/lims/browser/workflow/analysisrequest.py:248
 msgid "Sample date required for sample %s"
-msgstr ""
+msgstr "Monsterdatum vereist voor monster %s"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Sample due"
-msgstr ""
+msgstr "Monster verwacht"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:111
 msgid "Sample type"
-msgstr ""
+msgstr "Monstertype"
 
 #: senaite/core/content/interpretationtemplate.py:71
 msgid "Sample types"
-msgstr ""
+msgstr "Monstertypes"
 
 #: senaite/core/registry/schema.py:125
 msgid "Sample view configuration"
-msgstr ""
+msgstr "Configuratie monsterweergave"
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:15
 msgid "Sample with partitions"
-msgstr ""
+msgstr "Monster met partities"
 
 #: senaite/core/profiles/default/types/SampleTemplate.xml
 msgid "SampleTemplate"
-msgstr ""
+msgstr "MonsterSjabloon"
 
 #: senaite/core/profiles/default/types/SampleTemplates.xml
 msgid "SampleTemplates"
-msgstr ""
+msgstr "MonsterSjablonen"
 
 #: senaite/core/profiles/default/types/SampleType.xml
 msgid "SampleType"
-msgstr ""
+msgstr "MonsterType"
 
 #: senaite/core/profiles/default/types/SampleTypes.xml
 msgid "SampleTypes"
-msgstr ""
+msgstr "MonsterTypes"
 
 #: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
-msgstr ""
+msgstr "Monsternemer"
 
 #: bika/lims/content/analysisrequest.py:497
 msgid "Sampler for scheduled sampling"
-msgstr ""
+msgstr "Monsternemer voor geplande monstername"
 
 #: bika/lims/browser/workflow/analysisrequest.py:241
 msgid "Sampler required for sample %s"
-msgstr ""
+msgstr "Monsternemer vereist voor monster %s"
 
 #: senaite/core/browser/dashboard/dashboard.py:457
 #: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
-msgstr ""
+msgstr "Monsters"
 
 #: bika/lims/browser/analysisrequest/add2.py:2192
 msgid "Samples ${ARs} were successfully created."
-msgstr ""
+msgstr "Monsters ${ARs} zijn succesvol aangemaakt."
 
 #: senaite/core/browser/samples/invalidate_samples.py:155
 msgid "Samples ${sample_ids} were successfully invalidated, with notification emails sent for the following: ${notified_ids}."
-msgstr ""
+msgstr "Monsters ${sample_ids} zijn succesvol ongeldig verklaard, met meldingsmails verzonden voor de volgende: ${notified_ids}."
 
 #: senaite/core/browser/samples/invalidate_samples.py:164
 msgid "Samples ${sample_ids} were successfully invalidated."
-msgstr ""
+msgstr "Monsters ${sample_ids} zijn succesvol ongeldig verklaard."
 
 #: senaite/core/browser/dashboard/dashboard.py:400
 msgid "Samples awaiting collection of the sample"
-msgstr ""
+msgstr "Monsters die wachten op verzameling van het monster"
 
 #: senaite/core/browser/dashboard/dashboard.py:404
 msgid "Samples awaiting preservation"
-msgstr ""
+msgstr "Monsters die wachten op conservering"
 
 #: senaite/core/browser/dashboard/dashboard.py:416
 msgid "Samples awaiting reception at the laboratory"
-msgstr ""
+msgstr "Monsters die wachten op ontvangst bij het laboratorium"
 
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
-msgstr ""
+msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:67
 msgid "Samples rejection reporting form"
-msgstr ""
+msgstr "Formulier voor rapportage van monsterafwijzing"
 
 #: senaite/core/browser/dashboard/dashboard.py:81
 msgid "Samples to Receive"
-msgstr ""
+msgstr "Te ontvangen monsters"
 
 #: senaite/core/browser/dashboard/dashboard.py:432
 msgid "Samples whose reports have been published"
-msgstr ""
+msgstr "Monsters waarvan de rapporten zijn gepubliceerd"
 
 #: senaite/core/browser/dashboard/dashboard.py:424
 msgid "Samples whose results are awaiting verification"
-msgstr ""
+msgstr "Monsters waarvan de resultaten op verificatie wachten"
 
 #: senaite/core/browser/dashboard/dashboard.py:409
 msgid "Samples with a scheduled sampling date"
-msgstr ""
+msgstr "Monsters met een geplande monsternamedatum"
 
 #: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
-msgstr ""
+msgstr "Monstername"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:106
 msgid "Sampling Date"
-msgstr ""
+msgstr "Monsternamedatum"
 
 #: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
-msgstr ""
+msgstr "Monsternameafwijking"
 
 #: senaite/core/profiles/default/types/SamplingDeviations.xml
 msgid "Sampling Deviations"
-msgstr ""
+msgstr "Monsternameafwijkingen"
 
 #: bika/lims/content/samplepoint.py:83
 msgid "Sampling Frequency"
-msgstr ""
+msgstr "Monsternamefrequentie"
 
 #: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
-msgstr ""
+msgstr "Monstername gepland"
 
 #: senaite/core/vocabularies/setup.py:161
 msgid "Saturday"
-msgstr ""
+msgstr "Zaterdag"
 
 #: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
 msgid "Save"
-msgstr ""
+msgstr "Opslaan"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
-msgstr ""
+msgstr "Opslaan en kopiëren"
 
 # senaite.app.listing: Saved filter presets — footer button to save the
 # current view
 msgid "Save current view"
-msgstr ""
+msgstr "Huidige weergave opslaan"
 
 # senaite.app.listing: Saved filter presets — toggle title + menu header
 msgid "Saved filters"
-msgstr ""
+msgstr "Opgeslagen filters"
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
-msgstr ""
+msgstr "Opgeslagen items: {}"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Schedule"
-msgstr ""
+msgstr "Plannen"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Schedule sampling"
-msgstr ""
+msgstr "Monstername plannen"
 
 #: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
-msgstr ""
+msgstr "Geplande monstername"
 
 #: bika/lims/browser/instrument.py:400
 msgid "Scheduled task"
-msgstr ""
+msgstr "Geplande taak"
 
 #: bika/lims/content/abstractbaseanalysis.py:95
 msgid "Scientific name"
-msgstr ""
+msgstr "Wetenschappelijke naam"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:154
 msgid "Search"
-msgstr ""
+msgstr "Zoeken"
 
 # senaite.app.listing: Column config — search input placeholder
 msgid "Search columns…"
-msgstr ""
+msgstr "Kolommen zoeken…"
 
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
-msgstr ""
+msgstr "Zoeken..."
 
 #: bika/lims/browser/fields/coordinatefield.py:38
 msgid "Seconds"
-msgstr ""
+msgstr "Seconden"
 
 #: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
-msgstr ""
+msgstr "Beveiliging"
 
 #: bika/lims/content/container.py:118
 msgid "Security Seal Intact Y/N"
-msgstr ""
+msgstr "Verzegeling intact J/N"
 
 #: senaite/core/content/samplecontainer.py:122
 msgid "Security seal intact"
-msgstr ""
+msgstr "Verzegeling intact"
 
 #: bika/lims/content/analysisservice.py:261
 msgid "Select"
-msgstr ""
+msgstr "Selecteren"
 
 #: senaite/core/exportimport/import.pt:100
 msgid "Select Import Interface"
-msgstr ""
+msgstr "Import-interface selecteren"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:215
 msgid "Select Partition Analyses"
-msgstr ""
+msgstr "Partitie-analyses selecteren"
 
 #: bika/lims/content/analysisservice.py:146
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
-msgstr ""
+msgstr "Selecteer een standaardconservering voor deze analysedienst. Als de conservering afhangt van de combinatie met het monstertype, geef dan per monstertype een conservering op in de onderstaande tabel"
 
 # senaite.core.browser.modals.templates.create_worksheet.pt
 msgid "Select all"
-msgstr ""
+msgstr "Alles selecteren"
 
 #: bika/lims/browser/publish/templates/email.pt:168
 msgid "Select all:"
-msgstr ""
+msgstr "Alles selecteren:"
 
 #: bika/lims/content/instrument.py:223
 msgid "Select an Export interface for this instrument."
-msgstr ""
+msgstr "Selecteer een export-interface voor dit instrument."
 
 #: bika/lims/content/instrument.py:236
 msgid "Select an Import interface for this instrument."
-msgstr ""
+msgstr "Selecteer een import-interface voor dit instrument."
 
 #: bika/lims/content/artemplate.py:288
 msgid "Select analyses to include in this template"
-msgstr ""
+msgstr "Selecteer analyses om op te nemen in dit sjabloon"
 
 #: senaite/core/browser/worksheets/templates/view.pt:36
 msgid "Select analyst"
-msgstr ""
+msgstr "Analist selecteren"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:203
 msgid "Select any add-ons you want to activate immediately. You can also activate add-ons after the site has been created using the Add-ons control panel."
-msgstr ""
+msgstr "Selecteer de add-ons die u direct wilt activeren. U kunt add-ons ook activeren nadat de site is aangemaakt via het configuratiescherm voor add-ons."
 
 #: senaite/core/exportimport/import.pt:135
 msgid "Select existing file"
-msgstr ""
+msgstr "Bestaand bestand selecteren"
 
 #: bika/lims/content/instrumentcertification.py:85
 msgid "Select if is an in-house calibration certificate"
-msgstr ""
+msgstr "Selecteer of het een intern kalibratiecertificaat betreft"
 
 #: bika/lims/content/analysisservice.py:88
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
-msgstr ""
+msgstr "Selecteer of de te gebruiken berekening de standaardberekening van de standaardmethode is. Als deze niet is geselecteerd, kan de berekening handmatig worden gekozen"
 
 #: bika/lims/content/pricelist.py:76
 msgid "Select if the descriptions should be included"
-msgstr ""
+msgstr "Selecteer of de beschrijvingen moeten worden opgenomen"
 
 #: bika/lims/content/abstractbaseanalysis.py:393
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
-msgstr ""
+msgstr "Selecteer of de resultaten voor tests van dit type analyse met behulp van een instrument kunnen worden ingesteld. Indien uitgeschakeld, zullen er geen instrumenten beschikbaar zijn voor tests van dit type analyse in de weergave voor resultaatbeheer, ook al zijn er instrumenten toegewezen aan de voor de test geselecteerde methode."
 
 #: senaite/core/browser/worksheets/templates/view.pt:66
 msgid "Select instrument"
-msgstr ""
+msgstr "Instrument selecteren"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:50
 msgid "Select reasons"
-msgstr ""
+msgstr "Redenen selecteren"
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:76
 #: senaite/core/browser/worksheets/templates/view.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:33
 msgid "Select template"
-msgstr ""
+msgstr "Sjabloon selecteren"
 
 #: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
-msgstr ""
+msgstr "Selecteer het land dat de site standaard zal tonen"
 
 #: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
-msgstr ""
+msgstr "Selecteer de valuta die de site gebruikt om prijzen weer te geven."
 
 #: bika/lims/content/analysisservice.py:166
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
-msgstr ""
+msgstr "Selecteer de standaardcontainer voor deze analysedienst. Als de te gebruiken container afhangt van de combinatie van monstertype en conservering, geef de container dan op in de monstertypetabel hieronder"
 
 #: bika/lims/profiles/default/registry.xml
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
-msgstr ""
+msgstr "Selecteer de standaardstartpagina. Deze wordt gebruikt wanneer een klantgebruiker zich aanmeldt bij het systeem, of wanneer een klant wordt geselecteerd uit de lijst met klantmappen."
 
 #: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
-msgstr ""
+msgstr "Selecteer het standaardstickersjabloon voor automatisch afdrukken."
 
 #: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
-msgstr ""
+msgstr "Selecteer het standaardstickersjabloon voor automatisch afdrukken.<br/>"
 
 #: bika/lims/content/identifiertype.py:40
 msgid "Select the types that this ID is used to identify."
-msgstr ""
+msgstr "Selecteer de typen die met deze ID worden geïdentificeerd."
 
 #: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
-msgstr ""
+msgstr "Selecteer dit om automatische e-mailmeldingen aan de klant te activeren wanneer een monster wordt afgewezen."
 
 #: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
-msgstr ""
+msgstr "Selecteer dit om het dashboard te activeren als standaardvoorpagina."
 
 #: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
-msgstr ""
+msgstr "Selecteer dit om de workflowstappen voor monsterverzameling te activeren."
 
 #: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
-msgstr ""
+msgstr "Selecteer dit om een monsternamecoördinator toe te staan een monstername te plannen. Deze functionaliteit is alleen van kracht wanneer de 'Monstername-workflow' actief is"
 
 #: senaite/core/content/senaitesetup.py:1001
 msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
-msgstr ""
+msgstr "Selecteer dit om het verzenden van monsters via de overgang 'verzenden' toe te staan en de aanvullende status 'verzonden' in te schakelen. De analyses van een verzonden monster worden alleen-lezen en worden teruggezet naar hun vorige status wanneer het monster wordt hersteld. Standaard uitgeschakeld."
 
 #: senaite/core/content/senaitesetup.py:991
 msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
-msgstr ""
+msgstr "Selecteer dit om het afvoeren van monsters via de overgang 'afvoeren' toe te staan en de aanvullende status 'afgevoerd' in te schakelen. Standaard uitgeschakeld."
 
 #: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
-msgstr ""
+msgstr "Selecteer dit om de gebruiker toe te staan een aanvullende status 'Afgedrukt' toe te kennen aan die analyseaanvragen die zijn gepubliceerd. Standaard uitgeschakeld."
 
 #: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
-msgstr ""
+msgstr "Selecteer dit om monsters automatisch te ontvangen wanneer ze door laboratoriumpersoneel worden aangemaakt en de monstername-workflow is uitgeschakeld. Monsters die door contactpersonen van klanten worden aangemaakt, worden niet automatisch ontvangen"
 
 #: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-msgstr ""
+msgstr "Selecteer dit om monsterpartities te tonen aan contactpersonen van klanten. Indien gedeactiveerd, worden partities niet opgenomen in lijsten en wordt er geen infobericht met links naar het primaire monster getoond aan contactpersonen van klanten."
 
 #: bika/lims/content/worksheettemplate.py:82
 msgid "Select which Analyses should be included on the Worksheet"
-msgstr ""
+msgstr "Selecteer welke analyses op het werkblad moeten worden opgenomen"
 
 #: senaite/core/config/vocabularies.py:57
 msgid "Selection list"
-msgstr ""
+msgstr "Selectielijst"
 
 #: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
-msgstr ""
+msgstr "Zelfverificatie van resultaten"
 
 #: bika/lims/browser/publish/templates/email.pt:208
 msgid "Send"
-msgstr ""
+msgstr "Verzenden"
 
 #: bika/lims/browser/publish/templates/email.pt:23
 msgid "Send Analysis Reports via Email"
-msgstr ""
+msgstr "Analyserapporten via e-mail verzenden"
 
 #: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
-msgstr ""
+msgstr "Verzendlogboek"
 
 #: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
-msgstr ""
+msgstr "Verzendlogboekregel"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:132
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:135
 msgid "Send an email notification to ${recipients}"
-msgstr ""
+msgstr "Een e-mailmelding verzenden naar ${recipients}"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:132
 msgid "Sender"
-msgstr ""
+msgstr "Afzender"
 
 #: bika/lims/browser/publish/reports_listing.py:91
 msgid "Sent to"
-msgstr ""
+msgstr "Verzonden naar"
 
 #: bika/lims/browser/fields/partitionsetupfield.py:115
 #: bika/lims/content/analysisservice.py:129
 msgid "Separate Container"
-msgstr ""
+msgstr "Aparte container"
 
 #: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
-msgstr ""
+msgstr "Seq-type"
 
 #: bika/lims/content/instrument.py:145
 msgid "Serial No"
-msgstr ""
+msgstr "Serienr."
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:74
 #: bika/lims/browser/templates/analysisservice_info.pt:209
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:73
 msgid "Service"
-msgstr ""
+msgstr "Dienst"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
-msgstr ""
+msgstr "Dienst kan niet worden gedeselecteerd. Klik op de infoknop voor meer details"
 
 #: senaite/core/exportimport/instruments/importer.py:315
 msgid "Service keyword {analysis_keyword} not found"
-msgstr ""
+msgstr "Dienstsleutelwoord {analysis_keyword} niet gevonden"
 
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:119
 msgid "Set Conditions"
-msgstr ""
+msgstr "Voorwaarden instellen"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:167
 msgid "Set remarks"
-msgstr ""
+msgstr "Opmerkingen instellen"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:171
 msgid "Set remarks for selected analyses"
-msgstr ""
+msgstr "Opmerkingen instellen voor geselecteerde analyses"
 
 #: bika/lims/content/analysisrequest.py:672
 msgid "Set the Sample Rejection workflow and the reasons"
-msgstr ""
+msgstr "Stel de workflow voor monsterafwijzing en de redenen in"
 
 #: bika/lims/content/instrumentmaintenancetask.py:128
 msgid "Set the maintenance task as closed."
-msgstr ""
+msgstr "Stel de onderhoudstaak in als gesloten."
 
 #: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
-msgstr ""
+msgstr "Stel de tekst in voor de hoofdtekst van de e-mail die naar de contactpersoon van de klant van het monster wordt verzonden als de optie 'E-mailmelding bij monsterafwijzing' is ingeschakeld. U kunt gereserveerde sleutelwoorden gebruiken: $sample_id, $sample_link, $reasons, $lab_address"
 
 #: senaite/core/registry/schema.py:40
 msgid "Settings for Clients"
-msgstr ""
+msgstr "Instellingen voor klanten"
 
 #: bika/lims/profiles/default/types/BikaSetup.xml
 msgid "Setup"
-msgstr ""
+msgstr "Instellingen"
 
 #: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
-msgstr ""
+msgstr "Legplankcode"
 
 #: bika/lims/content/storagelocation.py:83
 msgid "Shelf Description"
-msgstr ""
+msgstr "Legplankbeschrijving"
 
 #: bika/lims/content/storagelocation.py:73
 msgid "Shelf Title"
-msgstr ""
+msgstr "Legplanktitel"
 
 #: bika/lims/config.py:84
 msgid "Shipping address"
-msgstr ""
+msgstr "Verzendadres"
 
 #: bika/lims/content/client.py:61
 msgid "Short and unique identifier of this client. Besides fast searches by client in Samples listings, the purposes of this field depend on the laboratory needs. For instance, the Client ID can be included as part of the Sample identifier, so the lab can easily know the client a given sample belongs to by just looking to its ID."
-msgstr ""
+msgstr "Korte en unieke identificatie van deze klant. Naast snel zoeken op klant in monsterlijsten hangen de doeleinden van dit veld af van de behoeften van het laboratorium. De klant-ID kan bijvoorbeeld worden opgenomen als onderdeel van de monsteridentificatie, zodat het lab eenvoudig kan weten tot welke klant een bepaald monster behoort door alleen naar de ID te kijken."
 
 #: bika/lims/content/method.py:160
 msgid "Short method description"
-msgstr ""
+msgstr "Korte methodebeschrijving"
 
 #: bika/lims/content/abstractbaseanalysis.py:68
 msgid "Short title"
-msgstr ""
+msgstr "Korte titel"
 
 #: bika/lims/content/analysisrequest.py:974
 msgid "Should the analyses be excluded from the invoice?"
-msgstr ""
+msgstr "Moeten de analyses worden uitgesloten van de factuur?"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:127
 msgid "Should the default example content be added to the site?"
-msgstr ""
+msgstr "Moet de standaard voorbeeldinhoud aan de site worden toegevoegd?"
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
-msgstr ""
+msgstr "Aanvullende velden tonen"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
-msgstr ""
+msgstr "Alles tonen"
 
 #: senaite/core/api/remarks.py:486
 msgid "Show history"
-msgstr ""
+msgstr "Geschiedenis tonen"
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
-msgstr ""
+msgstr "Laatste logboeken voor automatische import tonen"
 
 #: senaite/core/api/remarks.py:489
 msgid "Show less"
-msgstr ""
+msgstr "Minder tonen"
 
 #: senaite/core/api/remarks.py:488
 msgid "Show more"
-msgstr ""
+msgstr "Meer tonen"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
-msgstr ""
+msgstr "Standaardvelden tonen"
 
 # senaite.app.listing: Column config — plus button tooltip / aria-label
 msgid "Show this column"
-msgstr ""
+msgstr "Deze kolom tonen"
 
 #: senaite/core/browser/dashboard/dashboard.py:129
 msgid "Show/hide timeline"
-msgstr ""
+msgstr "Tijdlijn tonen/verbergen"
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
-msgstr ""
+msgstr "Handtekening"
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "Simple File"
-msgstr ""
+msgstr "Eenvoudig bestand"
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "Simple Image"
-msgstr ""
+msgstr "Eenvoudige afbeelding"
 
 #: bika/lims/content/storagelocation.py:43
 msgid "Site Code"
-msgstr ""
+msgstr "Sitecode"
 
 #: bika/lims/content/storagelocation.py:48
 msgid "Site Description"
-msgstr ""
+msgstr "Sitebeschrijving"
 
 #: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
-msgstr ""
+msgstr "Sitelogo"
 
 #: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
-msgstr ""
+msgstr "Sitelogo-CSS"
 
 #: bika/lims/content/storagelocation.py:38
 msgid "Site Title"
-msgstr ""
+msgstr "Sitetitel"
 
 #: senaite/core/browser/clients/client/attachments/view.py:67
 #: senaite/core/browser/viewlets/templates/attachments.pt:65
 msgid "Size"
-msgstr ""
+msgstr "Grootte"
 
 #: senaite/core/exportimport/instruments/importer.py:648
 msgid "Skipping result for analysis '{keyword}' of sample '{sid}' with calculation '{calculation}'"
-msgstr ""
+msgstr "Resultaat voor analyse '{keyword}' van monster '{sid}' met berekening '{calculation}' wordt overgeslagen"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Small Sticker"
-msgstr ""
+msgstr "Kleine sticker"
 
 #: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
-msgstr ""
+msgstr "Klein stickersjabloon"
 
 #: bika/lims/browser/auditlog.py:98
 msgid "Snapshot"
-msgstr ""
+msgstr "Momentopname"
 
 #: bika/lims/browser/worksheet/views/results.py:190
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
-msgstr ""
+msgstr "Sommige analyses gebruiken verouderde of niet-gekalibreerde instrumenten. Bewerken van resultaten niet toegestaan"
 
 #: bika/lims/content/abstractbaseanalysis.py:82
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
-msgstr ""
+msgstr "Sorteersleutel"
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort ascending"
-msgstr ""
+msgstr "Oplopend sorteren"
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort descending"
-msgstr ""
+msgstr "Aflopend sorteren"
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
-msgstr ""
+msgstr "Bron"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:93
 msgid "Specification"
-msgstr ""
+msgstr "Specificatie"
 
 #: senaite/core/content/dynamicanalysisspec.py:50
 msgid "Specification File"
-msgstr ""
+msgstr "Specificatiebestand"
 
 #: bika/lims/content/analysisrequest.py:707
 msgid "Specification Name"
-msgstr ""
+msgstr "Specificatienaam"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:18
 msgid "Specification ranges have changed since they were assigned"
-msgstr ""
+msgstr "De specificatiebereiken zijn gewijzigd sinds ze werden toegewezen"
 
 #: bika/lims/content/analysisspec.py:90
 msgid "Specifications"
-msgstr ""
+msgstr "Specificaties"
 
 #: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
-msgstr ""
+msgstr "Geef aan hoeveel exemplaren van elke sticker standaard moeten worden afgedrukt."
 
 #: bika/lims/content/worksheettemplate.py:63
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
-msgstr ""
+msgstr "Geef de grootte van het werkblad op, bijvoorbeeld overeenkomend met de trayafmeting van een specifiek instrument. Selecteer vervolgens een analyse-'type' per werkbladpositie. Waar QC-monsters worden geselecteerd, selecteer ook welk referentiemonster moet worden gebruikt. Als een duplicaatanalyse wordt geselecteerd, geef dan aan van welke monsterpositie het een duplicaat moet zijn"
 
 #: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
-msgstr ""
+msgstr "Splitslengte"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:149
 #: senaite/core/registry/schema.py:205
 msgid "Standard fields"
-msgstr ""
+msgstr "Standaardvelden"
 
 #: bika/lims/browser/pricelist.py:64
 msgid "Start Date"
-msgstr ""
+msgstr "Startdatum"
 
 #: bika/lims/validators.py:237
 msgid "Start date must be before End Date"
-msgstr ""
+msgstr "Startdatum moet vóór einddatum liggen"
 
 #: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
-msgstr ""
+msgstr "Status"
 
 #: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
-msgstr ""
+msgstr "Sticker"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Stickers preview"
-msgstr ""
+msgstr "Voorbeeld van stickers"
 
 # senaite.app.listing: Saved filter presets — star action tooltip when active
 msgid "Stop auto-applying"
-msgstr ""
+msgstr "Automatisch toepassen stoppen"
 
 #: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
-msgstr ""
+msgstr "Opslaglocatie"
 
 #: senaite/core/profiles/default/types/StorageLocations.xml
 msgid "Storage Locations"
-msgstr ""
+msgstr "Opslaglocaties"
 
 #: senaite/core/config/vocabularies.py:55
 msgid "String"
-msgstr ""
+msgstr "Tekenreeks"
 
 #: senaite/core/profiles/default/types/SubGroup.xml
 msgid "SubGroup"
-msgstr ""
+msgstr "Subgroep"
 
 #: senaite/core/profiles/default/types/SubGroups.xml
 msgid "SubGroups"
-msgstr ""
+msgstr "Subgroepen"
 
 #: bika/lims/content/subgroup.py:39
 msgid "Subgroups are sorted with this key in group views"
-msgstr ""
+msgstr "Subgroepen worden met deze sleutel gesorteerd in groepsweergaven"
 
 #: bika/lims/browser/publish/templates/email.pt:115
 #: bika/lims/browser/templates/analysisreport_info.pt:165
 msgid "Subject"
-msgstr ""
+msgstr "Onderwerp"
 
 #: senaite/core/exportimport/import.pt:124
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Submit"
-msgstr ""
+msgstr "Indienen"
 
 #: senaite/core/exportimport/import.pt:114
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
-msgstr ""
+msgstr "Dien een geldig Open XML-bestand (.XLSX) in met instellingsrecords om door te gaan."
 
 #: senaite/core/browser/dashboard/dashboard.py:490
 msgid "Submitted analyses awaiting verification"
-msgstr ""
+msgstr "Ingediende analyses in afwachting van verificatie"
 
 #: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
-msgstr ""
+msgstr "Ingediend en geverifieerd door dezelfde gebruiker: {}"
 
 #: bika/lims/browser/analyses/view.py:181
 msgid "Submitter"
-msgstr ""
+msgstr "Indiener"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
-msgstr ""
+msgstr "Subtotaal"
 
 #: senaite/core/vocabularies/setup.py:162
 msgid "Sunday"
-msgstr ""
+msgstr "Zondag"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:600
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Supplier"
-msgstr ""
+msgstr "Leverancier"
 
 #: senaite/core/profiles/default/types/Suppliers.xml
 msgid "Suppliers"
-msgstr ""
+msgstr "Leveranciers"
 
 #: bika/lims/browser/worksheet/views/referencesamples.py:75
 msgid "Supported Services"
-msgstr ""
+msgstr "Ondersteunde diensten"
 
 #: bika/lims/content/method.py:116
 msgid "Supported calculations of this method"
-msgstr ""
+msgstr "Ondersteunde berekeningen van deze methode"
 
 #: bika/lims/content/person.py:75
 msgid "Surname"
-msgstr ""
+msgstr "Achternaam"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:33
 msgid "Switch to classic view"
-msgstr ""
+msgstr "Overschakelen naar klassieke weergave"
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:6
 msgid "Switch to dashboard"
-msgstr ""
+msgstr "Overschakelen naar dashboard"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:25
 msgid "Switch to transposed view"
-msgstr ""
+msgstr "Overschakelen naar getransponeerde weergave"
 
 #: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
-msgstr ""
+msgstr "Systeemstandaard"
 
 #: bika/lims/browser/instrument.py:84
 msgid "Task"
-msgstr ""
+msgstr "Taak"
 
 #: bika/lims/content/instrumentcertification.py:57
 msgid "Task ID"
-msgstr ""
+msgstr "Taak-ID"
 
 #. Default: "Type"
 #: bika/lims/browser/instrument.py:86
 #: bika/lims/content/instrumentscheduledtask.py:66
 msgid "Task type"
-msgstr ""
+msgstr "Type"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:217
 msgid "Taxes"
-msgstr ""
+msgstr "Belastingen"
 
 #: bika/lims/content/method.py:78
 msgid "Technical description and instructions intended for analysts"
-msgstr ""
+msgstr "Technische beschrijving en instructies bedoeld voor analisten"
 
 #: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
-msgstr ""
+msgstr "Sjabloon"
 
 #: bika/lims/content/calculation.py:156
 msgid "Test Parameters"
-msgstr ""
+msgstr "Testparameters"
 
 #: bika/lims/content/calculation.py:170
 msgid "Test Result"
-msgstr ""
+msgstr "Testresultaat"
 
 #: senaite/core/config/vocabularies.py:56
 msgid "Text"
-msgstr ""
+msgstr "Tekst"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:5
 msgid "Thank you for your analysis request."
-msgstr ""
+msgstr "Bedankt voor uw analyseaanvraag."
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:54
 msgid "The ID of the site. This ends up as part of the URL. No special characters or spaces are allowed."
-msgstr ""
+msgstr "De ID van de site. Deze wordt onderdeel van de URL. Speciale tekens of spaties zijn niet toegestaan."
 
 #: bika/lims/content/laboratory.py:65
 msgid "The Laboratory's web address"
-msgstr ""
+msgstr "Het webadres van het laboratorium"
 
 #: senaite/core/browser/form/adapters/referencesample.py:46
 msgid "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
-msgstr ""
+msgstr "De referentiemonster-ID kan niet worden gewijzigd omdat deze al is gekoppeld aan andere objecten, zoals QC-analyses."
 
 #: bika/lims/content/laboratory.py:142
 msgid "The accreditation standard that applies, e.g. ISO 17025"
-msgstr ""
+msgstr "De van toepassing zijnde accreditatienorm, bijv. ISO 17025"
 
 #: bika/lims/content/analysisprofile.py:65
 msgid "The analyses included in this profile, grouped per category"
-msgstr ""
+msgstr "De analyses die in dit profiel zijn opgenomen, gegroepeerd per categorie"
 
 #: bika/lims/content/instrumentcalibration.py:97
 msgid "The analyst or agent responsible of the calibration"
-msgstr ""
+msgstr "De analist of medewerker die verantwoordelijk is voor de kalibratie"
 
 #: bika/lims/content/instrumentmaintenancetask.py:84
 msgid "The analyst or agent responsible of the maintenance"
-msgstr ""
+msgstr "De analist of medewerker die verantwoordelijk is voor het onderhoud"
 
 #: bika/lims/content/instrumentvalidation.py:79
 msgid "The analyst responsible of the validation"
-msgstr ""
+msgstr "De analist die verantwoordelijk is voor de validatie"
 
 #: bika/lims/browser/batch/batchbook.py:38
 msgid "The batch book allows to introduce analysis results for all samples in this batch. Please note that submitting the results for verification is only possible within samples or worksheets, because additional information like e.g. the instrument or the method need to be set additionally."
-msgstr ""
+msgstr "Met het batchboek kunt u analyseresultaten invoeren voor alle monsters in deze batch. Houd er rekening mee dat het indienen van de resultaten voor verificatie alleen mogelijk is binnen monsters of werkbladen, omdat aanvullende informatie zoals bijvoorbeeld het instrument of de methode aanvullend moet worden ingesteld."
 
 #: bika/lims/content/analysisrequest.py:852
 msgid "The client side identifier of the sample"
-msgstr ""
+msgstr "De identificatie van het monster aan de klantzijde"
 
 #: bika/lims/content/analysisrequest.py:818
 msgid "The client side order number for this request"
-msgstr ""
+msgstr "Het ordernummer aan de klantzijde voor deze aanvraag"
 
 #: bika/lims/content/analysisrequest.py:835
 msgid "The client side reference for this request"
-msgstr ""
+msgstr "De referentie aan de klantzijde voor deze aanvraag"
 
 #: bika/lims/content/instrument.py:348
 msgid "The date the instrument was installed"
-msgstr ""
+msgstr "De datum waarop het instrument is geïnstalleerd"
 
 #: bika/lims/content/analysisrequest.py:623
 msgid "The date when the sample was preserved"
-msgstr ""
+msgstr "De datum waarop het monster is geconserveerd"
 
 #: bika/lims/content/analysisrequest.py:1077
 msgid "The date when the sample was received"
-msgstr ""
+msgstr "De datum waarop het monster is ontvangen"
 
 #: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
-msgstr ""
+msgstr "Het decimaalteken dat is geselecteerd in Bika Setup wordt gebruikt."
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:113
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
-msgstr ""
+msgstr "De standaardinstelling voor de tijdzone van het portaal. Gebruikers kunnen hun eigen tijdzone instellen, mits er beschikbare tijdzones zijn gedefinieerd in de datum- en tijdinstellingen."
 
 #: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-msgstr ""
+msgstr "Het hier ingevoerde kortingspercentage wordt toegepast op de prijzen voor klanten die zijn gemarkeerd als 'leden', doorgaans coöperatieve leden of partners die deze korting verdienen"
 
 #: bika/lims/browser/publish/emailview.py:179
 msgid "The email 'From' address is invalid. Please verify the \"Publication 'From' address\" in Setup > Notifications and/or the \"Site 'From' address\" in Site Setup > Mail."
-msgstr ""
+msgstr "Het 'Van'-e-mailadres is ongeldig. Controleer het \"Publicatie-'Van'-adres\" in Instellingen > Meldingen en/of het \"Site-'Van'-adres\" in Site-instellingen > E-mail."
 
 #: bika/lims/content/analysisrequest.py:940
 msgid "The environmental condition during sampling"
-msgstr ""
+msgstr "De omgevingsconditie tijdens de monstername"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:104
 msgid "The fields are always listed on top and can not be faded out. You can drag and drop any fields to the lower list to change thier visibility."
-msgstr ""
+msgstr "De velden worden altijd bovenaan weergegeven en kunnen niet worden verborgen. U kunt velden naar de onderste lijst slepen om hun zichtbaarheid te wijzigen."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:150
 msgid "The fields are listed below the promient fields and can be faded out. You can drag and drop any fields to the upper list to change their visibility."
-msgstr ""
+msgstr "De velden worden onder de prominente velden weergegeven en kunnen worden verborgen. U kunt velden naar de bovenste lijst slepen om hun zichtbaarheid te wijzigen."
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:20
 msgid "The following partitions have been created from this Sample:"
-msgstr ""
+msgstr "De volgende partities zijn aangemaakt op basis van dit monster:"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:47
 msgid "The following sample(s) will be dispatched"
-msgstr ""
+msgstr "De volgende monster(s) worden verzonden"
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:47
 msgid "The following sample(s) will be disposed"
-msgstr ""
+msgstr "De volgende monster(s) worden afgevoerd"
 
 #: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
-msgstr ""
+msgstr "Het globale auditlogboek toont alle wijzigingen van het systeem. Indien ingeschakeld, worden alle entiteiten geïndexeerd in een aparte catalogus. Dit verlengt de tijd bij het aanmaken of wijzigen van objecten."
 
 #: bika/lims/content/samplepoint.py:75
 msgid "The height or depth at which the sample has to be taken"
-msgstr ""
+msgstr "De hoogte of diepte waarop het monster moet worden genomen"
 
 #: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
-msgstr ""
+msgstr "De houdbaarheidstijd voor dit monster en deze analyse is verstreken. Doorgaan met de analyse kan de betrouwbaarheid van de resultaten in gevaar brengen."
 
 #: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
-msgstr ""
+msgstr "De houdbaarheidstijd voor dit monster en deze analyse verloopt binnenkort. Voltooi de analyse zo snel mogelijk om de nauwkeurigheid en betrouwbaarheid van de gegevens te waarborgen."
 
 #: bika/lims/content/instrument.py:309
 #: bika/lims/content/instrumentcertification.py:58
 msgid "The instrument's ID in the lab's asset register"
-msgstr ""
+msgstr "De ID van het instrument in het inventarisregister van het lab"
 
 #: bika/lims/content/instrument.py:138
 msgid "The instrument's model number"
-msgstr ""
+msgstr "Het modelnummer van het instrument"
 
 #: bika/lims/content/instrumentcertification.py:111
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
-msgstr ""
+msgstr "Het interval wordt berekend vanaf het veld 'Van' en bepaalt na hoeveel dagen het certificaat verloopt. Het instellen van dit interval overschrijft het veld 'Tot' bij opslaan."
 
 #: senaite/core/browser/samples/invalidate_samples.py:121
 msgid "The invalidation process has been successfully cancelled."
-msgstr ""
+msgstr "Het ongeldigverklaringsproces is met succes geannuleerd."
 
 #: bika/lims/browser/accreditation.py:71
 msgid "The lab is not accredited, or accreditation has not been configured. "
-msgstr ""
+msgstr "Het lab is niet geaccrediteerd, of de accreditatie is niet geconfigureerd. "
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:90
 msgid "The main language of the site."
-msgstr ""
+msgstr "De hoofdtaal van de site."
 
 #: bika/lims/content/sampletype.py:166
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
-msgstr ""
+msgstr "Het minimale monstervolume dat nodig is voor analyse, bijv. '10 ml' of '1 kg'."
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:40
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
-msgstr ""
+msgstr "De opslag van de nummergenerator is leeg. Tellers worden geïnitialiseerd bij de eerste ID-generatie voor elk voorvoegsel."
 
 #: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
-msgstr ""
+msgstr "Het aantal dagen voordat een monster verloopt en niet meer kan worden geanalyseerd. Deze instelling kan per afzonderlijk monstertype worden overschreven in de instellingen voor monstertypen"
 
 #: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-msgstr ""
+msgstr "Het aantal minuten voordat een gebruiker automatisch wordt afgemeld. 0 schakelt automatisch afmelden uit"
 
 #: bika/lims/content/sampletype.py:117
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
-msgstr ""
+msgstr "De periode gedurende welke niet-geconserveerde monsters van dit type kunnen worden bewaard voordat ze verlopen en niet verder kunnen worden geanalyseerd"
 
 #: bika/lims/content/analysisrequest.py:644
 msgid "The person who preserved the sample"
-msgstr ""
+msgstr "De persoon die het monster heeft geconserveerd"
 
 #: bika/lims/content/analysisrequest.py:477
 msgid "The person who took the sample"
-msgstr ""
+msgstr "De persoon die het monster heeft genomen"
 
 #: bika/lims/content/abstractbaseanalysis.py:562
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
-msgstr ""
+msgstr "De prijs die per analyse in rekening wordt gebracht voor klanten die in aanmerking komen voor volumekortingen"
 
 #: bika/lims/content/analysisprofile.py:92
 msgid "The profile's commercial ID for accounting purposes."
-msgstr ""
+msgstr "De commerciële ID van het profiel voor boekhoudkundige doeleinden."
 
 #: bika/lims/content/analysisprofile.py:52
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
-msgstr ""
+msgstr "Het sleutelwoord van het profiel wordt gebruikt om het uniek te identificeren in importbestanden. Het moet uniek zijn en mag niet hetzelfde zijn als een ID van een tussentijds berekeningsveld."
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:23
 msgid "The ranges for the following analyses have been manually changed and they are no longer compliant with the ranges of the Specification:"
-msgstr ""
+msgstr "De bereiken voor de volgende analyses zijn handmatig gewijzigd en voldoen niet langer aan de bereiken van de specificatie:"
 
 #: bika/lims/content/laboratory.py:153
 msgid "The reference code issued to the lab by the accreditation body"
-msgstr ""
+msgstr "De referentiecode die door de accreditatie-instantie aan het lab is toegekend"
 
 #: bika/lims/content/calculation.py:171
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
-msgstr ""
+msgstr "Het resultaat nadat de berekening met testwaarden heeft plaatsgevonden. U moet de berekening opslaan voordat deze waarde wordt berekend."
 
 #: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
-msgstr ""
+msgstr "Het resultaat is vastgelegd na de houdbaarheidstijdlimiet."
 
 #: bika/lims/content/method.py:149
 msgid "The results for the Analysis Services that use this method can be set manually"
-msgstr ""
+msgstr "De resultaten voor de analysediensten die deze methode gebruiken, kunnen handmatig worden ingesteld"
 
 #: bika/lims/content/abstractbaseanalysis.py:514
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
-msgstr ""
+msgstr "De resultaten van veldanalyses worden vastgelegd tijdens de monstername op het monsterpunt, bijv. de temperatuur van een watermonster in de rivier waar het wordt genomen. Labanalyses worden in het laboratorium uitgevoerd"
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:8
 msgid "The sample cannot be received"
-msgstr ""
+msgstr "Het monster kan niet worden ontvangen"
 
 #: bika/lims/content/artemplate.py:110
 msgid "The sample is a mix of sub samples"
-msgstr ""
+msgstr "Het monster is een mengsel van submonsters"
 
 #: bika/lims/content/instrument.py:146
 msgid "The serial number that uniquely identifies the instrument"
-msgstr ""
+msgstr "Het serienummer dat het instrument uniek identificeert"
 
 #: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
-msgstr ""
+msgstr "De ID van het analytische protocol van de dienst"
 
 #: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
-msgstr ""
+msgstr "De commerciële ID van de dienst voor boekhoudkundige doeleinden"
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:14
 msgid "The specification has a Dynamic Specification assigned"
-msgstr ""
+msgstr "Aan de specificatie is een dynamische specificatie toegewezen"
 
 #: senaite/core/schema/emailfield.py:12
 msgid "The specified email is not valid."
-msgstr ""
+msgstr "Het opgegeven e-mailadres is niet geldig."
 
 #: bika/lims/content/referencesample.py:65
 msgid "The unique identifier for this reference sample. If specified, the system will use this value as the sample's ID instead of automatically generating one based on the formatting rules defined in the setup's ID server."
-msgstr ""
+msgstr "De unieke identificatie voor dit referentiemonster. Indien opgegeven, gebruikt het systeem deze waarde als de ID van het monster in plaats van er automatisch een te genereren op basis van de opmaakregels die zijn gedefinieerd in de ID-server van de instellingen."
 
 #: bika/lims/content/abstractbaseanalysis.py:363
 msgid "The unique keyword used to identify the analysis service in import files of bulk Sample requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
-msgstr ""
+msgstr "Het unieke sleutelwoord dat wordt gebruikt om de analysedienst te identificeren in importbestanden van bulk-monsteraanvragen en resultaatimports van instrumenten. Het wordt ook gebruikt om afhankelijke analysediensten te identificeren in door de gebruiker gedefinieerde resultaatberekeningen"
 
 #: bika/lims/browser/analysisrequest/add2.py:1461
 msgid "The value of field '%s' was emptied. Please select a new value."
-msgstr ""
+msgstr "De waarde van veld '%s' is leeggemaakt. Selecteer een nieuwe waarde."
 
 #: bika/lims/browser/publish/templates/email.pt:126
 msgid "The variable ${recipients} will be automatically replaced with the names and emails of the final selected recipients."
-msgstr ""
+msgstr "De variabele ${recipients} wordt automatisch vervangen door de namen en e-mailadressen van de uiteindelijk geselecteerde ontvangers."
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:93
 msgid "There are no pre-defined conditions set"
-msgstr ""
+msgstr "Er zijn geen vooraf gedefinieerde voorwaarden ingesteld"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:14
 msgid "This Analysis Specification has a Dynamic Specification assigned"
-msgstr ""
+msgstr "Aan deze analysespecificatie is een dynamische specificatie toegewezen"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:15
 msgid "This Sample has been rejected due to the following reasons:"
-msgstr ""
+msgstr "Dit monster is afgewezen om de volgende redenen:"
 
 #: bika/lims/browser/viewlets/templates/partition_ar_viewlet.pt:14
 msgid "This is a Partition from Sample"
-msgstr ""
+msgstr "Dit is een partitie van monster"
 
 #: bika/lims/browser/viewlets/templates/secondary_ar_viewlet.pt:15
 msgid "This is a Secondary Sample of"
-msgstr ""
+msgstr "Dit is een secundair monster van"
 
 #: bika/lims/browser/viewlets/templates/detached_partition_viewlet.pt:15
 msgid "This is a detached partition from Sample"
-msgstr ""
+msgstr "Dit is een losgekoppelde partitie van monster"
 
 #: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
-msgstr ""
+msgstr "Dit is de standaard maximale tijd die is toegestaan voor het uitvoeren van analyses. Deze wordt alleen gebruikt voor analyses waarbij de analysedienst geen doorlooptijd opgeeft. Alleen laboratoriumwerkdagen worden in aanmerking genomen."
 
 #: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
-msgstr ""
+msgstr "Dit is de standaard maximale tijd die is toegestaan voor het uitvoeren van analyses. Deze wordt alleen gebruikt voor analyses waarbij de analysedienst geen doorlooptijd opgeeft. Alleen laboratoriumwerkdagen worden in aanmerking genomen."
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:134
 msgid "This operation can not be undone. Are you sure you want to reject the selected analyses?"
-msgstr ""
+msgstr "Deze bewerking kan niet ongedaan worden gemaakt. Weet u zeker dat u de geselecteerde analyses wilt afwijzen?"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:14
 msgid "This report was sent to the following contacts:"
-msgstr ""
+msgstr "Dit rapport is verzonden naar de volgende contactpersonen:"
 
 #: bika/lims/browser/viewlets/templates/retest_ar_viewlet.pt:19
 msgid "This sample is a retest, automatically generated following the invalidation of sample ${invalidated_id}."
-msgstr ""
+msgstr "Dit monster is een hertest, automatisch gegenereerd na de ongeldigverklaring van monster ${invalidated_id}."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:28
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date} for the following reason(s): ${reason}."
-msgstr ""
+msgstr "Dit monster is ongeldig verklaard door ${actor_fullname} (${actor_id}) op ${date} om de volgende reden(en): ${reason}."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:38
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
-msgstr ""
+msgstr "Dit monster is ongeldig verklaard door ${actor_fullname} (${actor_id}) op ${date}."
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
-msgstr ""
+msgstr "Deze dienst kan niet worden geselecteerd om te voorkomen dat de analyse wordt uitgevoerd na de analytische houdbaarheidstijd."
 
 #: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
-msgstr ""
+msgstr "Dit toont een aangepast logo op uw SENAITE-site."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:57
 msgid "This site configuration is outdated and needs to be upgraded:"
-msgstr ""
+msgstr "Deze siteconfiguratie is verouderd en moet worden bijgewerkt:"
 
 #: bika/lims/content/laboratory.py:100
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
+msgstr "Deze waarde wordt onderaan alle gepubliceerde resultaten vermeld"
 
 #: bika/lims/browser/worksheet/tools.py:84
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
-msgstr ""
+msgstr "Dit werkblad is aangemaakt ter vervanging van het afgewezen werkblad bij ${ws_id}"
 
 #: bika/lims/browser/worksheet/tools.py:77
 msgid "This worksheet has been rejected.  The replacement worksheet is ${ws_id}"
-msgstr ""
+msgstr "Dit werkblad is afgewezen. Het vervangende werkblad is ${ws_id}"
 
 #: senaite/core/vocabularies/setup.py:159
 msgid "Thursday"
-msgstr ""
+msgstr "Donderdag"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:47
 msgid "Time"
-msgstr ""
+msgstr "Tijd"
 
 #: senaite/core/exportimport/import.pt:129
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
-msgstr ""
+msgstr "Tip. Bijgevoegde documenten worden niet geladen tenzij ze aanwezig zijn in de instantie."
 
 #: senaite/core/browser/controlpanel/labels/view.py:60
 #: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
-msgstr ""
+msgstr "Titel"
 
 #: bika/lims/content/storagelocation.py:54
 msgid "Title of location"
-msgstr ""
+msgstr "Titel van locatie"
 
 #: bika/lims/controlpanel/dynamic_analysisspecs.py:35
 msgid "Title of the Folder"
-msgstr ""
+msgstr "Titel van de map"
 
 #: bika/lims/content/storagelocation.py:74
 msgid "Title of the shelf"
-msgstr ""
+msgstr "Titel van de legplank"
 
 #: bika/lims/content/storagelocation.py:39
 msgid "Title of the site"
-msgstr ""
+msgstr "Titel van de site"
 
 #: bika/lims/content/instrumentcalibration.py:88
 #: bika/lims/content/instrumentmaintenancetask.py:75
 #: bika/lims/content/instrumentvalidation.py:70
 msgid "To"
-msgstr ""
+msgstr "Tot"
 
 #: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
-msgstr ""
+msgstr "Te conserveren"
 
 #: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
-msgstr ""
+msgstr "Te bemonsteren"
 
 #: senaite/core/browser/dashboard/dashboard.py:93
 msgid "To be Published"
-msgstr ""
+msgstr "Te publiceren"
 
 #: senaite/core/browser/dashboard/dashboard.py:89
 msgid "To be Verified"
-msgstr ""
+msgstr "Te verifiëren"
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
-msgstr ""
+msgstr "Om onder elke analysecategoriesectie op resultaatrapporten te worden weergegeven."
 
 #: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
-msgstr ""
+msgstr "Te conserveren"
 
 #: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
-msgstr ""
+msgstr "Af te drukken"
 
 #: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
-msgstr ""
+msgstr "Te bemonsteren"
 
 #: senaite/core/browser/dashboard/dashboard.py:148
 #: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
-msgstr ""
+msgstr "Te verifiëren"
 
 #: bika/lims/content/calculation.py:157
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
-msgstr ""
+msgstr "Voer hier waarden in voor alle berekeningsparameters om de berekening te testen. Dit omvat hierboven gedefinieerde tussentijdse velden, evenals eventuele diensten waarvan deze berekening afhankelijk is om resultaten te berekenen."
 
 #: senaite/core/registry/schema.py:174
 msgid "Toggle visibility of standard sample header fields"
-msgstr ""
+msgstr "Zichtbaarheid van standaard monsterkopvelden in-/uitschakelen"
 
 #: senaite/core/browser/samples/view.py:650
 msgid "Total"
-msgstr ""
+msgstr "Totaal"
 
 #: bika/lims/content/analysisprofile.py:142
 #: bika/lims/content/labproduct.py:67
 msgid "Total price"
-msgstr ""
+msgstr "Totaalprijs"
 
 #: bika/lims/browser/publish/emailview.py:202
 msgid "Total size of email exceeded {:.1f} MB ({:.2f} MB)"
-msgstr ""
+msgstr "Totale grootte van de e-mail overschreed {:.1f} MB ({:.2f} MB)"
 
 #: bika/lims/config.py:126
 msgid "Transposed"
-msgstr ""
+msgstr "Getransponeerd"
 
 #: senaite/core/vocabularies/setup.py:157
 msgid "Tuesday"
-msgstr ""
+msgstr "Dinsdag"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
 #: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:64
 msgid "Type of control to be displayed on value entry when choices are set"
-msgstr ""
+msgstr "Type besturingselement dat bij waarde-invoer wordt weergegeven wanneer keuzes zijn ingesteld"
 
 #: bika/lims/content/multifile.py:74
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
-msgstr ""
+msgstr "Type document (bijv. gebruikershandleiding, instrumentspecificaties, afbeelding, ...)"
 
 #: bika/lims/content/storagelocation.py:69
 msgid "Type of location"
-msgstr ""
+msgstr "Type locatie"
 
 #: senaite/core/content/samplecontainer.py:73
 msgid "Type of the container"
-msgstr ""
+msgstr "Type van de container"
 
 #: senaite/core/browser/controlpanel/templates/setupview.pt:27
 msgid "Type to filter ..."
-msgstr ""
+msgstr "Typ om te filteren ..."
 
 # senaite.app.listing: Column-filter row — searchable-select placeholder
 msgid "Type to filter..."
-msgstr ""
+msgstr "Typ om te filteren..."
 
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
-msgstr ""
+msgstr "Typen die labels rechtstreeks ondersteunen.<br/>OPMERKING: In clusteropstellingen moeten andere instanties handmatig opnieuw worden gestart om de wijzigingen door te voeren!"
 
 #: senaite/core/registry/schema.py:77
 msgid "Types with labels"
-msgstr ""
+msgstr "Typen met labels"
 
 #: senaite/core/content/resultsreport.py:100
 msgid "UID"
-msgstr ""
+msgstr "UID"
 
 #: bika/lims/browser/worksheet/views/printview.py:151
 msgid "Unable to load the template"
-msgstr ""
+msgstr "Kan het sjabloon niet laden"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassign"
-msgstr ""
+msgstr "Toewijzing opheffen"
 
 #: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
-msgstr ""
+msgstr "Niet toegewezen"
 
 #: senaite/core/browser/modals/analysis/schema.py:61
 msgid "Uncertainty"
-msgstr ""
+msgstr "Onzekerheid"
 
 #: bika/lims/content/abstractbaseanalysis.py:622
 msgid "Uncertainty value"
-msgstr ""
+msgstr "Onzekerheidswaarde"
 
 #: bika/lims/content/department.py:45
 msgid "Unique Department ID that identifies the department"
-msgstr ""
+msgstr "Unieke afdelings-ID die de afdeling identificeert"
 
 #: senaite/core/browser/modals/analysis/schema.py:96
 msgid "Unit"
-msgstr ""
+msgstr "Eenheid"
 
 #: senaite/core/browser/clients/client/attachments/view.py:125
 msgid "Unknown"
-msgstr ""
+msgstr "Onbekend"
 
 #: senaite/core/content/supplier.py:156
 msgid "Unknown IBAN country %s"
-msgstr ""
+msgstr "Onbekend IBAN-land %s"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:108
 msgid "Unlink User"
-msgstr ""
+msgstr "Gebruiker ontkoppelen"
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
-msgstr ""
+msgstr "Ontkoppelde gebruiker"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unlock"
-msgstr ""
+msgstr "Ontgrendelen"
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
-msgstr ""
+msgstr "Niet-herkend bestandsformaat ${file_format}"
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:51
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:63
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:51
 msgid "Unrecognized file format ${fileformat}"
-msgstr ""
+msgstr "Niet-herkend bestandsformaat ${fileformat}"
 
 #: senaite/core/exportimport/instruments/horiba/jobinyvon/icp.py:57
 msgid "Unrecognized file format ${format}"
-msgstr ""
+msgstr "Niet-herkend bestandsformaat ${format}"
 
 #: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
-msgstr ""
+msgstr "Niet toegewezen"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
-msgstr ""
+msgstr "Bijlagen bijwerken"
 
 # senaite.app.listing: Saved filter presets — Update preset action tooltip
 msgid "Update preset with current view"
-msgstr ""
+msgstr "Voorinstelling bijwerken met huidige weergave"
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
-msgstr ""
+msgstr "{} sleutel(s) bijgewerkt: {}"
 
 #: bika/lims/content/labcontact.py:47
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
-msgstr ""
+msgstr "Upload een gescande handtekening voor gebruik op afgedrukte analyseresultaatrapporten. De ideale grootte is 250 pixels breed bij 150 pixels hoog"
 
 #: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
-msgstr ""
+msgstr "Upload bestanden en afbeeldingen voor deze klant. Bestanden worden opgeslagen in de klantmap en kunnen later worden gedownload."
 
 #: bika/lims/content/analysisprofile.py:101
 msgid "Use Analysis Profile Price"
-msgstr ""
+msgstr "Analyseprofielprijs gebruiken"
 
 #: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
-msgstr ""
+msgstr "Dashboard als standaard startpagina gebruiken"
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:84
 msgid "Use Template"
-msgstr ""
+msgstr "Sjabloon gebruiken"
 
 #: bika/lims/content/analysisservice.py:87
 msgid "Use the Default Calculation of Method"
-msgstr ""
+msgstr "De standaardberekening van de methode gebruiken"
 
 #: bika/lims/content/instrument.py:292
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
-msgstr ""
+msgstr "Gebruik dit veld om willekeurige parameters door te geven aan de export-/importmodules."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:71
 #: senaite/core/browser/clients/client/contacts/view.py:74
 #: senaite/core/browser/controlpanel/contacts/view.py:62
 msgid "User Name"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:101
 msgid "User groups"
-msgstr ""
+msgstr "Gebruikersgroepen"
 
 #: senaite/core/browser/user/userdatapanel.py:181
 msgid "User is linked to lab contact '${fullname}'"
-msgstr ""
+msgstr "Gebruiker is gekoppeld aan labcontactpersoon '${fullname}'"
 
 #: senaite/core/browser/user/userdatapanel.py:192
 msgid "User is linked to the contact '${fullname}'"
-msgstr ""
+msgstr "Gebruiker is gekoppeld aan contactpersoon '${fullname}'"
 
 #: senaite/core/browser/user/userdatapanel.py:189
 msgid "User is linked to the global contact '${fullname}'"
-msgstr ""
+msgstr "Gebruiker is gekoppeld aan de globale contactpersoon '${fullname}'"
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
-msgstr ""
+msgstr "Gebruiker gekoppeld aan deze contactpersoon"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:98
 msgid "User name"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 #: senaite/core/content/resultsreport.py:105
 msgid "Username"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 #: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-msgstr ""
+msgstr "Te weinig datapunten gebruiken is statistisch niet zinvol. Stel een aanvaardbaar minimumaantal resultaten in voordat QC-statistieken worden berekend en uitgezet"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
-msgstr ""
+msgstr "Btw"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
 #: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
-msgstr ""
+msgstr "Btw %"
 
 #: bika/lims/content/organisation.py:52
 msgid "VAT number"
-msgstr ""
+msgstr "Btw-nummer"
 
 #: bika/lims/browser/analyses/view.py:223
 msgid "Valid"
-msgstr ""
+msgstr "Geldig"
 
 #: bika/lims/browser/instrument.py:662
 #: bika/lims/content/instrumentcertification.py:126
 msgid "Valid from"
-msgstr ""
+msgstr "Geldig vanaf"
 
 #: bika/lims/browser/instrument.py:663
 #: bika/lims/content/instrumentcertification.py:136
 msgid "Valid to"
-msgstr ""
+msgstr "Geldig tot"
 
 #: bika/lims/content/instrumentscheduledtask.py:122
 msgid "Validation"
-msgstr ""
+msgstr "Validatie"
 
 #: senaite/core/z3cform/error.py:32
 msgid "Validation failed."
-msgstr ""
+msgstr "Validatie mislukt."
 
 #: bika/lims/validators.py:346
 msgid "Validation failed: '${keyword}': duplicate keyword"
-msgstr ""
+msgstr "Validatie mislukt: '${keyword}': dubbel sleutelwoord"
 
 #: bika/lims/validators.py:365
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
-msgstr ""
+msgstr "Validatie mislukt: '${title}': Dit sleutelwoord is al in gebruik door dienst '${used_by}'"
 
 #: bika/lims/validators.py:354
 msgid "Validation failed: '${title}': duplicate title"
-msgstr ""
+msgstr "Validatie mislukt: '${title}': dubbele titel"
 
 #: bika/lims/validators.py:206
 msgid "Validation failed: '${value}' is not unique"
-msgstr ""
+msgstr "Validatie mislukt: '${value}' is niet uniek"
 
 #: bika/lims/validators.py:1465
 msgid "Validation failed: '{}' is not numeric"
-msgstr ""
+msgstr "Validatie mislukt: '{}' is niet numeriek"
 
 #: bika/lims/validators.py:624
 msgid "Validation failed: Bearing must be E/W"
-msgstr ""
+msgstr "Validatie mislukt: Peiling moet O/W zijn"
 
 #: bika/lims/validators.py:605
 msgid "Validation failed: Bearing must be N/S"
-msgstr ""
+msgstr "Validatie mislukt: Peiling moet N/Z zijn"
 
 #: bika/lims/validators.py:1350
 msgid "Validation failed: Could not import module '%s'"
-msgstr ""
+msgstr "Validatie mislukt: Kon module '%s' niet importeren"
 
 #: bika/lims/validators.py:966
 msgid "Validation failed: Error percentage must be between 0 and 100"
-msgstr ""
+msgstr "Validatie mislukt: Foutpercentage moet tussen 0 en 100 liggen"
 
 #: bika/lims/validators.py:982
 msgid "Validation failed: Error value must be 0 or greater"
-msgstr ""
+msgstr "Validatie mislukt: Foutwaarde moet 0 of groter zijn"
 
 #: bika/lims/validators.py:959
 msgid "Validation failed: Error values must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: Foutwaarden moeten numeriek zijn"
 
 #: bika/lims/validators.py:499
 msgid "Validation failed: Keyword '${keyword}' is invalid"
-msgstr ""
+msgstr "Validatie mislukt: Sleutelwoord '${keyword}' is ongeldig"
 
 #: bika/lims/validators.py:974
 msgid "Validation failed: Max values must be greater than Min values"
-msgstr ""
+msgstr "Validatie mislukt: Max-waarden moeten groter zijn dan Min-waarden"
 
 #: bika/lims/validators.py:944
 msgid "Validation failed: Max values must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: Max-waarden moeten numeriek zijn"
 
 #: bika/lims/validators.py:937
 msgid "Validation failed: Min values must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: Min-waarden moeten numeriek zijn"
 
 #: bika/lims/validators.py:1451
 msgid "Validation failed: Please set a default value when defining a required checkbox condition."
-msgstr ""
+msgstr "Validatie mislukt: Stel een standaardwaarde in bij het definiëren van een verplichte selectievakjevoorwaarde."
 
 #: bika/lims/validators.py:1445
 msgid "Validation failed: Please use the character '|' to separate the available options in 'Choices' subfield"
-msgstr ""
+msgstr "Validatie mislukt: Gebruik het teken '|' om de beschikbare opties in het subveld 'Keuzes' te scheiden"
 
 #: bika/lims/validators.py:770
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
-msgstr ""
+msgstr "Validatie mislukt: Voorgeconserveerde containers moeten een conservering geselecteerd hebben."
 
 #: bika/lims/validators.py:728
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
-msgstr ""
+msgstr "Validatie mislukt: De selectie vereist dat de volgende categorieën worden geselecteerd: ${categories}"
 
 #: bika/lims/validators.py:1014
 msgid "Validation failed: Values must be numbers"
-msgstr ""
+msgstr "Validatie mislukt: Waarden moeten getallen zijn"
 
 #: bika/lims/validators.py:393
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
-msgstr ""
+msgstr "Validatie mislukt: kolomtitel '${title}' moet sleutelwoord '${keyword}' hebben"
 
 #: bika/lims/validators.py:615
 msgid "Validation failed: degrees is 180; minutes must be zero"
-msgstr ""
+msgstr "Validatie mislukt: graden is 180; minuten moeten nul zijn"
 
 #: bika/lims/validators.py:620
 msgid "Validation failed: degrees is 180; seconds must be zero"
-msgstr ""
+msgstr "Validatie mislukt: graden is 180; seconden moeten nul zijn"
 
 #: bika/lims/validators.py:596
 msgid "Validation failed: degrees is 90; minutes must be zero"
-msgstr ""
+msgstr "Validatie mislukt: graden is 90; minuten moeten nul zijn"
 
 #: bika/lims/validators.py:601
 msgid "Validation failed: degrees is 90; seconds must be zero"
-msgstr ""
+msgstr "Validatie mislukt: graden is 90; seconden moeten nul zijn"
 
 #: bika/lims/validators.py:610
 msgid "Validation failed: degrees must be 0 - 180"
-msgstr ""
+msgstr "Validatie mislukt: graden moeten 0 - 180 zijn"
 
 #: bika/lims/validators.py:591
 msgid "Validation failed: degrees must be 0 - 90"
-msgstr ""
+msgstr "Validatie mislukt: graden moeten 0 - 90 zijn"
 
 #: bika/lims/validators.py:564
 msgid "Validation failed: degrees must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: graden moeten numeriek zijn"
 
 #: bika/lims/validators.py:405
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord '${keyword}' moet kolomtitel '${title}' hebben"
 
 #: senaite/core/api/analysisservice.py:172
 msgid "Validation failed: keyword contains invalid characters"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord bevat ongeldige tekens"
 
 #: senaite/core/api/analysisservice.py:177
 msgid "Validation failed: keyword is already in use"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord is al in gebruik"
 
 #: senaite/core/api/analysisservice.py:187
 msgid "Validation failed: keyword is already in use by calculation '{}'"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord is al in gebruik door berekening '{}'"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:95
 #: bika/lims/validators.py:324
 msgid "Validation failed: keyword is required"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord is verplicht"
 
 #: bika/lims/validators.py:580
 msgid "Validation failed: minutes must be 0 - 59"
-msgstr ""
+msgstr "Validatie mislukt: minuten moeten 0 - 59 zijn"
 
 #: bika/lims/validators.py:570
 msgid "Validation failed: minutes must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: minuten moeten numeriek zijn"
 
 #: bika/lims/validators.py:1042
 msgid "Validation failed: percent values must be between 0 and 100"
-msgstr ""
+msgstr "Validatie mislukt: procentwaarden moeten tussen 0 en 100 liggen"
 
 #: bika/lims/validators.py:1038
 msgid "Validation failed: percent values must be numbers"
-msgstr ""
+msgstr "Validatie mislukt: procentwaarden moeten getallen zijn"
 
 #: bika/lims/validators.py:584
 msgid "Validation failed: seconds must be 0 - 59"
-msgstr ""
+msgstr "Validatie mislukt: seconden moeten 0 - 59 zijn"
 
 #: bika/lims/validators.py:576
 msgid "Validation failed: seconds must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: seconden moeten numeriek zijn"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:88
 #: bika/lims/validators.py:320
 msgid "Validation failed: title is required"
-msgstr ""
+msgstr "Validatie mislukt: titel is verplicht"
 
 #: bika/lims/validators.py:1456
 msgid "Validation failed: value for Choices subfield is only required for when the control type of choice is 'Select'"
-msgstr ""
+msgstr "Validatie mislukt: waarde voor subveld Keuzes is alleen vereist wanneer het besturingstype van de keuze 'Select' is"
 
 #: bika/lims/validators.py:1438
 msgid "Validation failed: value for Choices subfield is required when the control type of choice is 'Select'"
-msgstr ""
+msgstr "Validatie mislukt: waarde voor subveld Keuzes is vereist wanneer het besturingstype van de keuze 'Select' is"
 
 #: senaite/core/content/analysiscategory.py:122
 #: senaite/core/content/subgroup.py:82
 msgid "Validation failed: value must be between 0 and 1000"
-msgstr ""
+msgstr "Validatie mislukt: waarde moet tussen 0 en 1000 liggen"
 
 #: senaite/core/content/analysiscategory.py:118
 #: senaite/core/content/subgroup.py:78
 msgid "Validation failed: value must be float"
-msgstr ""
+msgstr "Validatie mislukt: waarde moet een decimaal getal zijn"
 
 #: bika/lims/content/instrumentvalidation.py:51
 msgid "Validation report date"
-msgstr ""
+msgstr "Datum validatierapport"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Validations"
-msgstr ""
+msgstr "Validaties"
 
 #: bika/lims/browser/instrument.py:318
 #: bika/lims/content/instrumentvalidation.py:78
 msgid "Validator"
-msgstr ""
+msgstr "Validator"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:206
 msgid "Value"
-msgstr ""
+msgstr "Waarde"
 
 #: senaite/core/schema/coordinatefield.py:109
 msgid "Value for degrees must be within 0 and 180"
-msgstr ""
+msgstr "Waarde voor graden moet tussen 0 en 180 liggen"
 
 #: senaite/core/schema/coordinatefield.py:93
 msgid "Value for degrees must be within 0 and 90"
-msgstr ""
+msgstr "Waarde voor graden moet tussen 0 en 90 liggen"
 
 #: senaite/core/schema/coordinatefield.py:68
 msgid "Value for minutes must be within 0 and 59"
-msgstr ""
+msgstr "Waarde voor minuten moet tussen 0 en 59 liggen"
 
 #: senaite/core/schema/coordinatefield.py:77
 msgid "Value for seconds must be within 0 and 59.9999"
-msgstr ""
+msgstr "Waarde voor seconden moet tussen 0 en 59.9999 liggen"
 
 #: bika/lims/content/abstractanalysis.py:183
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
-msgstr ""
+msgstr "Hier kunnen waarden worden ingevoerd die de standaardwaarden overschrijven die zijn opgegeven in de tussenvelden van de berekening."
 
 #: senaite/core/browser/dashboard/dashboard.py:149
 #: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
-msgstr ""
+msgstr "Geverifieerd"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:133
 msgid "Verified By"
-msgstr ""
+msgstr "Geverifieerd door"
 
 #: senaite/core/browser/dashboard/dashboard.py:428
 msgid "Verified samples ready to be published"
-msgstr ""
+msgstr "Geverifieerde monsters klaar om te publiceren"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
-msgstr ""
+msgstr "Verifiëren"
 
 #: senaite/core/browser/dashboard/dashboard.py:109
 msgid "Verify Results"
-msgstr ""
+msgstr "Resultaten verifiëren"
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
 #: bika/lims/controlpanel/auditlog.py:72
 msgid "Version"
-msgstr ""
+msgstr "Versie"
 
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "View"
-msgstr ""
+msgstr "Weergeven"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
-msgstr ""
+msgstr "Bekijk uw SENAITE-site"
 
 # senaite.app.listing: Column config — visible-section header
 msgid "Visible"
-msgstr ""
+msgstr "Zichtbaar"
 
 # senaite.app.listing: Column config — counter title attribute
 msgid "Visible / total columns"
-msgstr ""
+msgstr "Zichtbare / totale kolommen"
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
-msgstr ""
+msgstr "Zichtbare velden"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:24
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:24
 msgid "Visit the Dynamic Specification for additional information:"
-msgstr ""
+msgstr "Bezoek de dynamische specificatie voor aanvullende informatie:"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:28
 msgid "Visit the Specification's changes history for additional information:"
-msgstr ""
+msgstr "Bezoek de wijzigingsgeschiedenis van de specificatie voor aanvullende informatie:"
 
 #: bika/lims/content/labproduct.py:36
 msgid "Volume"
-msgstr ""
+msgstr "Volume"
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:17
 msgid "Warning"
-msgstr ""
+msgstr "Waarschuwing"
 
 #: bika/lims/content/laboratory.py:132
 msgid "Web address for the accreditation body"
-msgstr ""
+msgstr "Webadres van de accreditatie-instantie"
 
 #: bika/lims/content/supplier.py:52
 msgid "Website"
-msgstr ""
+msgstr "Website"
 
 #: senaite/core/vocabularies/setup.py:158
 msgid "Wednesday"
-msgstr ""
+msgstr "Woensdag"
 
 #: senaite/core/browser/dashboard/dashboard.py:136
 msgid "Weekly"
-msgstr ""
+msgstr "Wekelijks"
 
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
-msgstr ""
+msgstr "Weken tot vervaldatum"
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:7
 msgid "Welcome"
-msgstr ""
+msgstr "Welkom"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:14
 msgid "Welcome to SENAITE"
-msgstr ""
+msgstr "Welkom bij SENAITE"
 
 #: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-msgstr ""
+msgstr "Indien ingeschakeld hebben analisten alleen toegang tot werkbladen waaraan ze zijn toegewezen. Indien uitgeschakeld hebben analisten toegang tot alle werkbladen."
 
 #: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-msgstr ""
+msgstr "Indien ingeschakeld kunnen alleen labmanagers werkbladen aanmaken en beheren. Indien uitgeschakeld kunnen ook analisten en labmedewerkers werkbladen beheren. Let op: Deze instelling wordt automatisch ingeschakeld en vergrendeld wanneer de toegang tot werkbladen is beperkt tot toegewezen analisten."
 
 #: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-msgstr ""
+msgstr "Indien ingeschakeld wordt het monster automatisch geverifieerd zodra alle resultaten zijn geverifieerd. Anders moeten gebruikers met voldoende rechten het monster daarna handmatig verifiëren. Standaard: ingeschakeld"
 
 #: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-msgstr ""
+msgstr "Indien ingeschakeld kunnen gebruikers resultaten indienen voor analyses die niet aan hen zijn toegewezen of voor niet-toegewezen analyses. Indien uitgeschakeld kunnen gebruikers alleen resultaten indienen voor analyses die aan henzelf zijn toegewezen. Deze instelling geldt niet voor gebruikers met de rol Labmanager."
 
 #: bika/lims/content/analysisprofile.py:102
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
-msgstr ""
+msgstr "Wanneer dit is ingesteld, gebruikt het systeem de prijs van het analyseprofiel voor de offerte en wordt de btw van het systeem overschreven door de specifieke btw van het analyseprofiel"
 
 #: bika/lims/content/abstractbaseanalysis.py:480
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
-msgstr ""
+msgstr "Wanneer de resultaten van duplicaatanalyses op werkbladen, uitgevoerd op hetzelfde monster, meer dan dit percentage verschillen, wordt een waarschuwing gegeven"
 
 #: bika/lims/validators.py:518
 msgid "Wildcards for interims are not allowed: ${wildcards}"
-msgstr ""
+msgstr "Jokertekens voor tussenvelden zijn niet toegestaan: ${wildcards}"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:20
 msgid "With best regards"
-msgstr ""
+msgstr "Met vriendelijke groet"
 
 #: bika/lims/content/instrumentcalibration.py:118
 #: bika/lims/content/instrumentmaintenancetask.py:103
 #: bika/lims/content/instrumentvalidation.py:100
 msgid "Work Performed"
-msgstr ""
+msgstr "Uitgevoerd werk"
 
 #: bika/lims/browser/auditlog.py:94
 #: bika/lims/controlpanel/auditlog.py:99
 msgid "Workflow State"
-msgstr ""
+msgstr "Workflowstatus"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Worksheet"
-msgstr ""
+msgstr "Werkblad"
 
 #: bika/lims/content/worksheettemplate.py:62
 msgid "Worksheet Layout"
-msgstr ""
+msgstr "Werkbladindeling"
 
 #: senaite/core/profiles/default/types/WorksheetTemplate.xml
 msgid "Worksheet Template"
-msgstr ""
+msgstr "Werkbladsjabloon"
 
 #: senaite/core/profiles/default/types/WorksheetTemplates.xml
 msgid "Worksheet Templates"
-msgstr ""
+msgstr "Werkbladsjablonen"
 
 #: senaite/core/registry/schema.py:109
 msgid "Worksheet printing templates order"
-msgstr ""
+msgstr "Volgorde van werkbladafdruksjablonen"
 
 #: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
-msgstr ""
+msgstr "Werkbladen"
 
 #: senaite/core/browser/dashboard/dashboard.py:531
 msgid "Worksheets that have been verified"
-msgstr ""
+msgstr "Werkbladen die zijn geverifieerd"
 
 #: senaite/core/browser/dashboard/dashboard.py:526
 msgid "Worksheets whose results are awaiting verification"
-msgstr ""
+msgstr "Werkbladen waarvan de resultaten op verificatie wachten"
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
-msgstr ""
+msgstr "Verkeerde IBAN-lengte met %s: %s"
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
-msgstr ""
+msgstr "Verkeerde IBAN-lengte met %s: %ste kort met %i"
 
 #: senaite/core/browser/dashboard/dashboard.py:140
 msgid "Yearly"
-msgstr ""
+msgstr "Jaarlijks"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
 msgid "Yes"
-msgstr ""
+msgstr "Ja"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:124
 msgid "You can add another SENAITE site:"
-msgstr ""
+msgstr "U kunt nog een SENAITE-site toevoegen:"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:109
 msgid "You can change the visibility of a field by selecting or unselecting the checkbox."
-msgstr ""
+msgstr "U kunt de zichtbaarheid van een veld wijzigen door het selectievakje aan of uit te vinken."
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:17
 msgid "You can enable the global Audit Log again in the <a href=\"${DYNAMIC_CONTENT}\">Setup</a>"
-msgstr ""
+msgstr "U kunt het globale auditlogboek opnieuw inschakelen in de <a href=\"${DYNAMIC_CONTENT}\">Instellingen</a>"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:294
 msgid "You can use the browse button to select and upload a new attachment."
-msgstr ""
+msgstr "U kunt de bladerknop gebruiken om een nieuwe bijlage te selecteren en te uploaden."
 
 #: bika/lims/browser/worksheet/tools.py:42
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
-msgstr ""
+msgstr "U hebt onvoldoende rechten om het werkblad ${worksheet_title} te bekijken."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:78
 msgid "You have multiple SENAITE sites:"
-msgstr ""
+msgstr "U hebt meerdere SENAITE-sites:"
 
 #: bika/lims/browser/worksheet/views/export.py:33
 msgid "You must select an instrument"
-msgstr ""
+msgstr "U moet een instrument selecteren"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:159
 msgid "You normally don't need to change anything here unless you have specific reasons and know what you are doing."
-msgstr ""
+msgstr "Normaal gesproken hoeft u hier niets te wijzigen, tenzij u specifieke redenen hebt en weet wat u doet."
 
 #: senaite/core/exportimport/instruments/sysmex/xs/i500.py:77
 msgid "You should introduce a default result key."
-msgstr ""
+msgstr "U moet een standaard resultaatsleutel invoeren."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:121
 msgid "Your SENAITE site has not been added yet:"
-msgstr ""
+msgstr "Uw SENAITE-site is nog niet toegevoegd:"
 
 #: bika/lims/browser/templates/referencesample_view.pt:134
 msgid "activate"
-msgstr ""
+msgstr "activeren"
 
 #. Default: "Classic"
 #: senaite/core/config/worksheet.py:25
 msgid "analyses_classic_view_name"
-msgstr ""
+msgstr "Klassiek"
 
 #. Default: "Transposed"
 #: senaite/core/config/worksheet.py:29
 msgid "analyses_transposed_view_name"
-msgstr ""
+msgstr "Getransponeerd"
 
 #. Default: "Analysis"
 #: senaite/core/config/vocabularies.py:35
 msgid "analysis_type_analysis"
-msgstr ""
+msgstr "Analyse"
 
 #. Default: "Blank"
 #: senaite/core/config/vocabularies.py:39
 msgid "analysis_type_blank"
-msgstr ""
+msgstr "Blanco"
 
 #. Default: "Control"
 #: senaite/core/config/vocabularies.py:43
 msgid "analysis_type_control"
-msgstr ""
+msgstr "Controle"
 
 #. Default: "Duplicate"
 #: senaite/core/config/vocabularies.py:47
 msgid "analysis_type_duplicate"
-msgstr ""
+msgstr "Duplicaat"
 
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
-msgstr ""
+msgstr "Analist moet worden opgegeven."
 
 # senaite.app.listing: Saved filter presets — micro-tag on the default preset
 msgid "auto"
-msgstr ""
+msgstr "auto"
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
-msgstr ""
+msgstr "halfjaarlijks"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:48
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:48
 msgid "by"
-msgstr ""
+msgstr "door"
 
 #. in '${calc}')"
 #. Default: "keyword '${keyword}' must have column title '${title}' (defined in '${calc}')"
 #: senaite/core/validators/interimfields.py:151
+#, fuzzy
 msgid "calcs_interims_validator_dup_keyword_error"
-msgstr ""
+msgstr "sleutelwoord '${keyword}' moet kolomtitel '${title}' hebben (gedefinieerd in '${calc}')"
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:57
 msgid "change_worksheet_result_layout_message"
-msgstr ""
+msgstr "Wijzigingen opgeslagen."
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:168
 msgid "changes_saved"
-msgstr ""
+msgstr "Wijzigingen opgeslagen."
 
 #. Results edition not allowed: ${inv}"
 #. Default: "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed: ${inv}"
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:214
+#, fuzzy
 msgid "check_instrument_validity_message"
-msgstr ""
+msgstr "Sommige analyses gebruiken verouderde of niet-gekalibreerde instrumenten. Bewerken van resultaten niet toegestaan: ${inv}"
 
 #. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #. Default: "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #: senaite/core/validators/interimfields.py:211
+#, fuzzy
 msgid "choice_syntax_validation_error"
-msgstr ""
+msgstr "Geen geldig formaat in het keuzeveld. Ondersteund formaat is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #. Default: "Control type is not supported for empty choices"
 #: senaite/core/validators/interimfields.py:111
 msgid "choices_and_restype_validator_no_choices_error"
-msgstr ""
+msgstr "Besturingstype wordt niet ondersteund voor lege keuzes"
 
 #. Default: "Chosen control type not supporting choices"
 #: senaite/core/validators/interimfields.py:117
 msgid "choices_and_restype_validator_not_supported_choices_error"
-msgstr ""
+msgstr "Gekozen besturingstype ondersteunt geen keuzes"
 
 #. Default: "Empty keys are not supported"
 #: senaite/core/validators/interimfields.py:169
 msgid "choices_empty_keys_validator_error"
-msgstr ""
+msgstr "Lege sleutels worden niet ondersteund"
 
 #. Default: "At least, two options for choices field are required"
 #: senaite/core/validators/interimfields.py:195
 msgid "choices_min_items_validator_error"
-msgstr ""
+msgstr "Ten minste twee opties voor het keuzeveld zijn vereist"
 
 #. Default: "Duplicate keys in choices field"
 #: senaite/core/validators/interimfields.py:183
 msgid "choices_unique_keys_validator_error"
-msgstr ""
+msgstr "Dubbele sleutels in het keuzeveld"
 
 #: bika/lims/content/instrumentcertification.py:250
 msgid "daily"
-msgstr ""
+msgstr "dagelijks"
 
 #. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -7276,7 +7279,7 @@ msgstr ""
 #. ${b} ${d}, ${Y} ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "date_format_long"
-msgstr ""
+msgstr "${d}-${m}-${Y} ${H}:${M}"
 
 #. Default: "${Y}-${m}-${d}"
 #. The variables used here are the same as used in the strftime formating.
@@ -7287,80 +7290,83 @@ msgstr ""
 #. ${b} ${d}, ${Y}
 #: ./TranslationServiceTool.py
 msgid "date_format_short"
-msgstr ""
+msgstr "${d}-${m}-${Y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
+#. Default: "yy-mm-dd"
+#, fuzzy
 msgid "date_format_short_datepicker"
-msgstr ""
+msgstr "dd-mm-jj"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "days"
-msgstr ""
+msgstr "dagen"
 
 #: bika/lims/browser/templates/referencesample_view.pt:127
 msgid "deactivate"
-msgstr ""
+msgstr "deactiveren"
 
 #. Default: "Sample disposed after the retention period."
 #: senaite/core/browser/samples/templates/dispose_samples.pt:66
 msgid "default_dispose_reason"
-msgstr ""
+msgstr "Monster afgevoerd na de bewaartermijn."
 
 #: senaite/core/api/remarks.py:485
 msgid "deleted by {user} at {time}"
-msgstr ""
+msgstr "verwijderd door {user} op {time}"
 
 #. Default: "Attached labels"
 #: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
-msgstr ""
+msgstr "Toegevoegde labels"
 
 #. Default: "The accreditation standard that applies, e.g. ISO 17025"
 #: senaite/core/content/laboratory.py:174
 msgid "description_accreditation"
-msgstr ""
+msgstr "De van toepassing zijnde accreditatienorm, bijv. ISO 17025"
 
 #. Default: "E.g. SANAS, APLAC, etc."
 #: senaite/core/content/laboratory.py:153
 msgid "description_accreditation_body"
-msgstr ""
+msgstr "Bijv. SANAS, APLAC, enz."
 
 #. and results reports by your accreditation body. Maximum size is 175 x 175
 #. pixels."
 #. Default: "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 #: senaite/core/content/laboratory.py:198
+#, fuzzy
 msgid "description_accreditation_body_logo"
-msgstr ""
+msgstr "Upload het logo dat u door uw accreditatie-instantie gemachtigd bent te gebruiken op uw website en resultaatrapporten. Maximale grootte is 175 x 175 pixels."
 
 #. Default: "Web address for the accreditation body"
 #: senaite/core/content/laboratory.py:163
 msgid "description_accreditation_body_url"
-msgstr ""
+msgstr "Webadres van de accreditatie-instantie"
 
 #. following fields are available: lab_is_accredited, lab_name, lab_country,
 #. confidence, accreditation_body_name, accreditation_standard,
 #. accreditation_reference"
 #. Default: "Enter the details of your lab's service accreditations here. The following fields are available: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 #: senaite/core/content/laboratory.py:220
+#, fuzzy
 msgid "description_accreditation_page_header"
-msgstr ""
+msgstr "Voer hier de gegevens van de dienstaccreditaties van uw lab in. De volgende velden zijn beschikbaar: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 
 #. Default: "The reference code issued to the lab by the accreditation body"
 #: senaite/core/content/laboratory.py:186
 msgid "description_accreditation_reference"
-msgstr ""
+msgstr "De referentiecode die door de accreditatie-instantie aan het lab is toegekend"
 
 #. Default: "The category the analysis service belongs to"
 #: bika/lims/content/abstractbaseanalysis.py:533
 msgid "description_analysis_category"
-msgstr ""
+msgstr "De categorie waartoe de analysedienst behoort"
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/abstractbaseanalysis.py:591
 msgid "description_analysis_department"
-msgstr ""
+msgstr "Selecteer de verantwoordelijke afdeling"
 
 #. registration form if the elapsed time since sample collection exceeds the
 #. holding time limit. Exceeding this time limit may result in unreliable or
@@ -7371,16 +7377,18 @@ msgstr ""
 #. view."
 #. Default: "This service will not appear for selection on the sample registration form if the elapsed time since sample collection exceeds the holding time limit. Exceeding this time limit may result in unreliable or compromised data, as the integrity of the sample can degrade over time. Consequently, any results obtained after this period may not accurately reflect the sample's true composition, impacting data validity. Note: This setting does not affect the test's availability in the 'Manage Analyses' view."
 #: bika/lims/content/abstractbaseanalysis.py:457
+#, fuzzy
 msgid "description_analysis_maxholdingtime"
-msgstr ""
+msgstr "Deze dienst verschijnt niet ter selectie op het monsterregistratieformulier als de verstreken tijd sinds de monstername de bewaartijdlimiet overschrijdt. Overschrijding van deze tijdslimiet kan leiden tot onbetrouwbare of gecompromitteerde gegevens, aangezien de integriteit van het monster in de loop van de tijd kan afnemen. Bijgevolg weerspiegelen resultaten die na deze periode worden verkregen mogelijk niet de werkelijke samenstelling van het monster, wat de geldigheid van de gegevens beïnvloedt. Let op: Deze instelling heeft geen invloed op de beschikbaarheid van de test in de weergave 'Analyses beheren'."
 
 #. in results entry listings. Note this only applies to the options displayed
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
 #: bika/lims/content/abstractbaseanalysis.py:773
+#, fuzzy
 msgid "description_analysis_results_options_sorting"
-msgstr ""
+msgstr "Criteria die worden gebruikt wanneer resultaatopties ter selectie worden weergegeven in lijsten voor resultaatinvoer. Let op: dit geldt alleen voor de opties die in de selectielijst worden weergegeven. Het heeft geen effect op de volgorde waarin resultaten worden weergegeven nadat ze zijn ingediend"
 
 #. in a range with minimum of 0 and maximum of 10, where the uncertainty value
 #. is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also
@@ -7394,58 +7402,64 @@ msgstr ""
 #. 20.00, 20.01 - 30.00 etc."
 #. Default: "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2%, a result of 100 will be reported as 100 ± 2.<br/>If you don't want uncertainty to be displayed for a given range, set 0 (or a value below 0) as the Uncertainty value.<br/>Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30.00 etc."
 #: bika/lims/content/abstractbaseanalysis.py:630
+#, fuzzy
 msgid "description_analysis_uncertainty"
-msgstr ""
+msgstr "Geef de onzekerheidswaarde op voor een bepaald bereik, bijv. voor resultaten in een bereik met een minimum van 0 en een maximum van 10, waar de onzekerheidswaarde 0,5 is - een resultaat van 6,67 wordt gerapporteerd als 6,67 ± 0,5.<br/>U kunt de onzekerheidswaarde ook opgeven als een percentage van de resultaatwaarde, door een '%' toe te voegen aan de waarde die is ingevoerd in de kolom 'Onzekerheidswaarde', bijv. voor resultaten in een bereik met een minimum van 10,01 en een maximum van 100, waar de onzekerheidswaarde 2% is, wordt een resultaat van 100 gerapporteerd als 100 ± 2.<br/>Als u niet wilt dat de onzekerheid voor een bepaald bereik wordt weergegeven, stel dan 0 (of een waarde onder 0) in als onzekerheidswaarde.<br/>Zorg ervoor dat opeenvolgende bereiken continu zijn, bijv. 0,00 - 10,00 wordt gevolgd door 10,01 - 20,00, 20,01 - 30,00 enz."
 
 #. mg/l, ppm, dB, mV, etc."
 #. Default: "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 #: bika/lims/content/abstractbaseanalysis.py:112
+#, fuzzy
 msgid "description_analysis_unit"
-msgstr ""
+msgstr "De meeteenheden voor de resultaten van deze analysedienst, bijv. mg/l, ppm, dB, mV, enz."
 
 #. Ensure to include the default unit in this list"
 #. Default: "Provide a list of units that are suitable for the analysis. Ensure to include the default unit in this list"
 #: bika/lims/content/abstractbaseanalysis.py:162
+#, fuzzy
 msgid "description_analysis_unitchoices"
-msgstr ""
+msgstr "Geef een lijst met eenheden op die geschikt zijn voor de analyse. Zorg ervoor dat u de standaardeenheid in deze lijst opneemt"
 
 #. reports."
 #. Default: "To be displayed below each Analysis Category section on results reports."
 #: senaite/core/content/analysiscategory.py:64
+#, fuzzy
 msgid "description_analysiscategory_comments"
-msgstr ""
+msgstr "Weer te geven onder elke sectie Analysecategorie op resultaatrapporten."
 
 #. Default: "Select the responsible department"
 #: senaite/core/content/analysiscategory.py:85
 msgid "description_analysiscategory_department"
-msgstr ""
+msgstr "Selecteer de verantwoordelijke afdeling"
 
 #. Duplicate values are ordered alphabetically."
 #. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 #: senaite/core/content/analysiscategory.py:99
+#, fuzzy
 msgid "description_analysiscategory_sort_key"
-msgstr ""
+msgstr "Decimale waarde van 0,0 - 1000,0 die de sorteervolgorde aangeeft. Dubbele waarden worden alfabetisch geordend."
 
 #. Default: "Commercial ID used for accounting"
 #: senaite/core/content/analysisprofile.py:125
 msgid "description_analysisprofile_commercial_id"
-msgstr ""
+msgstr "Commerciële ID gebruikt voor boekhouding"
 
 #. Default: "Please provide a unique profile keyword"
 #: senaite/core/content/analysisprofile.py:94
 msgid "description_analysisprofile_profile_key"
-msgstr ""
+msgstr "Geef een uniek profielsleutelwoord op"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/analysisprofile.py:149
 msgid "description_analysisprofile_profile_price"
-msgstr ""
+msgstr "Geef de prijs exclusief btw op"
 
 #. price"
 #. Default: "Please provide the VAT in percent that is added to the profile price"
 #: senaite/core/content/analysisprofile.py:161
+#, fuzzy
 msgid "description_analysisprofile_profile_vat"
-msgstr ""
+msgstr "Geef de btw in procenten op die aan de profielprijs wordt toegevoegd"
 
 #. profile won't be available for selection in sample creation and edit forms
 #. unless the selected sample type is one of these. If no sample type is set
@@ -7453,28 +7467,29 @@ msgstr ""
 #. the sample type of the sample."
 #. Default: "Sample types for which this analysis profile is supported. This profile won't be available for selection in sample creation and edit forms unless the selected sample type is one of these. If no sample type is set here, this profile will always be available for selection, regardless of the sample type of the sample."
 #: senaite/core/content/analysisprofile.py:184
+#, fuzzy
 msgid "description_analysisprofile_sampletypes"
-msgstr ""
+msgstr "Monstertypes waarvoor dit analyseprofiel wordt ondersteund. Dit profiel is niet beschikbaar ter selectie in formulieren voor het aanmaken en bewerken van monsters tenzij het geselecteerde monstertype een van deze is. Als hier geen monstertype is ingesteld, is dit profiel altijd beschikbaar ter selectie, ongeacht het monstertype van het monster."
 
 #. Default: "Select the included analyses for this profile"
 #: senaite/core/content/analysisprofile.py:110
 msgid "description_analysisprofile_services"
-msgstr ""
+msgstr "Selecteer de opgenomen analyses voor dit profiel"
 
 #. Default: "Use profile price instead of single analyses prices"
 #: senaite/core/content/analysisprofile.py:137
 msgid "description_analysisprofile_use_profile_price"
-msgstr ""
+msgstr "Profielprijs gebruiken in plaats van prijzen van afzonderlijke analyses"
 
 #. Default: "Number of samples to create with the information provided"
 #: bika/lims/content/analysisrequest.py:1441
 msgid "description_analysisrequest_numsamples"
-msgstr ""
+msgstr "Aantal aan te maken monsters met de opgegeven informatie"
 
 #. Default: "Link dynamic analysis specification"
 #: bika/lims/content/analysisspec.py:72
 msgid "description_analysisspec_dynamicspec"
-msgstr ""
+msgstr "Koppel dynamische analysespecificatie"
 
 #. outside this results range will raise an alert.<br/>'Min warn' and 'Max
 #. warn' values indicate a shoulder range. Any result outside the results
@@ -7485,108 +7500,115 @@ msgstr ""
 #. results report as well"
 #. Default: "'Min' and 'Max' values indicate a valid results range. Any result outside this results range will raise an alert.<br/>'Min warn' and 'Max warn' values indicate a shoulder range. Any result outside the results range but within the shoulder range will raise a less severe alert.<br/>If the result is out of range, the value set for '&lt; Min' or '&gt; Max' will be displayed in lists and results reports instead of the real result. In such case, the value set for 'Out of range comment' will be displayed in results report as well"
 #: bika/lims/content/analysisspec.py:91
+#, fuzzy
 msgid "description_analysisspec_resultsrange"
-msgstr ""
+msgstr "'Min'- en 'Max'-waarden geven een geldig resultaatbereik aan. Elk resultaat buiten dit resultaatbereik geeft een waarschuwing.<br/>'Min waarsch'- en 'Max waarsch'-waarden geven een schouderbereik aan. Elk resultaat buiten het resultaatbereik maar binnen het schouderbereik geeft een minder ernstige waarschuwing.<br/>Als het resultaat buiten het bereik ligt, wordt de waarde die is ingesteld voor '&lt; Min' of '&gt; Max' weergegeven in lijsten en resultaatrapporten in plaats van het werkelijke resultaat. In dat geval wordt de waarde die is ingesteld voor 'Opmerking buiten bereik' ook weergegeven in het resultaatrapport"
 
 #. Default: "Select the sample type for this specification"
 #: bika/lims/content/analysisspec.py:52
 msgid "description_analysisspec_sampletype"
-msgstr ""
+msgstr "Selecteer het monstertype voor deze specificatie"
 
 #. Default: "Contained samples in the PDF"
 #: bika/lims/content/arreport.py:82
 msgid "description_arreport_contained_samples"
-msgstr ""
+msgstr "Opgenomen monsters in de PDF"
 
 #. Default: "The primary sample of the PDF"
 #: bika/lims/content/arreport.py:52
 msgid "description_arreport_sample"
-msgstr ""
+msgstr "Het primaire monster van de PDF"
 
 #. Default: "Select the analysis profile for this template"
 #: bika/lims/content/artemplate.py:257
 msgid "description_artemplate_profile"
-msgstr ""
+msgstr "Selecteer het analyseprofiel voor dit sjabloon"
 
 #. Default: "Select the sample point for this template"
 #: bika/lims/content/artemplate.py:58
 msgid "description_artemplate_samplepoint"
-msgstr ""
+msgstr "Selecteer het monsterpunt voor dit sjabloon"
 
 #. Default: "Select the sample type for this template"
 #: bika/lims/content/artemplate.py:89
 msgid "description_artemplate_sampletype"
-msgstr ""
+msgstr "Selecteer het monstertype voor dit sjabloon"
 
 #. Default: "Select the type of the attachment"
 #: bika/lims/content/attachment.py:64
 msgid "description_attachment_type"
-msgstr ""
+msgstr "Selecteer het type van de bijlage"
 
 #. Default: "Assign the instrument for this log"
 #: bika/lims/content/autoimportlog.py:53
 msgid "description_autoimportlog_instrument"
-msgstr ""
+msgstr "Wijs het instrument toe voor dit logboek"
 
 #. Default: "The date and time when the log was created"
 #: bika/lims/content/autoimportlog.py:90
 msgid "description_autoimportlog_logtime"
-msgstr ""
+msgstr "De datum en tijd waarop het logboek is aangemaakt"
 
 #. Default: "The logged results"
 #: bika/lims/content/autoimportlog.py:77
 msgid "description_autoimportlog_results"
-msgstr ""
+msgstr "De gelogde resultaten"
 
 #. Default: "Select the client of this batch"
 #: bika/lims/content/batch.py:81
 msgid "description_batch_client"
-msgstr ""
+msgstr "Selecteer de klant van deze batch"
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
 #: bika/lims/content/bikasetup.py:397
+#, fuzzy
 msgid "description_bikasetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Als deze optie is geactiveerd, kan de vastlegdatum van het resultaat handmatig worden ingevoerd voor analyses"
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
 #: bika/lims/content/bikasetup.py:854
+#, fuzzy
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Indien geselecteerd ontvangen de verantwoordelijke personen van alle betrokken labafdelingen publicatie-e-mails."
 
 #. Default: "Group analyses by category for samples"
 #: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Analyses groeperen per categorie voor monsters"
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
 #: bika/lims/content/bikasetup.py:690
+#, fuzzy
 msgid "description_bikasetup_date_sampled_required"
-msgstr ""
+msgstr "Selecteer dit om het veld Datum bemonsterd verplicht te maken bij het aanmaken van monsters. Deze functionaliteit is alleen van kracht wanneer 'Monsternameworkflow' niet actief is"
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
 #: bika/lims/content/bikasetup.py:830
+#, fuzzy
 msgid "description_bikasetup_email_body_sample_publication"
-msgstr ""
+msgstr "Stel de standaard e-mailtekst in die wordt gebruikt bij het verzenden van resultaatrapporten naar de geselecteerde ontvangers. U kunt gereserveerde sleutelwoorden gebruiken: $client_name, $recipients, $lab_name, $lab_address"
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
 #: bika/lims/content/bikasetup.py:806
+#, fuzzy
 msgid "description_bikasetup_email_from_sample_publication"
-msgstr ""
+msgstr "E-mail die als 'Van'-adres wordt gebruikt voor uitgaande e-mails bij het publiceren van resultaatrapporten. Dit adres overschrijft de waarde die is ingesteld bij de 'Mailinstellingen' van het portaal."
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
 #: bika/lims/content/bikasetup.py:444
+#, fuzzy
 msgid "description_bikasetup_immediateresultsentry"
-msgstr ""
+msgstr "Sta de gebruiker toe om direct resultaten in te voeren na het aanmaken van monsters, bijv. om veldresultaten onmiddellijk in te voeren, of labresultaten, wanneer de automatische monsterontvangst is geactiveerd."
 
 #. sent to primary contacts and laboratory managers when a sample is
 #. invalidated. The following placeholders are supported: <code title='The ID
@@ -7597,25 +7619,27 @@ msgstr ""
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
 #: bika/lims/content/bikasetup.py:947
+#, fuzzy
 msgid "description_bikasetup_invalidation_email_body"
-msgstr ""
+msgstr "Definieer het sjabloon voor de e-mailtekst die automatisch wordt verzonden naar primaire contactpersonen en laboratoriummanagers wanneer een monster ongeldig wordt verklaard. De volgende plaatshouders worden ondersteund: <code title='De ID van het monster'>$sample_id</code>, <code title='De ID van de hertest van het monster'>$retest_id</code>, <code title='De link naar de hertest'>$retest_link</code>, <code title='De reden(en) voor ongeldigverklaring'>$reason</code>, <code title='Het adres van het lab'>$lab_address</code>."
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
 #: bika/lims/content/bikasetup.py:914
+#, fuzzy
 msgid "description_bikasetup_invalidation_reason_required"
-msgstr ""
+msgstr "Geef aan of het opgeven van een reden verplicht is bij het ongeldig verklaren van een monster. Indien ingeschakeld wordt de plaatshouder '$reason' in de e-mailtekst van de meldingsmail voor ongeldigverklaring vervangen door de ingevoerde reden."
 
 #. Default: "Analyses are required for sample registration"
 #: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Analyses zijn vereist voor monsterregistratie"
 
 #. Default: "Dependent services of this calculation"
 #: bika/lims/content/calculation.py:84
 msgid "description_calculation_dependentservices"
-msgstr ""
+msgstr "Afhankelijke diensten van deze berekening"
 
 #. dynamically calculated when an analysis using this calculation is
 #. displayed.</p><p>To enter a Calculation, use standard maths operators, + -
@@ -7626,8 +7650,9 @@ msgstr ""
 #. where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #. Default: "<p>The formula you type here will be dynamically calculated be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators, + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #: senaite/core/content/calculation.py:291
+#, fuzzy
 msgid "description_calculation_formula"
-msgstr ""
+msgstr "<p>De formule die u hier typt, wordt dynamisch berekend wanneer een analyse die deze berekening gebruikt wordt weergegeven.</p><p>Om een berekening in te voeren, gebruikt u standaard wiskundige operatoren, + - * / ( ), en alle beschikbare sleutelwoorden, zowel van andere analysediensten als de hier opgegeven tussenvelden, als variabelen. Zet ze tussen vierkante haken [ ].</p><p>Bijv. de berekening voor Totale hardheid, het totaal van calcium- (ppm) en magnesiumionen (ppm) in water, wordt ingevoerd als [Ca] + [Mg], waarbij Ca en Mg de sleutelwoorden zijn voor die twee analysediensten.</p>"
 
 #. library, you can import it here. E.g. if you want to use the 'floor'
 #. function from the Python 'math' module, you add 'math' to the Module field
@@ -7636,8 +7661,9 @@ msgstr ""
 #. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
+#, fuzzy
 msgid "description_calculation_imports"
-msgstr ""
+msgstr "Als uw formule een speciale functie uit een externe Python-bibliotheek nodig heeft, kunt u deze hier importeren. Bijv. als u de functie 'floor' uit de Python-module 'math' wilt gebruiken, voegt u 'math' toe aan het veld Module en 'floor' aan het veld functie. Het equivalent in Python zou 'from math import floor' zijn. In uw berekening zou u dan 'floor([Ca] + [Mg])' kunnen gebruiken."
 
 #. should your calculation require them. The field title specified here will
 #. be used as column headers and field descriptors where the interim fields
@@ -7646,99 +7672,104 @@ msgstr ""
 #. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
+#, fuzzy
 msgid "description_calculation_interims"
-msgstr ""
+msgstr "Definieer tussenvelden zoals vatmassa, verdunningsfactoren, mocht uw berekening deze nodig hebben. De hier opgegeven veldtitel wordt gebruikt als kolomkoppen en veldbeschrijvingen waar de tussenvelden worden weergegeven. Als 'Breed toepassen' is ingeschakeld, wordt het veld weergegeven in een selectievak bovenaan het werkblad, waardoor een specifieke waarde op alle bijbehorende velden op het blad kan worden toegepast."
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
 #. Default: "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 #: senaite/core/content/calculation.py:321
+#, fuzzy
 msgid "description_calculation_test_params"
-msgstr ""
+msgstr "Om de berekening te testen, voert u hier waarden in voor alle berekeningsparameters. Dit omvat de hierboven gedefinieerde tussenvelden, evenals alle diensten waarvan deze berekening afhankelijk is om resultaten te berekenen."
 
 #. values."
 #. Default: "The result after the calculation has taken place with test values."
 #: senaite/core/content/calculation.py:345
+#, fuzzy
 msgid "description_calculation_test_result"
-msgstr ""
+msgstr "Het resultaat nadat de berekening met testwaarden heeft plaatsgevonden."
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/analysiscategory.py:62
 msgid "description_category_department"
-msgstr ""
+msgstr "Selecteer de verantwoordelijke afdeling"
 
 #. Default: "Always expand the selected categories"
 #: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
-msgstr ""
+msgstr "De geselecteerde categorieën altijd uitvouwen"
 
 #. Default: "Show only selected categories"
 #: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
-msgstr ""
+msgstr "Alleen geselecteerde categorieën tonen"
 
 #. Default: "This value is reported at the bottom of all published results"
 #: senaite/core/content/laboratory.py:127
 msgid "description_confidence_level"
-msgstr ""
+msgstr "Deze waarde wordt gerapporteerd onderaan alle gepubliceerde resultaten"
 
 #. Default: "Contacts in CC for new samples"
 #: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
-msgstr ""
+msgstr "Contactpersonen in CC voor nieuwe monsters"
 
 #. could be selected here."
 #. Default: "If this container is pre-preserved, then the preservation method could be selected here."
 #: bika/lims/content/container.py:100
+#, fuzzy
 msgid "description_container_preservation"
-msgstr ""
+msgstr "Als deze container voorgeconserveerd is, kan hier de conserveringsmethode worden geselecteerd."
 
 #. Default: "Select the type of this container"
 #: bika/lims/content/container.py:57
 msgid "description_container_type"
-msgstr ""
+msgstr "Selecteer het type van deze container"
 
 #. Default: "${copyright} 2017-${current_year} ${senaitelims}"
 #: senaite/core/browser/viewlets/templates/footer.pt:13
 msgid "description_copyright"
-msgstr ""
+msgstr "${copyright} 2017-${current_year} ${senaitelims}"
 
 #. Default: "Please provide a unique department identifier"
 #: senaite/core/content/department.py:80
 msgid "description_department_id"
-msgstr ""
+msgstr "Geef een unieke afdelingsidentificatie op"
 
 #. the 'lab contacts' setup item. Departmental managers are referenced on
 #. analysis results reports containing analyses by their department."
 #. Default: "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 #: senaite/core/content/department.py:106
+#, fuzzy
 msgid "description_department_manager"
-msgstr ""
+msgstr "Selecteer een manager uit het beschikbare personeel dat is geconfigureerd onder het instellingenitem 'labcontactpersonen'. Afdelingsmanagers worden vermeld op analyseresultaatrapporten die analyses van hun afdeling bevatten."
 
 #. Default: "Name of the department"
 #: senaite/core/content/department.py:52
 msgid "description_department_title"
-msgstr ""
+msgstr "Naam van de afdeling"
 
 #. Default: "Location where the instrument is installed"
 #: bika/lims/content/instrument.py:322
 msgid "description_instrument_instrumentlocation"
-msgstr ""
+msgstr "Locatie waar het instrument is geïnstalleerd"
 
 #. Default: "Select the type of this instrument"
 #: bika/lims/content/instrument.py:82
 msgid "description_instrument_instrumenttype"
-msgstr ""
+msgstr "Selecteer het type van dit instrument"
 
 #. Default: "Select the manufacturer of this instrument"
 #: bika/lims/content/instrument.py:102
 msgid "description_instrument_manufacturer"
-msgstr ""
+msgstr "Selecteer de fabrikant van dit instrument"
 
 #. Default: "Methods that are supported by this analytical instrument"
 #: bika/lims/content/instrument.py:174
 msgid "description_instrument_methods"
-msgstr ""
+msgstr "Methoden die door dit analytische instrument worden ondersteund"
 
 #. where the system should look for the results files while automatically
 #. importing results. Having a folder for each Instrument and inside that
@@ -7747,132 +7778,140 @@ msgstr ""
 #. unique."
 #. Default: "For each interface of this instrument, you can define a folder where the system should look for the results files while automatically importing results. Having a folder for each Instrument and inside that folder creating different folders for each of its Interfaces can be a good approach. You can use Interface codes to be sure that folder names are unique."
 #: bika/lims/content/instrument.py:267
+#, fuzzy
 msgid "description_instrument_result_file_folder"
-msgstr ""
+msgstr "Voor elke interface van dit instrument kunt u een map definiëren waar het systeem naar de resultaatbestanden moet zoeken tijdens het automatisch importeren van resultaten. Een map voor elk instrument hebben en binnen die map verschillende mappen aanmaken voor elk van de interfaces kan een goede aanpak zijn. U kunt interfacecodes gebruiken om ervoor te zorgen dat mapnamen uniek zijn."
 
 #. Default: "Select the supplier of this instrument"
 #: bika/lims/content/instrument.py:122
 msgid "description_instrument_supplier"
-msgstr ""
+msgstr "Selecteer de leverancier van dit instrument"
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentcalibration.py:130
 msgid "description_instrumentcalibration_worker"
-msgstr ""
+msgstr "De persoon die de taak heeft uitgevoerd"
 
 #. Default: "The person at the supplier who prepared the certificat"
 #: bika/lims/content/instrumentcertification.py:149
 msgid "description_instrumentcertification_preparator"
-msgstr ""
+msgstr "De persoon bij de leverancier die het certificaat heeft opgesteld"
 
 #. Default: "The person at the supplier who approved the certificate"
 #: bika/lims/content/instrumentcertification.py:173
 msgid "description_instrumentcertification_validator"
-msgstr ""
+msgstr "De persoon bij de leverancier die het certificaat heeft goedgekeurd"
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentvalidation.py:112
 msgid "description_instrumentvalidation_worker"
-msgstr ""
+msgstr "De persoon die de taak heeft uitgevoerd"
 
 #. selected departments."
 #. Default: "Select a default department for this contact from one of the selected departments."
 #: bika/lims/content/labcontact.py:89
+#, fuzzy
 msgid "description_labcontact_default_department"
-msgstr ""
+msgstr "Selecteer een standaardafdeling voor deze contactpersoon uit een van de geselecteerde afdelingen."
 
 #. Default: "Assigned laboratory departments"
 #: bika/lims/content/labcontact.py:62
 msgid "description_labcontact_departments"
-msgstr ""
+msgstr "Toegewezen laboratoriumafdelingen"
 
 #. the default style."
 #. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
 #: senaite/core/content/label.py:72
+#, fuzzy
 msgid "description_label_color"
-msgstr ""
+msgstr "Hexkleurcode gebruikt voor de chip (bijv. #0d6efd). Laat leeg voor de standaardstijl."
 
 #. labeled content. The cascade runs in the same transaction as the save and
 #. may take a moment on large datasets."
 #. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
 #: senaite/core/content/label.py:45
+#, fuzzy
 msgid "description_label_title"
-msgstr ""
+msgstr "Het hernoemen van dit label herschrijft de opgeslagen naam op elke inhoud die momenteel is gelabeld. De cascade wordt uitgevoerd in dezelfde transactie als het opslaan en kan bij grote datasets even duren."
 
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
-msgstr ""
+msgstr "Vink dit vakje aan als uw laboratorium geaccrediteerd is"
 
 #. Default: "The Laboratory's web address"
 #: senaite/core/content/laboratory.py:101
 msgid "description_laboratory_lab_url"
-msgstr ""
+msgstr "Het webadres van het laboratorium"
 
 #. Default: "Supervisor of the Lab"
 #: bika/lims/content/laboratory.py:78
 msgid "description_laboratory_suervisor"
-msgstr ""
+msgstr "Supervisor van het lab"
 
 #. Default: "Supervisor of the Lab"
 #: senaite/core/content/laboratory.py:77
 msgid "description_laboratory_supervisor"
-msgstr ""
+msgstr "Supervisor van het lab"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/labproduct.py:89
 msgid "description_labproduct_price"
-msgstr ""
+msgstr "Geef de prijs exclusief btw op"
 
 #. price"
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
+#, fuzzy
 msgid "description_labproduct_vat"
-msgstr ""
+msgstr "Geef de btw in procenten op die aan de labproductprijs wordt toegevoegd"
 
 #. nested and positioned as they appear on the site. Use the controls to hide,
 #. show or reorder each viewlet."
 #. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+#, fuzzy
 msgid "description_manage_viewlets"
-msgstr ""
+msgstr "De viewletmanagers en hun viewlets worden ter plaatse getoond, genest en gepositioneerd zoals ze op de site verschijnen. Gebruik de bediening om elke viewlet te verbergen, tonen of herordenen."
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
 msgid "description_multifile_document_location"
-msgstr ""
+msgstr "Locatie waar de documentenset is opgeborgen"
 
 #. image, ...)"
 #. Default: "Type of document (e.g. user manual, instrument specifications, image, ...)"
 #: senaite/core/content/multifile.py:83
+#, fuzzy
 msgid "description_multifile_document_type"
-msgstr ""
+msgstr "Type document (bijv. gebruikershandleiding, instrumentspecificaties, afbeelding, ...)"
 
 #. Default: "File upload"
 #: senaite/core/content/multifile.py:51
 msgid "description_multifile_file"
-msgstr ""
+msgstr "Bestand uploaden"
 
 #. Default: "Greeting title eg. Mr, Mrs, Dr"
 #: senaite/core/content/person.py:71
 msgid "description_person_salutation"
-msgstr ""
+msgstr "Aanhef bijv. Dhr., Mevr., Dr."
 
 #. Default: "Reference sample values are zero or 'blank'"
 #: bika/lims/content/referencedefinition.py:77
 msgid "description_referencedefinition_blank"
-msgstr ""
+msgstr "Referentiemonsterwaarden zijn nul of 'blanco'"
 
 #. definition."
 #. Default: "Hazard categories that apply to samples of this reference definition."
 #: bika/lims/content/referencedefinition.py:106
+#, fuzzy
 msgid "description_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën die van toepassing zijn op monsters van deze referentiedefinitie."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: bika/lims/content/referencedefinition.py:91
 msgid "description_referencedefinition_hazardous"
-msgstr ""
+msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
 
 #. category. Enter minimum and maximum values to indicate a valid results
 #. range. Any result outside this range will raise an alert. The % Error field
@@ -7882,61 +7921,67 @@ msgstr ""
 #. alert."
 #. Default: "Click on Analysis Categories to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 #: bika/lims/content/referencedefinition.py:55
+#, fuzzy
 msgid "description_referencedefinition_referencevalues"
-msgstr ""
+msgstr "Klik op Analysecategorieën om analysediensten in elke categorie te zien. Voer minimum- en maximumwaarden in om een geldig resultaatbereik aan te geven. Elk resultaat buiten dit bereik geeft een waarschuwing. Het veld % Fout maakt het mogelijk om een % onzekerheid in aanmerking te nemen bij het evalueren van resultaten ten opzichte van minimum- en maximumwaarden. Een resultaat buiten het bereik maar toch binnen het bereik als de % fout in aanmerking wordt genomen, geeft een minder ernstige waarschuwing."
 
 #. inherit from the reference definition."
 #. Default: "Hazard categories for this reference sample. Leave empty to inherit from the reference definition."
 #: bika/lims/content/referencesample.py:118
+#, fuzzy
 msgid "description_referencesample_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën voor dit referentiemonster. Laat leeg om over te nemen van de referentiedefinitie."
 
 #. Default: "Select the manufacturer for this sample"
 #: bika/lims/content/referencesample.py:136
 msgid "description_referencesample_manufacturer"
-msgstr ""
+msgstr "Selecteer de fabrikant voor dit monster"
 
 #. Default: "Select the reference definition for this sample"
 #: bika/lims/content/referencesample.py:82
 msgid "description_referencesample_referencedefinition"
-msgstr ""
+msgstr "Selecteer de referentiedefinitie voor dit monster"
 
 #. the paste popup in the sample add form. Please note that the paste button
 #. will only show for the fields listed here."
 #. Default: "Add all field names that support to enter multiple values using the paste popup in the sample add form. Please note that the paste button will only show for the fields listed here."
 #: senaite/core/registry/schema.py:375
+#, fuzzy
 msgid "description_registry_allow_multi_paste"
-msgstr ""
+msgstr "Voeg alle veldnamen toe die het invoeren van meerdere waarden ondersteunen via de plakpop-up in het formulier voor het toevoegen van monsters. Let op: de plakknop wordt alleen weergegeven voor de hier vermelde velden."
 
 #. catalogs in which these portal types should be indexed, beyond the default
 #. catalogs. A restart is required for these changes to take effect."
 #. Default: "Define the relationship between portal types and the additional catalogs in which these portal types should be indexed, beyond the default catalogs. A restart is required for these changes to take effect."
 #: senaite/core/registry/schema.py:278
+#, fuzzy
 msgid "description_registry_catalog_mappings"
-msgstr ""
+msgstr "Definieer de relatie tussen portaaltypes en de aanvullende catalogi waarin deze portaaltypes moeten worden geïndexeerd, naast de standaardcatalogi. Een herstart is vereist om deze wijzigingen van kracht te laten worden."
 
 #. logs into the system, or when a client is selected from the client folder
 #. listing"
 #. Default: "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing"
 #: senaite/core/registry/schema.py:51
+#, fuzzy
 msgid "description_registry_client_landing_page"
-msgstr ""
+msgstr "Selecteer de standaard bestemmingspagina. Deze wordt gebruikt wanneer een klantgebruiker inlogt op het systeem, of wanneer een klant wordt geselecteerd uit de klantmaplijst"
 
 #. structure of the site via Generic Setup"
 #. Default: "List of portal types to be skipped when exporting the content structure of the site via Generic Setup"
 #: senaite/core/registry/schema.py:238
+#, fuzzy
 msgid "description_registry_generic_setup_skip_export_types"
-msgstr ""
+msgstr "Lijst van portaaltypes die moeten worden overgeslagen bij het exporteren van de inhoudsstructuur van de site via Generic Setup"
 
 #. Default: "Attach import file to all Worksheet assigned analyses"
 #: senaite/core/registry/schema.py:443
 msgid "description_registry_import_analysis_attach_attachment"
-msgstr ""
+msgstr "Importbestand koppelen aan alle aan het werkblad toegewezen analyses"
 
 #. Default: "Automatically submit analyses upon import"
 #: senaite/core/registry/schema.py:456
 msgid "description_registry_import_analysis_submit"
-msgstr ""
+msgstr "Analyses automatisch indienen bij import"
 
 #. in its own ZODB transaction with a per-sample retry on conflict. This
 #. reduces the chance that ID-counter or container contention aborts the whole
@@ -7944,192 +7989,200 @@ msgstr ""
 #. batch is created in a single transaction (legacy behaviour)."
 #. Default: "When enabled, each sample created from the add form is committed in its own ZODB transaction with a per-sample retry on conflict. This reduces the chance that ID-counter or container contention aborts the whole batch on instances with many concurrent users. When disabled, the whole batch is created in a single transaction (legacy behaviour)."
 #: senaite/core/registry/schema.py:391
+#, fuzzy
 msgid "description_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Indien ingeschakeld wordt elk monster dat via het toevoegformulier wordt aangemaakt vastgelegd in zijn eigen ZODB-transactie met een nieuwe poging per monster bij een conflict. Dit vermindert de kans dat conflicten om de ID-teller of container de hele batch afbreken op instanties met veel gelijktijdige gebruikers. Indien uitgeschakeld wordt de hele batch in één transactie aangemaakt (verouderd gedrag)."
 
 #. matching the source sample structure. Each partition will be created with
 #. the same configuration (sample type, container, preservation) and analyses
 #. as the source partition."
 #. Default: "When enabled, copying a sample will also create partitions matching the source sample structure. Each partition will be created with the same configuration (sample type, container, preservation) and analyses as the source partition."
 #: senaite/core/registry/schema.py:328
+#, fuzzy
 msgid "description_registry_sample_add_copy_partitions"
-msgstr ""
+msgstr "Indien ingeschakeld worden bij het kopiëren van een monster ook partities aangemaakt die overeenkomen met de structuur van het bronmonster. Elke partitie wordt aangemaakt met dezelfde configuratie (monstertype, container, conservering) en analyses als de bronpartitie."
 
 #. copying analyses to a new sample in the sample add form."
 #. Default: "Add all analyses workflow states that should be skipped when copying analyses to a new sample in the sample add form."
 #: senaite/core/registry/schema.py:359
+#, fuzzy
 msgid "description_registry_sample_add_skip_analyses_in_states"
-msgstr ""
+msgstr "Voeg alle analyseworkflowstatussen toe die moeten worden overgeslagen bij het kopiëren van analyses naar een nieuw monster in het formulier voor het toevoegen van monsters."
 
 #. copying a sample. Only analyses that directly belong to the source sample
 #. will be copied to the new sample."
 #. Default: "When enabled, analyses from partitions will be excluded when copying a sample. Only analyses that directly belong to the source sample will be copied to the new sample."
 #: senaite/core/registry/schema.py:344
+#, fuzzy
 msgid "description_registry_sample_add_skip_partition_analyses"
-msgstr ""
+msgstr "Indien ingeschakeld worden analyses van partities uitgesloten bij het kopiëren van een monster. Alleen analyses die rechtstreeks tot het bronmonster behoren, worden naar het nieuwe monster gekopieerd."
 
 #. upon sample creation. This option is disabled by default, but certain add-
 #. ons may depend on it to operate correctly."
 #. Default: "When enabled, triggers “before” and “after” transition events upon sample creation. This option is disabled by default, but certain add-ons may depend on it to operate correctly."
 #: senaite/core/registry/schema.py:410
+#, fuzzy
 msgid "description_registry_trigger_events_on_sample_creation"
-msgstr ""
+msgstr "Indien ingeschakeld activeert dit “voor”- en “na”-overgangsgebeurtenissen bij het aanmaken van monsters. Deze optie is standaard uitgeschakeld, maar bepaalde add-ons kunnen ervan afhankelijk zijn om correct te werken."
 
 #. Default: "Worksheet view configuration"
 #: senaite/core/registry/schema.py:99
 msgid "description_registry_worksheet_settings"
-msgstr ""
+msgstr "Configuratie van werkbladweergave"
 
 #. Default: "Contained samples in the PDF"
 #: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
-msgstr ""
+msgstr "Opgenomen monsters in de PDF"
 
 #. Default: "The primary sample of the PDF"
 #: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
-msgstr ""
+msgstr "Het primaire monster van de PDF"
 
 #. Default: "Assign sample to a batch"
 #: bika/lims/content/analysisrequest.py:331
 msgid "description_sample_batch"
-msgstr ""
+msgstr "Monster toewijzen aan een batch"
 
 #. Default: "The contacts used in CC for email notifications"
 #: bika/lims/content/analysisrequest.py:200
 msgid "description_sample_cccontact"
-msgstr ""
+msgstr "De contactpersonen die in CC worden gebruikt voor e-mailmeldingen"
 
 #. Default: "Select the client for this sample"
 #: bika/lims/content/analysisrequest.py:258
 msgid "description_sample_client"
-msgstr ""
+msgstr "Selecteer de klant voor dit monster"
 
 #. Default: "Select the primary contact for this sample"
 #: bika/lims/content/analysisrequest.py:159
 msgid "description_sample_contact"
-msgstr ""
+msgstr "Selecteer de primaire contactpersoon voor dit monster"
 
 #. Default: "Select a container for this sample"
 #: bika/lims/content/analysisrequest.py:569
 msgid "description_sample_container"
-msgstr ""
+msgstr "Selecteer een container voor dit monster"
 
 #. Default: "The date when the sample was taken"
 #: bika/lims/content/analysisrequest.py:453
 msgid "description_sample_datesampled"
-msgstr ""
+msgstr "De datum waarop het monster is genomen"
 
 #. Default: "Reference to detached sample"
 #: bika/lims/content/analysisrequest.py:1311
 msgid "description_sample_detached_from"
-msgstr ""
+msgstr "Verwijzing naar losgekoppeld monster"
 
 #. Default: "Reference to the source sample this sample was duplicated from"
 #: bika/lims/content/analysisrequest.py:1283
 msgid "description_sample_duplicated_from"
-msgstr ""
+msgstr "Verwijzing naar het bronmonster waarvan dit monster is gedupliceerd"
 
 #. Default: "Generated invoice for this sample"
 #: bika/lims/content/analysisrequest.py:1049
 msgid "description_sample_invoice"
-msgstr ""
+msgstr "Gegenereerde factuur voor dit monster"
 
 #. Default: "Reference to parent sample"
 #: bika/lims/content/analysisrequest.py:1255
 msgid "description_sample_parent_sample"
-msgstr ""
+msgstr "Verwijzing naar bovenliggend monster"
 
 #. Default: "Select the needed preservation for this sample"
 #: bika/lims/content/analysisrequest.py:600
 msgid "description_sample_preservation"
-msgstr ""
+msgstr "Selecteer de benodigde conservering voor dit monster"
 
 #. Default: "Select a sample to create a secondary Sample"
 #: bika/lims/content/analysisrequest.py:295
 msgid "description_sample_primary"
-msgstr ""
+msgstr "Selecteer een monster om een secundair monster aan te maken"
 
 #. Default: "Select an analysis profile for this sample"
 #: bika/lims/content/analysisrequest.py:421
 msgid "description_sample_profiles"
-msgstr ""
+msgstr "Selecteer een analyseprofiel voor dit monster"
 
 #. sample publication report"
 #. Default: "Select an analysis specification that should be used in the sample publication report"
 #: bika/lims/content/analysisrequest.py:737
+#, fuzzy
 msgid "description_sample_publicationspecification"
-msgstr ""
+msgstr "Selecteer een analysespecificatie die moet worden gebruikt in het publicatierapport van het monster"
 
 #. Default: "Reference to retracted sample"
 #: bika/lims/content/analysisrequest.py:1339
 msgid "description_sample_retracted"
-msgstr ""
+msgstr "Verwijzing naar ingetrokken monster"
 
 #. Default: "The condition of the sample"
 #: bika/lims/content/analysisrequest.py:900
 msgid "description_sample_samplecondition"
-msgstr ""
+msgstr "De conditie van het monster"
 
 #. Default: "Location where the sample was taken"
 #: bika/lims/content/analysisrequest.py:770
 msgid "description_sample_samplepoint"
-msgstr ""
+msgstr "Locatie waar het monster is genomen"
 
 #. Default: "Select the sample type of this sample"
 #: bika/lims/content/analysisrequest.py:541
 msgid "description_sample_sampletype"
-msgstr ""
+msgstr "Selecteer het monstertype van dit monster"
 
 #. Default: "The date when the sample will be taken"
 #: bika/lims/content/analysisrequest.py:516
 msgid "description_sample_samplingdate"
-msgstr ""
+msgstr "De datum waarop het monster zal worden genomen"
 
 #. Default: "Deviation between the sample and how it was sampled"
 #: bika/lims/content/analysisrequest.py:872
 msgid "description_sample_samplingdeviation"
-msgstr ""
+msgstr "Afwijking tussen het monster en hoe het is bemonsterd"
 
 #. Default: "Select an analysis specification for this sample"
 #: bika/lims/content/analysisrequest.py:693
 msgid "description_sample_specification"
-msgstr ""
+msgstr "Selecteer een analysespecificatie voor dit monster"
 
 #. Default: "Location where the sample is kept"
 #: bika/lims/content/analysisrequest.py:794
 msgid "description_sample_storagelocation"
-msgstr ""
+msgstr "Locatie waar het monster wordt bewaard"
 
 #. Default: "The assigned batch sub group of this request"
 #: bika/lims/content/analysisrequest.py:366
 msgid "description_sample_subgroup"
-msgstr ""
+msgstr "De toegewezen batchsubgroep van deze aanvraag"
 
 #. Default: "Select an analysis template for this sample"
 #: bika/lims/content/analysisrequest.py:393
 msgid "description_sample_template"
-msgstr ""
+msgstr "Selecteer een analysesjabloon voor dit monster"
 
 #. and put together from more than one sub sample, e.g. several surface
 #. samples from a dam mixed together to be a representative sample for the
 #. dam. The default, unchecked, indicates 'grab' samples"
 #. Default: "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 #: senaite/core/content/samplepoint.py:147
+#, fuzzy
 msgid "description_samplepoint_composite"
-msgstr ""
+msgstr "Vink dit vakje aan als de monsters die op dit punt worden genomen 'samengesteld' zijn en zijn samengevoegd uit meer dan één submonster, bijv. verschillende oppervlaktemonsters uit een dam die samen zijn gemengd tot een representatief monster voor de dam. De standaardinstelling, niet aangevinkt, geeft 'grab'-monsters aan"
 
 #. Default: "The height or depth at which the sample has to be taken"
 #: senaite/core/content/samplepoint.py:91
 msgid "description_samplepoint_elevation"
-msgstr ""
+msgstr "De hoogte of diepte waarop het monster moet worden genomen"
 
 #. further analysis. It plays a pivotal role in research as it can
 #. significantly influence the results and conclusions drawn from the study."
 #. Default: "The geographical point or area from which samples are taken for further analysis. It plays a pivotal role in research as it can significantly influence the results and conclusions drawn from the study."
 #: senaite/core/content/samplepoint.py:76
+#, fuzzy
 msgid "description_samplepoint_location"
-msgstr ""
+msgstr "Het geografische punt of gebied waaruit monsters worden genomen voor verdere analyse. Het speelt een cruciale rol in het onderzoek, aangezien het de resultaten en conclusies van de studie aanzienlijk kan beïnvloeden."
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
@@ -8137,14 +8190,16 @@ msgstr ""
 #. regardless of the type."
 #. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
 #: bika/lims/content/samplepoint.py:98
+#, fuzzy
 msgid "description_samplepoint_sampletypes"
-msgstr ""
+msgstr "De lijst met monstertypes die op dit monsterpunt kunnen worden verzameld. Het veld voor de selectie van een monsterpunt in de aanmaak- en bewerkingsformulieren voor monsters wordt dienovereenkomstig gefilterd. Monsterpunten waaraan geen monstertype is toegewezen, blijven echter altijd beschikbaar voor selectie, ongeacht het type."
 
 #. frequency here, e.g. weekly"
 #. Default: "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 #: senaite/core/content/samplepoint.py:103
+#, fuzzy
 msgid "description_samplepoint_sampling_frequency"
-msgstr ""
+msgstr "Als op dit monsterpunt periodiek een monster wordt genomen, voer hier dan de frequentie in, bijv. wekelijks"
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
@@ -8152,308 +8207,340 @@ msgstr ""
 #. regardless of the type."
 #. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
 #: senaite/core/content/samplepoint.py:126
+#, fuzzy
 msgid "description_samplepoint_sampling_sample_types"
-msgstr ""
+msgstr "De lijst met monstertypes die op dit monsterpunt kunnen worden verzameld. Het veld voor de selectie van een monsterpunt in de aanmaak- en bewerkingsformulieren voor monsters wordt dienovereenkomstig gefilterd. Monsterpunten waaraan geen monstertype is toegewezen, blijven echter altijd beschikbaar voor selectie, ongeacht het type."
 
 #. sample is received"
 #. Default: "Automatically redirect the user to the partitions view when the sample is received"
 #: senaite/core/content/sampletemplate.py:258
+#, fuzzy
 msgid "description_sampletemplate_auto_partition"
-msgstr ""
+msgstr "De gebruiker automatisch doorverwijzen naar de partitieweergave wanneer het monster wordt ontvangen"
 
 #. Default: "Select if the sample is a mix of sub samples"
 #: senaite/core/content/sampletemplate.py:219
 msgid "description_sampletemplate_composite"
-msgstr ""
+msgstr "Selecteer of het monster een mengsel van deelmonsters is"
 
 #. ID'"
 #. Default: "Each line defines a new partition identified by the 'Partition ID'"
 #: senaite/core/content/sampletemplate.py:245
+#, fuzzy
 msgid "description_sampletemplate_partitions"
-msgstr ""
+msgstr "Elke regel definieert een nieuwe partitie die wordt geïdentificeerd door de 'Partitie-ID'"
 
 #. Default: "Select the sample point for this template"
 #: senaite/core/content/sampletemplate.py:187
 msgid "description_sampletemplate_samplepoint"
-msgstr ""
+msgstr "Selecteer het monsterpunt voor dit sjabloon"
 
 #. Default: "Select the sample type for this template"
 #: senaite/core/content/sampletemplate.py:209
 msgid "description_sampletemplate_sampletype"
-msgstr ""
+msgstr "Selecteer het monstertype voor dit sjabloon"
 
 #. Default: "Enable sampling workflow for the created samples"
 #: senaite/core/content/sampletemplate.py:228
 msgid "description_sampletemplate_sampling_required"
-msgstr ""
+msgstr "Monstername-workflow inschakelen voor de aangemaakte monsters"
 
 #. Default: "Select the services for this template"
 #: senaite/core/content/sampletemplate.py:273
 msgid "description_sampletemplate_services"
-msgstr ""
+msgstr "Selecteer de diensten voor dit sjabloon"
 
 #. Default: "Defines the stickers to use for this sample type."
 #: senaite/core/content/sampletype.py:281
 msgid "description_sampletype_admitted_stickers_templates"
-msgstr ""
+msgstr "Definieert de stickers die voor dit monstertype worden gebruikt."
 
 #. automatically assigned a container of this type, unless it has been
 #. specified in more details per analysis service"
 #. Default: "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 #: senaite/core/content/sampletype.py:258
+#, fuzzy
 msgid "description_sampletype_containertype"
-msgstr ""
+msgstr "Het standaardcontainertype. Nieuwe monsterpartities krijgen automatisch een container van dit type toegewezen, tenzij dit gedetailleerder is opgegeven per analysedienst"
 
 #. before they expire and cannot be analysed any further"
 #. Default: "The period for which unpreserved samples of this type can be kept before they expire and cannot be analysed any further"
 #: senaite/core/content/sampletype.py:155
+#, fuzzy
 msgid "description_sampletype_duration_period"
-msgstr ""
+msgstr "De periode waarin ongeconserveerde monsters van dit type kunnen worden bewaard voordat ze vervallen en niet verder kunnen worden geanalyseerd"
 
 #. display the appropriate pictograms in reports and lists."
 #. Default: "Hazard categories that apply to samples of this type. Used to display the appropriate pictograms in reports and lists."
 #: senaite/core/content/sampletype.py:180
+#, fuzzy
 msgid "description_sampletype_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën die van toepassing zijn op monsters van dit type. Worden gebruikt om de juiste pictogrammen weer te geven in rapporten en lijsten."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: senaite/core/content/sampletype.py:168
 msgid "description_sampletype_hazardous"
-msgstr ""
+msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
 
 #. kg'."
 #. Default: "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 #: senaite/core/content/sampletype.py:235
+#, fuzzy
 msgid "description_sampletype_min_volume"
-msgstr ""
+msgstr "Het minimale monstervolume dat vereist is voor analyse, bijv. '10 ml' of '1 kg'."
 
 #. Default: "Only ASCII characters without whitespaces are allowed."
 #: senaite/core/content/sampletype.py:222
 msgid "description_sampletype_prefix"
-msgstr ""
+msgstr "Alleen ASCII-tekens zonder spaties zijn toegestaan."
 
 #. Default: "Select the sample matrix for this sample type"
 #: senaite/core/content/sampletype.py:208
 msgid "description_sampletype_samplematrix"
-msgstr ""
+msgstr "Selecteer de monstermatrix voor dit monstertype"
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
 #: senaite/core/content/senaitesetup.py:362
+#, fuzzy
 msgid "description_senaitesetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Als deze optie is geactiveerd, kan de vastlegdatum van het resultaat handmatig worden ingevoerd voor analyses"
 
 #. to them or for unassigned analyses. When disabled, users can only submit
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 #: senaite/core/content/senaitesetup.py:456
+#, fuzzy
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
-msgstr ""
+msgstr "Indien ingeschakeld kunnen gebruikers resultaten indienen voor analyses die niet aan hen zijn toegewezen of voor niet-toegewezen analyses. Indien uitgeschakeld kunnen gebruikers alleen resultaten indienen voor analyses die aan henzelf zijn toegewezen. Deze instelling is niet van toepassing op gebruikers met de rol Labmanager."
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
 #: senaite/core/content/senaitesetup.py:289
+#, fuzzy
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Indien geselecteerd ontvangen de verantwoordelijken van alle betrokken labafdelingen publicatie-e-mails."
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 #: senaite/core/content/senaitesetup.py:428
+#, fuzzy
 msgid "description_senaitesetup_auto_log_off"
-msgstr ""
+msgstr "Het aantal minuten voordat een gebruiker automatisch wordt afgemeld. 0 schakelt automatisch afmelden uit"
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 #: senaite/core/content/senaitesetup.py:655
+#, fuzzy
 msgid "description_senaitesetup_auto_verify_samples"
-msgstr ""
+msgstr "Indien ingeschakeld wordt het monster automatisch geverifieerd zodra alle resultaten zijn geverifieerd. Anders moeten gebruikers met voldoende rechten het monster achteraf handmatig verifiëren. Standaard: ingeschakeld"
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
 #: senaite/core/content/senaitesetup.py:600
+#, fuzzy
 msgid "description_senaitesetup_categorise_analysis_services"
-msgstr ""
+msgstr "Analysediensten per categorie groeperen in de LIMS-tabellen, handig wanneer de lijst lang is"
 
 #. Default: "Group analyses by category for samples"
 #: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Analyses per categorie groeperen voor monsters"
 
 #. Default: "Select the currency the site will use to display prices."
 #: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
-msgstr ""
+msgstr "Selecteer de valuta die de site gebruikt om prijzen weer te geven."
 
 #. Default: "Select this to activate the dashboard as a default front page."
 #: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
-msgstr ""
+msgstr "Selecteer dit om het dashboard te activeren als standaard startpagina."
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
 #: senaite/core/content/senaitesetup.py:387
+#, fuzzy
 msgid "description_senaitesetup_date_sampled_required"
-msgstr ""
+msgstr "Selecteer dit om het veld Bemonsteringsdatum verplicht te maken bij het aanmaken van een monster. Deze functionaliteit werkt alleen wanneer de 'Monstername-workflow' niet actief is"
 
 #. Default: "Preferred decimal mark for reports."
 #: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
-msgstr ""
+msgstr "Voorkeursdecimaalteken voor rapporten."
 
 #. Default: "Select the country the site will show by default"
 #: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
-msgstr ""
+msgstr "Selecteer het land dat de site standaard toont"
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 #: senaite/core/content/senaitesetup.py:745
+#, fuzzy
 msgid "description_senaitesetup_default_number_of_ars_to_add"
-msgstr ""
+msgstr "Standaardwaarde van het 'Aantal monsters' wanneer gebruikers op de knop 'TOEVOEGEN' klikken om nieuwe monsters aan te maken"
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
 #: senaite/core/content/senaitesetup.py:261
+#, fuzzy
 msgid "description_senaitesetup_email_from_sample_publication"
-msgstr ""
+msgstr "E-mailadres dat als 'Van'-adres wordt gebruikt voor uitgaande e-mails bij het publiceren van resultaatrapporten. Dit adres overschrijft de waarde die is ingesteld bij de 'Mailinstellingen' van het portaal."
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
 #: senaite/core/content/senaitesetup.py:642
+#, fuzzy
 msgid "description_senaitesetup_enable_analysis_remarks"
-msgstr ""
+msgstr "Indien ingeschakeld wordt bij elke analyse in de weergave voor resultaatinvoer een vrij tekstveld weergegeven"
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
 #: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
-msgstr ""
+msgstr "Analysespecificaties die rechtstreeks op het monster worden bewerkt."
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
 #: senaite/core/content/senaitesetup.py:759
+#, fuzzy
 msgid "description_senaitesetup_enable_rejection_workflow"
-msgstr ""
+msgstr "Selecteer dit om de afwijzingsworkflow voor monsters te activeren. In het actiemenu wordt een optie 'Afwijzen' weergegeven."
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
 #: senaite/core/content/senaitesetup.py:626
+#, fuzzy
 msgid "description_senaitesetup_exponential_format_threshold"
-msgstr ""
+msgstr "Resultaatwaarden met ten minste dit aantal significante cijfers worden weergegeven in wetenschappelijke notatie met de letter 'e' om de exponent aan te geven. De precisie kan in afzonderlijke analysediensten worden geconfigureerd."
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
 #: senaite/core/content/senaitesetup.py:330
+#, fuzzy
 msgid "description_senaitesetup_immediateresultsentry"
-msgstr ""
+msgstr "Sta de gebruiker toe om resultaten direct na het aanmaken van het monster in te voeren, bijv. om veldresultaten direct in te voeren, of labresultaten wanneer de automatische monsterontvangst is geactiveerd."
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
 #: senaite/core/content/senaitesetup.py:412
+#, fuzzy
 msgid "description_senaitesetup_invalidation_reason_required"
-msgstr ""
+msgstr "Geef aan of het opgeven van een reden verplicht is bij het ongeldig maken van een monster. Indien ingeschakeld wordt de tijdelijke aanduiding '$reason' in de tekst van de meldingsmail voor het ongeldig maken van het monster vervangen door de ingevoerde reden."
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
 #: senaite/core/content/senaitesetup.py:875
+#, fuzzy
 msgid "description_senaitesetup_landing_page"
-msgstr ""
+msgstr "De landingspagina wordt getoond aan niet-geauthenticeerde gebruikers als het dashboard niet is geselecteerd als standaard startpagina. Als er geen landingspagina is geselecteerd, wordt de standaard startpagina weergegeven."
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
 #: senaite/core/content/senaitesetup.py:374
+#, fuzzy
 msgid "description_senaitesetup_maxnumberofsamplesadd"
-msgstr ""
+msgstr "Maximum aantal monsters dat kan worden aangemaakt overeenkomstig de waarde die is ingesteld voor het veld 'Aantal monsters' op het monsterregistratieformulier"
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 #: senaite/core/content/senaitesetup.py:525
+#, fuzzy
 msgid "description_senaitesetup_member_discount"
-msgstr ""
+msgstr "Het hier ingevoerde kortingspercentage wordt toegepast op de prijzen voor klanten die zijn gemarkeerd als 'leden', doorgaans coöperatieleden of geassocieerden die deze korting verdienen"
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 #: senaite/core/content/senaitesetup.py:584
+#, fuzzy
 msgid "description_senaitesetup_minimum_results"
-msgstr ""
+msgstr "Te weinig gegevenspunten gebruiken is statistisch niet zinvol. Stel een acceptabel minimumaantal resultaten in voordat QC-statistieken worden berekend en uitgezet"
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 #: senaite/core/content/senaitesetup.py:688
+#, fuzzy
 msgid "description_senaitesetup_number_of_required_verifications"
-msgstr ""
+msgstr "Aantal vereiste verificaties voordat een bepaald resultaat als 'geverifieerd' wordt beschouwd. Deze instelling kan voor elke analyse worden overschreven in de bewerkingsweergave van de analysedienst. Standaard 1"
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
 #: senaite/core/content/senaitesetup.py:275
+#, fuzzy
 msgid "description_senaitesetup_publication_email_text"
-msgstr ""
+msgstr "Stel de standaard te gebruiken e-mailtekst in bij het verzenden van resultaatrapporten naar de geselecteerde ontvangers. Je kunt gereserveerde sleutelwoorden gebruiken: $client_name, $recipients, $lab_name, $lab_address"
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
 #: senaite/core/content/senaitesetup.py:774
+#, fuzzy
 msgid "description_senaitesetup_rejection_reasons"
-msgstr ""
+msgstr "Voer de vooraf gedefinieerde afwijzingsredenen in die gebruikers kunnen selecteren bij het afwijzen van een monster."
 
 #. When disabled, analysts and lab clerks can also manage worksheets. Note:
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 #: senaite/core/content/senaitesetup.py:472
+#, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_management"
-msgstr ""
+msgstr "Indien ingeschakeld kunnen alleen labmanagers werkbladen aanmaken en beheren. Indien uitgeschakeld kunnen ook analisten en labmedewerkers werkbladen beheren. Let op: deze instelling wordt automatisch ingeschakeld en vergrendeld wanneer de toegang tot werkbladen is beperkt tot toegewezen analisten."
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 #: senaite/core/content/senaitesetup.py:442
+#, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_users_access"
-msgstr ""
+msgstr "Indien ingeschakeld hebben analisten alleen toegang tot werkbladen waaraan zij zijn toegewezen. Indien uitgeschakeld hebben analisten toegang tot alle werkbladen."
 
 #. Default: "Preferred decimal mark for results"
 #: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
-msgstr ""
+msgstr "Voorkeursdecimaalteken voor resultaten"
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
 #: senaite/core/content/senaitesetup.py:969
+#, fuzzy
 msgid "description_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Indien ingeschakeld kunnen gebruikers met voldoende rechten rechtstreeks vanuit een bestaand monster een broer-monster aanmaken via de actie 'Dupliceren' in de monsterlijst. Standaard ingeschakeld."
 
 #. Default: "Analyses are required for sample registration"
 #: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Analyses zijn vereist voor monsterregistratie"
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
 #: senaite/core/content/senaitesetup.py:805
+#, fuzzy
 msgid "description_senaitesetup_sampleview_columns_order"
-msgstr ""
+msgstr "Selecteer welke kolommen worden weergegeven in de monsteranalyselijsten. De volgorde van selectie bepaalt de weergavevolgorde. Niet-geselecteerde kolommen worden verborgen. Laat leeg om alle kolommen in de standaardvolgorde weer te geven."
 
 #. Default: "Preferred scientific notation format for reports"
 #: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
-msgstr ""
+msgstr "Voorkeursnotatie voor wetenschappelijke notatie voor rapporten"
 
 #. Default: "Preferred scientific notation format for results"
 #: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
-msgstr ""
+msgstr "Voorkeursnotatie voor wetenschappelijke notatie voor resultaten"
 
 #. verify it. This setting only take effect for those users with a role
 #. assigned that allows them to verify results (by default, managers,
@@ -8461,165 +8548,179 @@ msgstr ""
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 #: senaite/core/content/senaitesetup.py:670
+#, fuzzy
 msgid "description_senaitesetup_self_verification_enabled"
-msgstr ""
+msgstr "Indien ingeschakeld kan een gebruiker die een resultaat heeft ingediend, dit ook verifiëren. Deze instelling werkt alleen voor gebruikers met een toegewezen rol die hen toestaat resultaten te verifiëren (standaard managers, labmanagers en verifieerders). Deze instelling kan voor een bepaalde analyse worden overschreven in de bewerkingsweergave van de analysedienst. Standaard uitgeschakeld."
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
 #: senaite/core/content/senaitesetup.py:400
+#, fuzzy
 msgid "description_senaitesetup_show_lab_name_in_login"
-msgstr ""
+msgstr "Indien geselecteerd wordt de naam van het laboratorium weergegeven op de aanmeldpagina, boven de toegangsgegevens."
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 #: senaite/core/content/senaitesetup.py:899
+#, fuzzy
 msgid "description_senaitesetup_show_partitions"
-msgstr ""
+msgstr "Selecteer dit om monsterpartities te tonen aan klantcontactpersonen. Indien gedeactiveerd worden partities niet opgenomen in lijsten en wordt er geen infobericht met links naar het primaire monster weergegeven aan klantcontactpersonen."
 
 #. navigation. The order of selection determines the display order in the
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
 #: senaite/core/content/senaitesetup.py:914
+#, fuzzy
 msgid "description_senaitesetup_sidebar_folders"
-msgstr ""
+msgstr "Selecteer welke mappen op het hoogste niveau in de zijbalknavigatie moeten worden weergegeven. De volgorde van selectie bepaalt de weergavevolgorde in de zijbalk. Als er geen zijn geselecteerd, worden alle mappen in de standaardvolgorde weergegeven."
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
 #: senaite/core/content/senaitesetup.py:933
+#, fuzzy
 msgid "description_senaitesetup_sidebar_navigation_depth"
-msgstr ""
+msgstr "Maximale diepte van de zijbalknavigatieboom. Niveau 1 toont alleen mappen op het hoogste niveau, niveau 2 bevat de onderliggende mappen, enzovoort."
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
 #: senaite/core/content/senaitesetup.py:950
+#, fuzzy
 msgid "description_senaitesetup_sidebar_skip_types"
-msgstr ""
+msgstr "Selecteer welke inhoudstypes moeten worden uitgesloten van de zijbalknavigatie. Als er geen zijn geselecteerd, worden alle inhoudstypes weergegeven."
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
 #: senaite/core/content/senaitesetup.py:704
+#, fuzzy
 msgid "description_senaitesetup_type_of_multi_verification"
-msgstr ""
+msgstr "Kies het type meervoudige verificatie voor dezelfde gebruiker. Deze instelling kan het meer dan één keer verifiëren/opeenvolgend verifiëren voor dezelfde gebruiker in-/uitschakelen."
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
 #: senaite/core/content/senaitesetup.py:542
+#, fuzzy
 msgid "description_senaitesetup_vat"
-msgstr ""
+msgstr "Voer een percentagewaarde in, bijv. 14.0. Dit percentage wordt systeembreed toegepast, maar kan op afzonderlijke items worden overschreven"
 
 #. view. Classic layout displays the Samples in rows and the analyses in
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 #: senaite/core/content/senaitesetup.py:846
+#, fuzzy
 msgid "description_senaitesetup_worksheet_layout"
-msgstr ""
+msgstr "Voorkeursindeling van de resultaatinvoertabel in de werkbladweergave. De klassieke indeling geeft de monsters in rijen en de analyses in kolommen weer. De getransponeerde indeling geeft de monsters in kolommen en de analyses in rijen weer."
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
 #: senaite/core/content/senaitesetup.py:825
+#, fuzzy
 msgid "description_senaitesetup_wsview_columns_order"
-msgstr ""
+msgstr "Selecteer welke kolommen worden weergegeven in de werkbladanalyselijsten. De volgorde van selectie bepaalt de weergavevolgorde. Niet-geselecteerde kolommen worden verborgen. Laat leeg om alle kolommen in de standaardvolgorde weer te geven."
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
 #: bika/lims/content/bikasetup.py:617
+#, fuzzy
 msgid "description_setup_landingpage"
-msgstr ""
+msgstr "De landingspagina wordt getoond aan niet-geauthenticeerde gebruikers als het dashboard niet is geselecteerd als standaard startpagina. Als er geen landingspagina is geselecteerd, wordt de standaard startpagina weergegeven."
 
 #. Default: "Code for the location"
 #: senaite/core/content/storagelocation.py:106
 msgid "description_storagelocation_location_code"
-msgstr ""
+msgstr "Code voor de locatie"
 
 #. Default: "Description of the location"
 #: senaite/core/content/storagelocation.py:118
 msgid "description_storagelocation_location_description"
-msgstr ""
+msgstr "Beschrijving van de locatie"
 
 #. Default: "Title of location"
 #: senaite/core/content/storagelocation.py:94
 msgid "description_storagelocation_location_title"
-msgstr ""
+msgstr "Titel van locatie"
 
 #. Default: "Type of location"
 #: senaite/core/content/storagelocation.py:130
 msgid "description_storagelocation_location_type"
-msgstr ""
+msgstr "Type locatie"
 
 #. Default: "Code the the shelf"
 #: senaite/core/content/storagelocation.py:154
 msgid "description_storagelocation_shelf_code"
-msgstr ""
+msgstr "Code voor de plank"
 
 #. Default: "Description of the shelf"
 #: senaite/core/content/storagelocation.py:166
 msgid "description_storagelocation_shelf_description"
-msgstr ""
+msgstr "Beschrijving van de plank"
 
 #. Default: "Title of the shelf"
 #: senaite/core/content/storagelocation.py:142
 msgid "description_storagelocation_shelf_title"
-msgstr ""
+msgstr "Titel van de plank"
 
 #. Default: "Code for the site"
 #: senaite/core/content/storagelocation.py:70
 msgid "description_storagelocation_site_code"
-msgstr ""
+msgstr "Code voor de vestiging"
 
 #. Default: "Description of the site"
 #: senaite/core/content/storagelocation.py:82
 msgid "description_storagelocation_site_description"
-msgstr ""
+msgstr "Beschrijving van de vestiging"
 
 #. Default: "Title of the site"
 #: senaite/core/content/storagelocation.py:58
 msgid "description_storagelocation_site_title"
-msgstr ""
+msgstr "Titel van de vestiging"
 
 #. Duplicate values are ordered alphabetically."
 #. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 #: senaite/core/content/subgroup.py:60
+#, fuzzy
 msgid "description_subgroup_sort_key"
-msgstr ""
+msgstr "Float-waarde van 0.0 - 1000.0 die de sorteervolgorde aangeeft. Dubbele waarden worden alfabetisch geordend."
 
 #. Default: "International Bank Account Number"
 #: senaite/core/content/supplier.py:100
 msgid "description_supplier_iban"
-msgstr ""
+msgstr "Internationaal bankrekeningnummer"
 
 #. Default: "National Identification Bank Account Number"
 #: senaite/core/content/supplier.py:88
 msgid "description_supplier_nib"
-msgstr ""
+msgstr "Nationaal identificatiebankrekeningnummer"
 
 #. contact profile."
 #. Default: "User is linked to a contact. Please change your settings in the contact profile."
 #: senaite/core/browser/user/userdatapanel.py:82
+#, fuzzy
 msgid "description_user_contact"
-msgstr ""
+msgstr "De gebruiker is gekoppeld aan een contactpersoon. Wijzig je instellingen in het contactprofiel."
 
 #. Default: "Select the preferred instrument"
 #: senaite/core/content/worksheettemplate.py:266
 msgid "description_worksheettemplate_instrument"
-msgstr ""
+msgstr "Selecteer het gewenste instrument"
 
 #. with the selected method.<br/>In order to apply this change to the services
 #. list, you should save the change first."
 #. Default: "Restrict the available analysis services and instruments to those with the selected method.<br/>In order to apply this change to the services list, you should save the change first."
 #: senaite/core/content/worksheettemplate.py:240
+#, fuzzy
 msgid "description_worksheettemplate_restrict_to_method"
-msgstr ""
+msgstr "Beperk de beschikbare analysediensten en instrumenten tot die met de geselecteerde methode.<br/>Om deze wijziging op de dienstenlijst toe te passen, moet je de wijziging eerst opslaan."
 
 #. Default: "Select which Analyses should be included on the Worksheet"
 #: senaite/core/content/worksheettemplate.py:350
 msgid "description_worksheettemplate_services"
-msgstr ""
+msgstr "Selecteer welke analyses op het werkblad moeten worden opgenomen"
 
 #. specific instrument's tray size. Then select an Analysis 'type' per
 #. Worksheet position. Where QC samples are selected, also select which
@@ -8627,402 +8728,405 @@ msgstr ""
 #. indicate which sample position it should be a duplicate of"
 #. Default: "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 #: senaite/core/content/worksheettemplate.py:315
+#, fuzzy
 msgid "description_worksheettemplate_template_layout"
-msgstr ""
+msgstr "Geef de grootte van het werkblad op, bijv. overeenkomend met de traygrootte van een specifiek instrument. Selecteer vervolgens per werkbladpositie een analyse'type'. Waar QC-monsters worden geselecteerd, selecteer ook welk referentiemonster moet worden gebruikt. Als een duplicaatanalyse is geselecteerd, geef dan aan van welke monsterpositie het een duplicaat moet zijn"
 
 #. Default: "Not found Analysis position for duplicate."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:114
 msgid "duplicate_reference_not_found"
-msgstr ""
+msgstr "Analysepositie voor duplicaat niet gevonden."
 
 #. routine analysis."
 #. Default: "Duplicate in position ${dup} references this, so it must be a routine analysis."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:164
+#, fuzzy
 msgid "duplicate_reference_this_position"
-msgstr ""
+msgstr "Duplicaat op positie ${dup} verwijst hiernaar, dus het moet een routineanalyse zijn."
 
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr ""
+msgstr "${days} dagen"
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr ""
+msgstr "${hours} uur"
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr ""
+msgstr "Dagen"
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr ""
+msgstr "Uren"
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr ""
+msgstr "Minuten"
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr ""
+msgstr "Seconden"
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr ""
+msgstr "${minutes} minuten"
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr ""
+msgstr "${seconds} seconden"
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
-msgstr ""
+msgstr "Inhoud van het bestand"
 
 #: senaite/core/api/remarks.py:481
 msgid "edited"
-msgstr ""
+msgstr "bewerkt"
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #: bika/lims/browser/analysisrequest/add2.py:2081
+#, fuzzy
 msgid "error_analyssirequest_numsamples_above_max"
-msgstr ""
+msgstr "Het aantal aan te maken monsters voor record 'Monster ${record_index}' (${num_samples}) ligt boven ${max_num_samples}"
 
 #. Default: "${name} is after ${max_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:120
 msgid "error_datetime_after_max"
-msgstr ""
+msgstr "${name} ligt na ${max_date}, corrigeer dit."
 
 #. Default: "${name} is before ${min_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:94
 msgid "error_datetime_before_min"
-msgstr ""
+msgstr "${name} ligt voor ${min_date}, corrigeer dit."
 
 #. Default: "Unable to load the template"
 #: senaite/core/browser/worksheets/worksheet/printview.py:155
 msgid "error_load_template_worksheet"
-msgstr ""
+msgstr "Kan het sjabloon niet laden"
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:48
 msgid "fieldset_samplepoint_location"
-msgstr ""
+msgstr "Locatie"
 
 #. Default: "Analyses"
 #: senaite/core/content/sampletemplate.py:152
 msgid "fieldset_sampletemplate_analyses"
-msgstr ""
+msgstr "Analyses"
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:141
 msgid "fieldset_sampletemplate_partitions"
-msgstr ""
+msgstr "Partities"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/formula.py:121
 msgid "formula_validation_chain_error"
-msgstr ""
+msgstr "Interne fout in validatieketen: ${error}"
 
 #. Default: "cryogenic / inert gas"
 #: senaite/core/vocabularies/hazard_categories.py:167
 msgid "hazard_ASPH01_common"
-msgstr ""
+msgstr "cryogeen / inert gas"
 
 #. Default: "Asphyxiating atmosphere"
 #: senaite/core/vocabularies/hazard_categories.py:165
 msgid "hazard_ASPH01_name"
-msgstr ""
+msgstr "Verstikkende atmosfeer"
 
 #. Default: "infectious / biological"
 #: senaite/core/vocabularies/hazard_categories.py:104
 msgid "hazard_BIO01_common"
-msgstr ""
+msgstr "infectieus / biologisch"
 
 #. Default: "Biohazard"
 #: senaite/core/vocabularies/hazard_categories.py:103
 msgid "hazard_BIO01_name"
-msgstr ""
+msgstr "Biologisch gevaar"
 
 #. Default: "freezing / cold storage"
 #: senaite/core/vocabularies/hazard_categories.py:158
 msgid "hazard_COLD01_common"
-msgstr ""
+msgstr "vriezen / koude opslag"
 
 #. Default: "Low temperature"
 #: senaite/core/vocabularies/hazard_categories.py:157
 msgid "hazard_COLD01_name"
-msgstr ""
+msgstr "Lage temperatuur"
 
 #. Default: "electric shock"
 #: senaite/core/vocabularies/hazard_categories.py:132
 msgid "hazard_ELEC01_common"
-msgstr ""
+msgstr "elektrische schok"
 
 #. Default: "Electricity"
 #: senaite/core/vocabularies/hazard_categories.py:131
 msgid "hazard_ELEC01_name"
-msgstr ""
+msgstr "Elektriciteit"
 
 #. Default: "explosive"
 #: senaite/core/vocabularies/hazard_categories.py:48
 msgid "hazard_GHS01_common"
-msgstr ""
+msgstr "explosief"
 
 #. Default: "Explosive"
 #: senaite/core/vocabularies/hazard_categories.py:47
 msgid "hazard_GHS01_name"
-msgstr ""
+msgstr "Explosief"
 
 #. Default: "flammable"
 #: senaite/core/vocabularies/hazard_categories.py:54
 msgid "hazard_GHS02_common"
-msgstr ""
+msgstr "ontvlambaar"
 
 #. Default: "Flammable"
 #: senaite/core/vocabularies/hazard_categories.py:53
 msgid "hazard_GHS02_name"
-msgstr ""
+msgstr "Ontvlambaar"
 
 #. Default: "oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:60
 msgid "hazard_GHS03_common"
-msgstr ""
+msgstr "oxiderend"
 
 #. Default: "Oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:59
 msgid "hazard_GHS03_name"
-msgstr ""
+msgstr "Oxiderend"
 
 #. Default: "pressurised gas"
 #: senaite/core/vocabularies/hazard_categories.py:66
 msgid "hazard_GHS04_common"
-msgstr ""
+msgstr "gas onder druk"
 
 #. Default: "Compressed gas"
 #: senaite/core/vocabularies/hazard_categories.py:65
 msgid "hazard_GHS04_name"
-msgstr ""
+msgstr "Samengeperst gas"
 
 #. Default: "acid / caustic"
 #: senaite/core/vocabularies/hazard_categories.py:72
 msgid "hazard_GHS05_common"
-msgstr ""
+msgstr "zuur / bijtend"
 
 #. Default: "Corrosive"
 #: senaite/core/vocabularies/hazard_categories.py:71
 msgid "hazard_GHS05_name"
-msgstr ""
+msgstr "Corrosief"
 
 #. Default: "poisonous"
 #: senaite/core/vocabularies/hazard_categories.py:78
 msgid "hazard_GHS06_common"
-msgstr ""
+msgstr "giftig"
 
 #. Default: "Acute toxicity"
 #: senaite/core/vocabularies/hazard_categories.py:77
 msgid "hazard_GHS06_name"
-msgstr ""
+msgstr "Acute toxiciteit"
 
 #. Default: "harmful / irritant"
 #: senaite/core/vocabularies/hazard_categories.py:84
 msgid "hazard_GHS07_common"
-msgstr ""
+msgstr "schadelijk / irriterend"
 
 #. Default: "Health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:83
 msgid "hazard_GHS07_name"
-msgstr ""
+msgstr "Gezondheidsgevaar"
 
 #. Default: "carcinogenic / mutagenic"
 #: senaite/core/vocabularies/hazard_categories.py:90
 msgid "hazard_GHS08_common"
-msgstr ""
+msgstr "kankerverwekkend / mutageen"
 
 #. Default: "Serious health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:89
 msgid "hazard_GHS08_name"
-msgstr ""
+msgstr "Ernstig gezondheidsgevaar"
 
 #. Default: "environmentally hazardous"
 #: senaite/core/vocabularies/hazard_categories.py:97
 msgid "hazard_GHS09_common"
-msgstr ""
+msgstr "milieugevaarlijk"
 
 #. Default: "Environmental hazard"
 #: senaite/core/vocabularies/hazard_categories.py:96
 msgid "hazard_GHS09_name"
-msgstr ""
+msgstr "Milieugevaar"
 
 #. Default: "heated material"
 #: senaite/core/vocabularies/hazard_categories.py:145
 msgid "hazard_HOT01_common"
-msgstr ""
+msgstr "verhit materiaal"
 
 #. Default: "Hot content"
 #: senaite/core/vocabularies/hazard_categories.py:144
 msgid "hazard_HOT01_name"
-msgstr ""
+msgstr "Hete inhoud"
 
 #. Default: "hot to touch"
 #: senaite/core/vocabularies/hazard_categories.py:139
 msgid "hazard_HSURF01_common"
-msgstr ""
+msgstr "heet bij aanraking"
 
 #. Default: "Hot surface"
 #: senaite/core/vocabularies/hazard_categories.py:138
 msgid "hazard_HSURF01_name"
-msgstr ""
+msgstr "Heet oppervlak"
 
 #. Default: "NMR / MRI"
 #: senaite/core/vocabularies/hazard_categories.py:125
 msgid "hazard_MAG01_common"
-msgstr ""
+msgstr "NMR / MRI"
 
 #. Default: "Magnetic field"
 #: senaite/core/vocabularies/hazard_categories.py:124
 msgid "hazard_MAG01_name"
-msgstr ""
+msgstr "Magnetisch veld"
 
 #. Default: "UV / laser / RF"
 #: senaite/core/vocabularies/hazard_categories.py:118
 msgid "hazard_NIR01_common"
-msgstr ""
+msgstr "UV / laser / RF"
 
 #. Default: "Non-ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:117
 msgid "hazard_NIR01_name"
-msgstr ""
+msgstr "Niet-ioniserende straling"
 
 #. Default: "ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:112
 msgid "hazard_RAD01_common"
-msgstr ""
+msgstr "ioniserende straling"
 
 #. Default: "Radioactive"
 #: senaite/core/vocabularies/hazard_categories.py:111
 msgid "hazard_RAD01_name"
-msgstr ""
+msgstr "Radioactief"
 
 #. Default: "autoclave / sterilisation"
 #: senaite/core/vocabularies/hazard_categories.py:151
 msgid "hazard_STEAM01_common"
-msgstr ""
+msgstr "autoclaaf / sterilisatie"
 
 #. Default: "Hot steam"
 #: senaite/core/vocabularies/hazard_categories.py:150
 msgid "hazard_STEAM01_name"
-msgstr ""
+msgstr "Hete stoom"
 
 #. Default: "Hazardous"
 #: senaite/core/api/hazard.py:37
 msgid "hazard_warning_label"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #. Default: "Legacy Setup"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:16
 msgid "heading_legacy_setup"
-msgstr ""
+msgstr "Verouderde instellingen"
 
 #. Default: "Re-enter the password. Make sure the passwords are identical."
 #: senaite/core/browser/user/passwordpanel.py:44
 msgid "help_confirm_password"
-msgstr ""
+msgstr "Voer het wachtwoord opnieuw in. Zorg ervoor dat de wachtwoorden identiek zijn."
 
 #. Default: "Enter full name, e.g. John Smith."
 #: senaite/core/browser/user/userdatapanel.py:65
 msgid "help_full_name_creation"
-msgstr ""
+msgstr "Voer de volledige naam in, bijv. Jan Jansen."
 
 #. Default: "Enter your new password."
 #: senaite/core/browser/user/passwordpanel.py:37
 msgid "help_new_password"
-msgstr ""
+msgstr "Voer je nieuwe wachtwoord in."
 
 #. Default: "Your time zone"
 #: senaite/core/browser/user/personalpreferences.py:39
 msgid "help_timezone"
-msgstr ""
+msgstr "Je tijdzone"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "hours"
-msgstr ""
+msgstr "uur"
 
 #. Default: "'${function}' not found in module '${module}'"
 #: senaite/core/validators/imports.py:66
 msgid "importable_function_error"
-msgstr ""
+msgstr "'${function}' niet gevonden in module '${module}'"
 
 #. Default: "Could not import module '${module}'"
 #: senaite/core/validators/imports.py:49
 msgid "importable_module_error"
-msgstr ""
+msgstr "Kan module '${module}' niet importeren"
 
 #: bika/lims/browser/publish/templates/email.pt:189
 msgid "in"
-msgstr ""
+msgstr "in"
 
 #. Default: "Instrument exporter not found"
 #: senaite/core/browser/worksheets/worksheet/export.py:66
 msgid "instrument_exporter_not_found_message"
-msgstr ""
+msgstr "Instrumentexporteur niet gevonden"
 
 #. Default: "Interim field ${row_num}: ${message}"
 #: senaite/core/validators/interimfields.py:299
 msgid "interim_field_error"
-msgstr ""
+msgstr "Tussenveld ${row_num}: ${message}"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/interimfields.py:278
 msgid "interims_validation_chain_error"
-msgstr ""
+msgstr "Interne fout in validatieketen: ${error}"
 
 #. Default: "'${field_name}' contains invalid characters"
 #: senaite/core/validators/interimfields.py:68
 msgid "invalid_characters_validator_error"
-msgstr ""
+msgstr "'${field_name}' bevat ongeldige tekens"
 
 #. Default: "AnalysesServices not found for keywords: ${keywords}"
 #: senaite/core/validators/formula.py:92
 msgid "invalid_keyword_error"
-msgstr ""
+msgstr "Geen analysediensten gevonden voor sleutelwoorden: ${keywords}"
 
 #. Default: "Invalid wildcards found: ${wildcards}"
 #: senaite/core/validators/formula.py:71
 msgid "invalid_wildcards_check_error"
-msgstr ""
+msgstr "Ongeldige jokertekens gevonden: ${wildcards}"
 
 #. Default: "Labels"
 #: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
-msgstr ""
+msgstr "Labels"
 
 #. Default: "Add to the following groups:"
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:276
 msgid "label_add_to_groups"
-msgstr ""
+msgstr "Toevoegen aan de volgende groepen:"
 
 #. Default: "Address"
 #: senaite/core/content/person.py:197
 msgid "label_address"
-msgstr ""
+msgstr "Adres"
 
 #. Default: "Analysis Category"
 #: bika/lims/content/abstractbaseanalysis.py:530
 msgid "label_analysis_category"
-msgstr ""
+msgstr "Analysecategorie"
 
 #. Default: "Department"
 #: bika/lims/content/abstractbaseanalysis.py:588
 msgid "label_analysis_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. of a parameter that can be reliably detected by a specified testing
 #. methodology with a defined level of confidence. Results below this
@@ -9031,13 +9135,14 @@ msgstr ""
 #. detection capability of the method at a reliable level."
 #. Default: "The Lower Limit of Detection (LLOD) is the lowest concentration of a parameter that can be reliably detected by a specified testing methodology with a defined level of confidence. Results below this threshold are typically reported as '< LLOD' (or 'Not Detected'), indicating that the parameter's concentration, if present, is below the detection capability of the method at a reliable level."
 #: bika/lims/content/abstractbaseanalysis.py:207
+#, fuzzy
 msgid "label_analysis_lower_limit_of_detection_description"
-msgstr ""
+msgstr "De ondergrens van detectie (LLOD) is de laagste concentratie van een parameter die betrouwbaar kan worden gedetecteerd met een bepaalde testmethode en een gedefinieerd betrouwbaarheidsniveau. Resultaten onder deze drempel worden doorgaans gerapporteerd als '< LLOD' (of 'Niet gedetecteerd'), wat aangeeft dat de concentratie van de parameter, indien aanwezig, onder de detectiecapaciteit van de methode ligt op een betrouwbaar niveau."
 
 #. Default: "Lower Limit of Detection (LLOD)"
 #: bika/lims/content/abstractbaseanalysis.py:203
 msgid "label_analysis_lower_limit_of_detection_title"
-msgstr ""
+msgstr "Ondergrens van detectie (LLOD)"
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
@@ -9047,33 +9152,34 @@ msgstr ""
 #. cannot be determined reliably."
 #. Default: "The Lower Limit of Quantification (LLOQ) is the lowest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results below this value cannot be quantified with confidence and are typically reported as '< LOQ' (or 'Detected but < LOQ'), indicating that while the parameter may be present, its exact concentration cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:231
+#, fuzzy
 msgid "label_analysis_lower_limit_of_quantification_description"
-msgstr ""
+msgstr "De ondergrens van kwantificering (LLOQ) is de laagste concentratie van een parameter die betrouwbaar en nauwkeurig kan worden gemeten met de bepaalde testmethode, met acceptabele niveaus van precisie en nauwkeurigheid. Resultaten onder deze waarde kunnen niet met vertrouwen worden gekwantificeerd en worden doorgaans gerapporteerd als '< LOQ' (of 'Gedetecteerd maar < LOQ'), wat aangeeft dat de parameter weliswaar aanwezig kan zijn, maar dat de exacte concentratie niet betrouwbaar kan worden bepaald."
 
 #. Default: "Lower Limit Of Quantification (LLOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:227
 msgid "label_analysis_lower_limit_of_quantification_title"
-msgstr ""
+msgstr "Ondergrens van kwantificering (LLOQ)"
 
 #. Default: "Maximum holding time"
 #: bika/lims/content/abstractbaseanalysis.py:453
 msgid "label_analysis_maxholdingtime"
-msgstr ""
+msgstr "Maximale bewaartijd"
 
 #. Default: "Sorting criteria"
 #: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
-msgstr ""
+msgstr "Sorteercriteria"
 
 #. Default: "Default Unit"
 #: bika/lims/content/abstractbaseanalysis.py:108
 msgid "label_analysis_unit"
-msgstr ""
+msgstr "Standaardeenheid"
 
 #. Default: "Units for Selection"
 #: bika/lims/content/abstractbaseanalysis.py:158
 msgid "label_analysis_unitchoices"
-msgstr ""
+msgstr "Eenheden voor selectie"
 
 #. of a parameter that can be reliably measured using a specified testing
 #. methodology. Beyond this limit, results may no longer be accurate or valid
@@ -9083,13 +9189,14 @@ msgstr ""
 #. the method."
 #. Default: "The Upper Limit of Detection (ULOD) is the highest concentration of a parameter that can be reliably measured using a specified testing methodology. Beyond this limit, results may no longer be accurate or valid due to instrument saturation or methodological limitations. Results exceeding this threshold are typically reported as '> ULOD', indicating that the parameter's concentration is above the reliable detection range of the method."
 #: bika/lims/content/abstractbaseanalysis.py:277
+#, fuzzy
 msgid "label_analysis_upper_limit_of_detection_description"
-msgstr ""
+msgstr "De bovengrens van detectie (ULOD) is de hoogste concentratie van een parameter die betrouwbaar kan worden gemeten met een bepaalde testmethode. Boven deze grens zijn resultaten mogelijk niet langer nauwkeurig of geldig vanwege instrumentverzadiging of methodologische beperkingen. Resultaten die deze drempel overschrijden worden doorgaans gerapporteerd als '> ULOD', wat aangeeft dat de concentratie van de parameter boven het betrouwbare detectiebereik van de methode ligt."
 
 #. Default: "Upper Limit of Detection (ULOD)"
 #: bika/lims/content/abstractbaseanalysis.py:274
 msgid "label_analysis_upper_limit_of_detection_title"
-msgstr ""
+msgstr "Bovengrens van detectie (ULOD)"
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
@@ -9098,2401 +9205,2405 @@ msgstr ""
 #. exact concentration cannot be determined reliably."
 #. Default: "The Upper Limit of Quantification (ULOQ) is the highest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results above this value cannot be quantified with confidence and are typically reported as '> ULOQ', indicating that its exact concentration cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:255
+#, fuzzy
 msgid "label_analysis_upper_limit_of_quantification_description"
-msgstr ""
+msgstr "De bovengrens van kwantificering (ULOQ) is de hoogste concentratie van een parameter die betrouwbaar en nauwkeurig kan worden gemeten met de bepaalde testmethode, met acceptabele niveaus van precisie en nauwkeurigheid. Resultaten boven deze waarde kunnen niet met vertrouwen worden gekwantificeerd en worden doorgaans gerapporteerd als '> ULOQ', wat aangeeft dat de exacte concentratie niet betrouwbaar kan worden bepaald."
 
 #. Default: "Upper Limit Of Quantification (ULOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:252
 msgid "label_analysis_upper_limit_of_quantification_title"
-msgstr ""
+msgstr "Bovengrens van kwantificering (ULOQ)"
 
 #. Default: "Sample types"
 #: senaite/core/content/analysisprofile.py:180
 msgid "label_analysisprofile_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Number of samples"
 #: bika/lims/content/analysisrequest.py:1437
 msgid "label_analysisrequest_numsamples"
-msgstr ""
+msgstr "Aantal monsters"
 
 #. Default: "Dynamic Analysis Specification"
 #: bika/lims/content/analysisspec.py:69
 msgid "label_analysisspec_dynamicspec"
-msgstr ""
+msgstr "Dynamische analysespecificatie"
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisspec.py:49
 msgid "label_analysisspec_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Contained Samples"
 #: bika/lims/content/arreport.py:79
 msgid "label_arreport_contained_samples"
-msgstr ""
+msgstr "Bevatte monsters"
 
 #. Default: "Primary Sample"
 #: bika/lims/content/arreport.py:49
 msgid "label_arreport_sample"
-msgstr ""
+msgstr "Primair monster"
 
 #. Default: "Analysis Profile"
 #: bika/lims/content/artemplate.py:254
 msgid "label_artemplate_profile"
-msgstr ""
+msgstr "Analyseprofiel"
 
 #. Default: "Sample Point"
 #: bika/lims/content/artemplate.py:55
 msgid "label_artemplate_samplepoint"
-msgstr ""
+msgstr "Monsterpunt"
 
 #. Default: "Sample Type"
 #: bika/lims/content/artemplate.py:86
 msgid "label_artemplate_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Attachment Type"
 #: bika/lims/content/attachment.py:61
 msgid "label_attachment_type"
-msgstr ""
+msgstr "Bijlagetype"
 
 #. Default: "Instrument"
 #: bika/lims/content/autoimportlog.py:50
 msgid "label_autoimportlog_instrument"
-msgstr ""
+msgstr "Instrument"
 
 #. Default: "Log Time"
 #: bika/lims/content/autoimportlog.py:87
 msgid "label_autoimportlog_logtime"
-msgstr ""
+msgstr "Logtijd"
 
 #. Default: "Results"
 #: bika/lims/content/autoimportlog.py:74
 msgid "label_autoimportlog_results"
-msgstr ""
+msgstr "Resultaten"
 
 #. Default: "Client"
 #: bika/lims/content/batch.py:78
 msgid "label_batch_client"
-msgstr ""
+msgstr "Client"
 
 #. Default: "Allow to set the result capture date"
 #: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Vastlegdatum van resultaat toestaan in te stellen"
 
 #. Default: "Always send publication email to responsibles"
 #: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Altijd publicatie-e-mail naar verantwoordelijken sturen"
 
 #. Default: "Categorize sample analyses"
 #: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Monsteranalyses categoriseren"
 
 #. Default: "Date sampled required"
 #: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
-msgstr ""
+msgstr "Bemonsteringsdatum vereist"
 
 #. Default: "Email body for Sample publication notifications"
 #: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
-msgstr ""
+msgstr "E-mailtekst voor meldingen over monsterpublicatie"
 
 #. Default: "Publication 'From' address"
 #: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
-msgstr ""
+msgstr "Publicatie-'Van'-adres"
 
 #. Default: "Immediate results entry"
 #: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
-msgstr ""
+msgstr "Directe resultaatinvoer"
 
 #. Default: "Email body for Sample Invalidation notifications"
 #: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
-msgstr ""
+msgstr "E-mailtekst voor meldingen over het ongeldig maken van monsters"
 
 #. Default: "Invalidation reason required"
 #: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
-msgstr ""
+msgstr "Reden voor ongeldig maken vereist"
 
 #. Default: "Require sample analyses"
 #: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Monsteranalyses vereisen"
 
 #. Default: "DependentServices"
 #: senaite/core/content/calculation.py:352
 msgid "label_calculation_dependent_services"
-msgstr ""
+msgstr "Afhankelijke diensten"
 
 #. Default: "Dependent services"
 #: bika/lims/content/calculation.py:81
 msgid "label_calculation_dependentservices"
-msgstr ""
+msgstr "Afhankelijke diensten"
 
 #. Default: "Calculation Formula"
 #: senaite/core/content/calculation.py:287
 msgid "label_calculation_formula"
-msgstr ""
+msgstr "Berekeningsformule"
 
 #. Default: "Function"
 #: senaite/core/content/calculation.py:185
 msgid "label_calculation_import_function_name"
-msgstr ""
+msgstr "Functie"
 
 #. Default: "Module"
 #: senaite/core/content/calculation.py:179
 msgid "label_calculation_import_module_name"
-msgstr ""
+msgstr "Module"
 
 #. Default: "Additional Python Libraries"
 #: senaite/core/content/calculation.py:266
 msgid "label_calculation_imports"
-msgstr ""
+msgstr "Aanvullende Python-bibliotheken"
 
 #. Default: "Calculation Interim Fields"
 #: senaite/core/content/calculation.py:243
 msgid "label_calculation_interims"
-msgstr ""
+msgstr "Tussenvelden voor berekening"
 
 #. Default: "Raw Test Result"
 #: senaite/core/content/calculation.py:336
 msgid "label_calculation_raw_test_keywords"
-msgstr ""
+msgstr "Ruw testresultaat"
 
 #. Default: "Keyword"
 #: senaite/core/content/calculation.py:198
 msgid "label_calculation_test_param_keyword"
-msgstr ""
+msgstr "Sleutelwoord"
 
 #. Default: "Value"
 #: senaite/core/content/calculation.py:207
 msgid "label_calculation_test_param_value"
-msgstr ""
+msgstr "Waarde"
 
 #. Default: "Test Parameters"
 #: senaite/core/content/calculation.py:317
 msgid "label_calculation_test_params"
-msgstr ""
+msgstr "Testparameters"
 
 #. Default: "Test Result"
 #: senaite/core/content/calculation.py:343
 msgid "label_calculation_test_result"
-msgstr ""
+msgstr "Testresultaat"
 
 #. Default: "Department"
 #: bika/lims/content/analysiscategory.py:59
 msgid "label_category_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. Default: "Default categories"
 #: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
-msgstr ""
+msgstr "Standaardcategorieën"
 
 #. Default: "Restrict categories"
 #: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
-msgstr ""
+msgstr "Categorieën beperken"
 
 #. Default: "Confirm password"
 #: senaite/core/browser/user/passwordpanel.py:43
 msgid "label_confirm_password"
-msgstr ""
+msgstr "Wachtwoord bevestigen"
 
 #. Default: "Contacts to CC"
 #: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
-msgstr ""
+msgstr "Contactpersonen voor CC"
 
 #. Default: "Email Telephone Fax"
 #: senaite/core/content/person.py:137
 msgid "label_contact_information"
-msgstr ""
+msgstr "E-mail Telefoon Fax"
 
 #. Default: "Preservation"
 #: bika/lims/content/container.py:97
 msgid "label_container_preservation"
-msgstr ""
+msgstr "Conservering"
 
 #. Default: "Container Type"
 #: bika/lims/content/container.py:54
 msgid "label_container_type"
-msgstr ""
+msgstr "Containertype"
 
 #. Default: "Manager"
 #: senaite/core/content/department.py:102
 msgid "label_department_manager"
-msgstr ""
+msgstr "Manager"
 
 #. edit the container itself, ${go_here}."
 #. Default: "You are editing the default view of a container. If you wanted to edit the container itself, ${go_here}."
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
+#, fuzzy
 msgid "label_edit_default_view_container"
-msgstr ""
+msgstr "Je bewerkt de standaardweergave van een container. Als je de container zelf wilde bewerken, ${go_here}."
 
 #. Default: "go here"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
 msgid "label_edit_default_view_container_go_here"
-msgstr ""
+msgstr "ga hierheen"
 
 #. Default: "Bank Details"
 #: senaite/core/content/supplier.py:72
 msgid "label_fieldset_supplier_bank_details"
-msgstr ""
+msgstr "Bankgegevens"
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheettemplate.py:332
 msgid "label_fieldset_worksheettemplate_analyses"
-msgstr ""
+msgstr "Analyses"
 
 #. Default: "Layout"
 #: senaite/core/content/worksheettemplate.py:275
 msgid "label_fieldset_worksheettemplate_layout"
-msgstr ""
+msgstr "Indeling"
 
 #. Default: "Include client contacts"
 #: senaite/core/browser/controlpanel/contacts/templates/contacts_filter.pt:10
 msgid "label_include_client_contacts"
-msgstr ""
+msgstr "Klantcontactpersonen opnemen"
 
 #. Default: "Location"
 #: bika/lims/content/instrument.py:319
 msgid "label_instrument_instrumentlocation"
-msgstr ""
+msgstr "Locatie"
 
 #. Default: "Instrument type"
 #: bika/lims/content/instrument.py:79
 msgid "label_instrument_instrumenttype"
-msgstr ""
+msgstr "Instrumenttype"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/instrument.py:99
 msgid "label_instrument_manufacturer"
-msgstr ""
+msgstr "Fabrikant"
 
 #. Default: "Supported methods"
 #: bika/lims/content/instrument.py:172
 msgid "label_instrument_methods"
-msgstr ""
+msgstr "Ondersteunde methoden"
 
 #. Default: "Result files folders"
 #: bika/lims/content/instrument.py:265
 msgid "label_instrument_result_file_folder"
-msgstr ""
+msgstr "Mappen voor resultaatbestanden"
 
 #. Default: "Supplier"
 #: bika/lims/content/instrument.py:119
 msgid "label_instrument_supplier"
-msgstr ""
+msgstr "Leverancier"
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentcalibration.py:127
 msgid "label_instrumentcalibration_worker"
-msgstr ""
+msgstr "Uitgevoerd door"
 
 #. Default: "Prepared by"
 #: bika/lims/content/instrumentcertification.py:146
 msgid "label_instrumentcertification_preparator"
-msgstr ""
+msgstr "Voorbereid door"
 
 #. Default: "Approved by"
 #: bika/lims/content/instrumentcertification.py:170
 msgid "label_instrumentcertification_validator"
-msgstr ""
+msgstr "Goedgekeurd door"
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentvalidation.py:109
 msgid "label_instrumentvalidation_worker"
-msgstr ""
+msgstr "Uitgevoerd door"
 
 #. Default: "Allow empty"
 #: senaite/core/schema/interimfields.py:87
 msgid "label_interim_allow_empty"
-msgstr ""
+msgstr "Leeg toestaan"
 
 #. Default: "Apply wide"
 #: senaite/core/schema/interimfields.py:127
 msgid "label_interim_apply_wide"
-msgstr ""
+msgstr "Breed toepassen"
 
 #. Default: "Choices"
 #: senaite/core/schema/interimfields.py:67
 msgid "label_interim_choices"
-msgstr ""
+msgstr "Keuzes"
 
 #. Default: "Default value"
 #: senaite/core/schema/interimfields.py:57
 msgid "label_interim_default_value"
-msgstr ""
+msgstr "Standaardwaarde"
 
 #. Default: "Hidden"
 #: senaite/core/schema/interimfields.py:117
 msgid "label_interim_hidden"
-msgstr ""
+msgstr "Verborgen"
 
 #. Default: "Keyword"
 #: senaite/core/schema/interimfields.py:37
 msgid "label_interim_keyword"
-msgstr ""
+msgstr "Sleutelwoord"
 
 #. Default: "Report"
 #: senaite/core/schema/interimfields.py:107
 msgid "label_interim_report"
-msgstr ""
+msgstr "Rapport"
 
 #. Default: "Result type"
 #: senaite/core/schema/interimfields.py:76
 msgid "label_interim_result_type"
-msgstr ""
+msgstr "Resultaattype"
 
 #. Default: "Field title"
 #: senaite/core/schema/interimfields.py:47
 msgid "label_interim_title"
-msgstr ""
+msgstr "Veldtitel"
 
 #. Default: "Unit"
 #: senaite/core/schema/interimfields.py:97
 msgid "label_interim_unit"
-msgstr ""
+msgstr "Eenheid"
 
 #. Default: "Default Department"
 #: bika/lims/content/labcontact.py:86
 msgid "label_labcontact_default_department"
-msgstr ""
+msgstr "Standaardafdeling"
 
 #. Default: "Departments"
 #: bika/lims/content/labcontact.py:59
 msgid "label_labcontact_departments"
-msgstr ""
+msgstr "Afdelingen"
 
 #. Default: "Supervisor"
 #: senaite/core/content/laboratory.py:73
 msgid "label_laboratory_supervisor"
-msgstr ""
+msgstr "Supervisor"
 
 #. Default: "Document ID"
 #: senaite/core/content/multifile.py:39
 msgid "label_multifile_document_id"
-msgstr ""
+msgstr "Document-ID"
 
 #. Default: "Document Location"
 #: senaite/core/content/multifile.py:67
 msgid "label_multifile_document_location"
-msgstr ""
+msgstr "Documentlocatie"
 
 #. Default: "Document Type"
 #: senaite/core/content/multifile.py:79
 msgid "label_multifile_document_type"
-msgstr ""
+msgstr "Documenttype"
 
 #. Default: "Document Version"
 #: senaite/core/content/multifile.py:59
 msgid "label_multifile_document_version"
-msgstr ""
+msgstr "Documentversie"
 
 #. Default: "Document"
 #: senaite/core/content/multifile.py:47
 msgid "label_multifile_file"
-msgstr ""
+msgstr "Document"
 
 #. Default: "New password"
 #: senaite/core/browser/user/passwordpanel.py:36
 msgid "label_new_password"
-msgstr ""
+msgstr "Nieuw wachtwoord"
 
 #. Default: "Fax (business)"
 #: senaite/core/content/person.py:169
 msgid "label_person_business_fax"
-msgstr ""
+msgstr "Fax (zakelijk)"
 
 #. Default: "Phone (business)"
 #: senaite/core/content/person.py:160
 msgid "label_person_business_phone"
-msgstr ""
+msgstr "Telefoon (zakelijk)"
 
 #. Default: "Department"
 #: senaite/core/content/person.py:119
 msgid "label_person_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. Default: "Description"
 #: senaite/core/content/person.py:59
 msgid "label_person_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Email Address"
 #: senaite/core/content/person.py:151
 msgid "label_person_email_address"
-msgstr ""
+msgstr "E-mailadres"
 
 #. Default: "Firstname"
 #: senaite/core/content/person.py:79
 msgid "label_person_firstname"
-msgstr ""
+msgstr "Voornaam"
 
 #. Default: "Phone (home)"
 #: senaite/core/content/person.py:178
 msgid "label_person_home_phone"
-msgstr ""
+msgstr "Telefoon (privé)"
 
 #. Default: "Job title"
 #: senaite/core/content/person.py:111
 msgid "label_person_job_title"
-msgstr ""
+msgstr "Functietitel"
 
 #. Default: "Middle initial"
 #: senaite/core/content/person.py:87
 msgid "label_person_middleinitial"
-msgstr ""
+msgstr "Tussenletter"
 
 #. Default: "Middle name"
 #: senaite/core/content/person.py:95
 msgid "label_person_middlename"
-msgstr ""
+msgstr "Tussennaam"
 
 #. Default: "Phone (mobile)"
 #: senaite/core/content/person.py:187
 msgid "label_person_mobile_phone"
-msgstr ""
+msgstr "Telefoon (mobiel)"
 
 #. Default: "Physical address"
 #: senaite/core/content/person.py:210
 msgid "label_person_physical_address"
-msgstr ""
+msgstr "Fysiek adres"
 
 #. Default: "Postal address"
 #: senaite/core/content/person.py:219
 msgid "label_person_postal_address"
-msgstr ""
+msgstr "Postadres"
 
 #. Default: "Salutation"
 #: senaite/core/content/person.py:67
 msgid "label_person_salutation"
-msgstr ""
+msgstr "Aanhef"
 
 #. Default: "Surname"
 #: senaite/core/content/person.py:103
 msgid "label_person_surname"
-msgstr ""
+msgstr "Achternaam"
 
 #. Default: "Title"
 #: senaite/core/content/person.py:51
 msgid "label_person_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Username"
 #: senaite/core/content/person.py:127
 msgid "label_person_username"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 #. Default: "SENAITE is powered by"
 #: senaite/core/browser/viewlets/templates/colophon.pt:11
 msgid "label_powered_by"
-msgstr ""
+msgstr "SENAITE draait op"
 
 #. Default: "Plone & Python"
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "label_powered_by_plone"
-msgstr ""
+msgstr "Plone & Python"
 
 #. Default: "Publication preference"
 #: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
-msgstr ""
+msgstr "Publicatievoorkeur"
 
 #. Default: "Blank"
 #: bika/lims/content/referencedefinition.py:75
 msgid "label_referencedefinition_blank"
-msgstr ""
+msgstr "Blanco"
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencedefinition.py:104
 msgid "label_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën"
 
 #. Default: "Hazardous"
 #: bika/lims/content/referencedefinition.py:89
 msgid "label_referencedefinition_hazardous"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #. Default: "Reference Values"
 #: bika/lims/content/referencedefinition.py:53
 msgid "label_referencedefinition_referencevalues"
-msgstr ""
+msgstr "Referentiewaarden"
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencesample.py:116
 msgid "label_referencesample_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/referencesample.py:133
 msgid "label_referencesample_manufacturer"
-msgstr ""
+msgstr "Fabrikant"
 
 #. Default: "Reference Definition"
 #: bika/lims/content/referencesample.py:79
 msgid "label_referencesample_referencedefinition"
-msgstr ""
+msgstr "Referentiedefinitie"
 
 #. Default: "Catalog mappings"
 #: senaite/core/registry/schema.py:274
 msgid "label_registry_catalog_mappings"
-msgstr ""
+msgstr "Catalogustoewijzingen"
 
 #. Default: "Portal type"
 #: senaite/core/registry/schema.py:286
 msgid "label_registry_catalog_mappings_key"
-msgstr ""
+msgstr "Portaaltype"
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:293
 msgid "label_registry_catalog_mappings_value"
-msgstr ""
+msgstr "Catalogi"
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:265
 msgid "label_registry_catalogs_fieldset"
-msgstr ""
+msgstr "Catalogi"
 
 #. Default: "Client landing page"
 #: senaite/core/registry/schema.py:47
 msgid "label_registry_client_landing_page"
-msgstr ""
+msgstr "Landingspagina voor klant"
 
 #. Default: "Portal types to skip on content structure export"
 #: senaite/core/registry/schema.py:234
 msgid "label_registry_generic_setup_skip_export_types"
-msgstr ""
+msgstr "Portaaltypes om over te slaan bij export van inhoudsstructuur"
 
 #. Default: "Import"
 #: senaite/core/registry/schema.py:428
 msgid "label_registry_import"
-msgstr ""
+msgstr "Importeren"
 
 #. Default: "Attach import file to Analyses"
 #: senaite/core/registry/schema.py:439
 msgid "label_registry_import_analysis_attach_attachment"
-msgstr ""
+msgstr "Importbestand aan analyses koppelen"
 
 #. Default: "Submit Analyses upon import"
 #: senaite/core/registry/schema.py:452
 msgid "label_registry_import_analysis_submit"
-msgstr ""
+msgstr "Analyses indienen bij import"
 
 #. Default: "Allow multi paste"
 #: senaite/core/registry/schema.py:371
 msgid "label_registry_sample_add_allow_multi_paste_fields"
-msgstr ""
+msgstr "Meervoudig plakken toestaan"
 
 #. Default: "Commit each sample in its own transaction"
 #: senaite/core/registry/schema.py:387
 msgid "label_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Elk monster in een eigen transactie vastleggen"
 
 #. Default: "Copy sample structure with partitions"
 #: senaite/core/registry/schema.py:324
 msgid "label_registry_sample_add_copy_partitions"
-msgstr ""
+msgstr "Monsterstructuur met partities kopiëren"
 
 #. Default: "Skip analyses workflow states on copy"
 #: senaite/core/registry/schema.py:355
 msgid "label_registry_sample_add_skip_analyses_in_states"
-msgstr ""
+msgstr "Werkstroomstatussen van analyses overslaan bij kopiëren"
 
 #. Default: "Skip partition analyses on copy"
 #: senaite/core/registry/schema.py:340
 msgid "label_registry_sample_add_skip_partition_analyses"
-msgstr ""
+msgstr "Partitieanalyses overslaan bij kopiëren"
 
 #. Default: "Samples"
 #: senaite/core/registry/schema.py:309
 msgid "label_registry_samples"
-msgstr ""
+msgstr "Monsters"
 
 #. Default: "Trigger events on sample creation"
 #: senaite/core/registry/schema.py:406
 msgid "label_registry_trigger_events_on_sample_creation"
-msgstr ""
+msgstr "Gebeurtenissen activeren bij aanmaken monster"
 
 #. Default: "Worksheet"
 #: senaite/core/registry/schema.py:95
 msgid "label_registry_worksheet_settings"
-msgstr ""
+msgstr "Werkblad"
 
 #. Default: "Contained Samples"
 #: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
-msgstr ""
+msgstr "Bevatte monsters"
 
 #. Default: "Primary Sample"
 #: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
-msgstr ""
+msgstr "Primair monster"
 
 #. Default: "Batch"
 #: bika/lims/content/analysisrequest.py:328
 msgid "label_sample_batch"
-msgstr ""
+msgstr "Batch"
 
 #. Default: "CC Contact"
 #: bika/lims/content/analysisrequest.py:197
 msgid "label_sample_cccontact"
-msgstr ""
+msgstr "CC-contact"
 
 #. Default: "Client"
 #: bika/lims/content/analysisrequest.py:255
 msgid "label_sample_client"
-msgstr ""
+msgstr "Client"
 
 #. Default: "Contact"
 #: bika/lims/content/analysisrequest.py:156
 msgid "label_sample_contact"
-msgstr ""
+msgstr "Contact"
 
 #. Default: "Container"
 #: bika/lims/content/analysisrequest.py:566
 msgid "label_sample_container"
-msgstr ""
+msgstr "Container"
 
 #. Default: "Date Sampled"
 #: bika/lims/content/analysisrequest.py:449
 msgid "label_sample_datesampled"
-msgstr ""
+msgstr "Datum bemonsterd"
 
 #. Default: "Detached from sample"
 #: bika/lims/content/analysisrequest.py:1308
 msgid "label_sample_detached_from"
-msgstr ""
+msgstr "Losgekoppeld van monster"
 
 #. Default: "Duplicated from sample"
 #: bika/lims/content/analysisrequest.py:1280
 msgid "label_sample_duplicated_from"
-msgstr ""
+msgstr "Gedupliceerd van monster"
 
 #. Default: "Invoice"
 #: bika/lims/content/analysisrequest.py:1046
 msgid "label_sample_invoice"
-msgstr ""
+msgstr "Factuur"
 
 #. Default: "Parent sample"
 #: bika/lims/content/analysisrequest.py:1252
 msgid "label_sample_parent_sample"
-msgstr ""
+msgstr "Bovenliggend monster"
 
 #. Default: "Preservation"
 #: bika/lims/content/analysisrequest.py:597
 msgid "label_sample_preservation"
-msgstr ""
+msgstr "Conservering"
 
 #. Default: "Primary Sample"
 #: bika/lims/content/analysisrequest.py:292
 msgid "label_sample_primary"
-msgstr ""
+msgstr "Primair monster"
 
 #. Default: "Analysis Profiles"
 #: bika/lims/content/analysisrequest.py:418
 msgid "label_sample_profiles"
-msgstr ""
+msgstr "Analyseprofielen"
 
 #. Default: "Publication Specification"
 #: bika/lims/content/analysisrequest.py:734
 msgid "label_sample_publicationspecification"
-msgstr ""
+msgstr "Publicatiespecificatie"
 
 #. Default: "Retest from sample"
 #: bika/lims/content/analysisrequest.py:1336
 msgid "label_sample_retracted"
-msgstr ""
+msgstr "Hertest van monster"
 
 #. Default: "Sample Condition"
 #: bika/lims/content/analysisrequest.py:897
 msgid "label_sample_samplecondition"
-msgstr ""
+msgstr "Monstertoestand"
 
 #. Default: "Sample Point"
 #: bika/lims/content/analysisrequest.py:767
 msgid "label_sample_samplepoint"
-msgstr ""
+msgstr "Monsterpunt"
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisrequest.py:538
 msgid "label_sample_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Expected Sampling Date"
 #: bika/lims/content/analysisrequest.py:512
 msgid "label_sample_samplingdate"
-msgstr ""
+msgstr "Verwachte monsternamedatum"
 
 #. Default: "Sampling Deviation"
 #: bika/lims/content/analysisrequest.py:869
 msgid "label_sample_samplingdeviation"
-msgstr ""
+msgstr "Monsternameafwijking"
 
 #. Default: "Analysis Specification"
 #: bika/lims/content/analysisrequest.py:690
 msgid "label_sample_specification"
-msgstr ""
+msgstr "Analysespecificatie"
 
 #. Default: "Storage Location"
 #: bika/lims/content/analysisrequest.py:791
 msgid "label_sample_storagelocation"
-msgstr ""
+msgstr "Opslaglocatie"
 
 #. Default: "Batch Sub-group"
 #: bika/lims/content/analysisrequest.py:363
 msgid "label_sample_subgroup"
-msgstr ""
+msgstr "Batch-subgroep"
 
 #. Default: "Sample Template"
 #: bika/lims/content/analysisrequest.py:390
 msgid "label_sample_template"
-msgstr ""
+msgstr "Monstersjabloon"
 
 #. Default: "Sample Types"
 #: bika/lims/content/samplepoint.py:95
 msgid "label_samplepoint_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Category"
 #: senaite/core/content/samplepreservation.py:55
 msgid "label_samplepreservation_category"
-msgstr ""
+msgstr "Categorie"
 
 #. Default: "Container"
 #: senaite/core/content/sampletemplate.py:81
 msgid "label_sampletemplate_partition_container"
-msgstr ""
+msgstr "Container"
 
 #. Default: "Partition ID"
 #: senaite/core/content/sampletemplate.py:60
 msgid "label_sampletemplate_partition_part_id"
-msgstr ""
+msgstr "Partitie-ID"
 
 #. Default: "Preservation"
 #: senaite/core/content/sampletemplate.py:103
 msgid "label_sampletemplate_partition_preservation"
-msgstr ""
+msgstr "Conservering"
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:125
 msgid "label_sampletemplate_partition_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:243
 msgid "label_sampletemplate_partitions"
-msgstr ""
+msgstr "Partities"
 
 #. Default: "Sample Point"
 #: senaite/core/content/sampletemplate.py:185
 msgid "label_sampletemplate_samplepoint"
-msgstr ""
+msgstr "Monsterpunt"
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:207
 msgid "label_sampletemplate_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Admitted stickers for the sample type"
 #: senaite/core/content/sampletype.py:100
 msgid "label_sampletype_admitted"
-msgstr ""
+msgstr "Toegestane stickers voor het monstertype"
 
 #. Default: "Admitted sticker templates"
 #: senaite/core/content/sampletype.py:279
 msgid "label_sampletype_admitted_stickers_templates"
-msgstr ""
+msgstr "Toegestane stickersjablonen"
 
 #. Default: "Default Container Type"
 #: senaite/core/content/sampletype.py:254
 msgid "label_sampletype_containertype"
-msgstr ""
+msgstr "Standaard containertype"
 
 #. Default: "Description"
 #: senaite/core/content/sampletype.py:142
 msgid "label_sampletype_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Default large sticker"
 #: senaite/core/content/sampletype.py:120
 msgid "label_sampletype_large_default"
-msgstr ""
+msgstr "Standaard grote sticker"
 
 #. Default: "Sample Matrix"
 #: senaite/core/content/sampletype.py:204
 msgid "label_sampletype_samplematrix"
-msgstr ""
+msgstr "Monstermatrix"
 
 #. Default: "Default small sticker"
 #: senaite/core/content/sampletype.py:111
 msgid "label_sampletype_small_default"
-msgstr ""
+msgstr "Standaard kleine sticker"
 
 #. Default: "Name"
 #: senaite/core/content/sampletype.py:134
 msgid "label_sampletype_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Save"
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
-msgstr ""
+msgstr "Opslaan"
 
 #. Default: "SENAITE LIMS"
 #: senaite/core/browser/viewlets/templates/footer.pt:14
 msgid "label_senaite"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
 #: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
-msgstr ""
+msgstr "Maximumwaarde voor het veld 'Aantal monsters' bij registratie"
 
 #. Default: "Landing Page"
 #: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
-msgstr ""
+msgstr "Startpagina"
 
 #. Default: "Item"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:78
 msgid "label_setupview_item"
-msgstr ""
+msgstr "Item"
 
 #. Default: "Items"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:81
 msgid "label_setupview_items"
-msgstr ""
+msgstr "Items"
 
 #. Default: "Out of range comment"
 #: bika/lims/browser/fields/resultrangefield.py:42
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:136
 msgid "label_specs_rangecomment"
-msgstr ""
+msgstr "Opmerking buiten bereik"
 
 #. Default: "Time zone"
 #: senaite/core/browser/user/personalpreferences.py:38
 msgid "label_timezone"
-msgstr ""
+msgstr "Tijdzone"
 
 #. Default: "Title"
 #: senaite/core/browser/install/templates/senaite-addsite.pt:62
 msgid "label_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Upgrade…"
 #: senaite/core/browser/install/templates/senaite-overview.pt:67
 msgid "label_upgrade_hellip"
-msgstr ""
+msgstr "Upgraden…"
 
 #. Default: "Contact"
 #: senaite/core/browser/user/userdatapanel.py:81
 msgid "label_user_contact"
-msgstr ""
+msgstr "Contact"
 
 #. Default: "Email"
 #: senaite/core/browser/user/userdatapanel.py:70
 msgid "label_user_email"
-msgstr ""
+msgstr "E-mail"
 
 #. Default: "Full Name"
 #: senaite/core/browser/user/userdatapanel.py:64
 msgid "label_user_full_name"
-msgstr ""
+msgstr "Volledige naam"
 
 #. Default: "Preferred instrument"
 #: senaite/core/content/worksheettemplate.py:262
 msgid "label_worksheettemplate_instrument"
-msgstr ""
+msgstr "Voorkeursinstrument"
 
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
-msgstr ""
+msgstr "Beperken tot methode"
 
 #. Default: "Added ${count} label(s) to ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:185
 msgid "labels_added"
-msgstr ""
+msgstr "${count} label(s) toegevoegd aan ${affected} monster(s)"
 
 #. sample(s)"
 #. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:174
+#, fuzzy
 msgid "labels_changed"
-msgstr ""
+msgstr "${added} toegevoegd en ${removed} verwijderd toegepast op ${affected} monster(s)"
 
 #. Default: "Removed ${count} label(s) from ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:194
 msgid "labels_removed"
-msgstr ""
+msgstr "${count} label(s) verwijderd van ${affected} monster(s)"
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
 msgid "listing_add_analyses_column_category_title"
-msgstr ""
+msgstr "Categorie"
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:93
 msgid "listing_add_analyses_column_client"
-msgstr ""
+msgstr "Client"
 
 #. Default: "Order"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:102
 msgid "listing_add_analyses_column_client_order_number"
-msgstr ""
+msgstr "Order"
 
 #. Default: "Date Received"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:132
 msgid "listing_add_analyses_column_date_received"
-msgstr ""
+msgstr "Datum ontvangen"
 
 #. Default: "Due Date"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:139
 msgid "listing_add_analyses_column_due_date"
-msgstr ""
+msgstr "Vervaldatum"
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:110
 msgid "listing_add_analyses_column_request_id"
-msgstr ""
+msgstr "Aanvraag-ID"
 
 #. Default: "Analysis"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:125
 msgid "listing_add_analyses_column_title"
-msgstr ""
+msgstr "Analyse"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:150
 msgid "listing_add_analyses_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Filter by template method"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:221
 msgid "listing_add_analyses_state_restrict_to_method"
-msgstr ""
+msgstr "Filteren op sjabloonmethode"
 
 #. Default: "Filter by template services"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:203
 msgid "listing_add_analyses_state_restrict_to_services"
-msgstr ""
+msgstr "Filteren op sjabloondiensten"
 
 #. Default: "Add Analyses"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:74
 msgid "listing_add_analyses_title"
-msgstr ""
+msgstr "Analyses toevoegen"
 
 #. Default: "Add Blank Reference"
 #: senaite/core/browser/worksheets/worksheet/add_blank.py:44
 msgid "listing_add_blank_title"
-msgstr ""
+msgstr "Blancoreferentie toevoegen"
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/add_control.py:43
 msgid "listing_add_control_title"
-msgstr ""
+msgstr "Controlereferentie toevoegen"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:99
 msgid "listing_add_duplicate_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Add Duplicate"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:51
 msgid "listing_add_duplicate_title"
-msgstr ""
+msgstr "Duplicaat toevoegen"
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:81
 msgid "listing_add_duplication_column_client"
-msgstr ""
+msgstr "Client"
 
 #. Default: "Date Requested"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:88
 msgid "listing_add_duplication_column_created"
-msgstr ""
+msgstr "Datum aangevraagd"
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:74
 msgid "listing_add_duplication_column_request_id"
-msgstr ""
+msgstr "Aanvraag-ID"
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:67
 msgid "listing_add_duplication_column_title"
-msgstr ""
+msgstr "Positie"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:50
 msgid "listing_analysiscategories_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Department"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:80
 msgid "listing_analysiscategories_column_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:72
 msgid "listing_analysiscategories_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:87
 msgid "listing_analysiscategories_column_sort_key"
-msgstr ""
+msgstr "Sorteersleutel"
 
 #. Default: "Category"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:66
 msgid "listing_analysiscategories_column_title"
-msgstr ""
+msgstr "Categorie"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:98
 msgid "listing_analysiscategories_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:114
 msgid "listing_analysiscategories_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:106
 msgid "listing_analysiscategories_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Analysis Categories"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:57
 msgid "listing_analysiscategories_title"
-msgstr ""
+msgstr "Analysecategorieën"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:54
 msgid "listing_analysisprofiles_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:76
 msgid "listing_analysisprofiles_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Profile Key"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:83
 msgid "listing_analysisprofiles_column_profilekey"
-msgstr ""
+msgstr "Profielsleutel"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:91
 msgid "listing_analysisprofiles_column_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Profile"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:69
 msgid "listing_analysisprofiles_column_title"
-msgstr ""
+msgstr "Profiel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:103
 msgid "listing_analysisprofiles_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:119
 msgid "listing_analysisprofiles_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:111
 msgid "listing_analysisprofiles_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Analysis Profiles"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:61
 msgid "listing_analysisprofiles_title"
-msgstr ""
+msgstr "Analyseprofielen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:50
 msgid "listing_attachmenttypes_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:73
 msgid "listing_attachmenttypes_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:67
 msgid "listing_attachmenttypes_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:83
 msgid "listing_attachmenttypes_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:99
 msgid "listing_attachmenttypes_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:91
 msgid "listing_attachmenttypes_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Attachment Types"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:57
 msgid "listing_attachmenttypes_title"
-msgstr ""
+msgstr "Bijlagetypes"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:50
 msgid "listing_batchlabels_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:67
 msgid "listing_batchlabels_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:77
 msgid "listing_batchlabels_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:93
 msgid "listing_batchlabels_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:85
 msgid "listing_batchlabels_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Batch Labels"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:57
 msgid "listing_batchlabels_title"
-msgstr ""
+msgstr "Batchlabels"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/calculations/view.py:51
 msgid "listing_calculation_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/calculations/view.py:75
 msgid "listing_calculation_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Formula"
 #: senaite/core/browser/controlpanel/calculations/view.py:82
 msgid "listing_calculation_formula"
-msgstr ""
+msgstr "Formule"
 
 #. Default: "Calculation"
 #: senaite/core/browser/controlpanel/calculations/view.py:68
 msgid "listing_calculation_title"
-msgstr ""
+msgstr "Berekening"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/calculations/view.py:93
 msgid "listing_calculations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/calculations/view.py:111
 msgid "listing_calculations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/calculations/view.py:102
 msgid "listing_calculations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Calculations"
 #: senaite/core/browser/controlpanel/calculations/view.py:58
 msgid "listing_calculations_title"
-msgstr ""
+msgstr "Berekeningen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/containertypes/view.py:51
 msgid "listing_containertypes_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/containertypes/view.py:72
 msgid "listing_containertypes_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/containertypes/view.py:66
 msgid "listing_containertypes_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/containertypes/view.py:82
 msgid "listing_containertypes_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/containertypes/view.py:98
 msgid "listing_containertypes_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/containertypes/view.py:90
 msgid "listing_containertypes_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Container Types"
 #: senaite/core/browser/controlpanel/containertypes/view.py:58
 msgid "listing_containertypes_title"
-msgstr ""
+msgstr "Containertypes"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:52
 msgid "listing_dynamic_analysisspec_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:61
 msgid "listing_dynamic_analysisspec_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:76
 msgid "listing_dynamic_analysisspecs_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:70
 msgid "listing_dynamic_analysisspecs_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:86
 msgid "listing_dynamic_analysisspecs_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:102
 msgid "listing_dynamic_analysisspecs_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:94
 msgid "listing_dynamic_analysisspecs_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Dynamic Analysis Specifications"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:61
 msgid "listing_dynamic_analysisspecs_title"
-msgstr ""
+msgstr "Dynamische analysespecificaties"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:52
 msgid "listing_instrumentlocations_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:74
 msgid "listing_instrumentlocations_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Location"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:67
 msgid "listing_instrumentlocations_column_title"
-msgstr ""
+msgstr "Locatie"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:94
 msgid "listing_instrumentlocations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:86
 msgid "listing_instrumentlocations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:102
 msgid "listing_instrumentlocations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Instrument Locations"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:58
 msgid "listing_instrumentlocations_title"
-msgstr ""
+msgstr "Instrumentlocaties"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:49
 msgid "listing_instrumenttypes_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:72
 msgid "listing_instrumenttypes_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:65
 msgid "listing_instrumenttypes_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:83
 msgid "listing_instrumenttypes_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:101
 msgid "listing_instrumenttypes_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:92
 msgid "listing_instrumenttypes_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Instrument Types"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:56
 msgid "listing_instrumenttypes_title"
-msgstr ""
+msgstr "Instrumenttypes"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:52
 msgid "listing_interpretationtemplates_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:75
 msgid "listing_interpretationtemplates_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:81
 msgid "listing_interpretationtemplates_column_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Text"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:88
 msgid "listing_interpretationtemplates_column_text"
-msgstr ""
+msgstr "Tekst"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:68
 msgid "listing_interpretationtemplates_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:99
 msgid "listing_interpretationtemplates_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:115
 msgid "listing_interpretationtemplates_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:107
 msgid "listing_interpretationtemplates_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Interpretation Templates"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:58
 msgid "listing_interpretationtemplates_title"
-msgstr ""
+msgstr "Interpretatiesjablonen"
 
 #. Default: "Add"
 #: view.py:49
 msgid "listing_labproduct_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Price"
 #: view.py:87
 msgid "listing_labproducts_column_price"
-msgstr ""
+msgstr "Prijs"
 
 #. Default: "Product"
 #: view.py:66
 msgid "listing_labproducts_column_title"
-msgstr ""
+msgstr "Product"
 
 #. Default: "Total Price"
 #: view.py:102
 msgid "listing_labproducts_column_total_price"
-msgstr ""
+msgstr "Totaalprijs"
 
 #. Default: "Unit"
 #: view.py:80
 msgid "listing_labproducts_column_unit"
-msgstr ""
+msgstr "Eenheid"
 
 #. Default: "VAT Amount"
 #: view.py:95
 msgid "listing_labproducts_column_vatamount"
-msgstr ""
+msgstr "Btw-bedrag"
 
 #. Default: "Volume"
 #: view.py:73
 msgid "listing_labproducts_column_volume"
-msgstr ""
+msgstr "Volume"
 
 #. Default: "Active"
 #: view.py:114
 msgid "listing_labproducts_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: view.py:132
 msgid "listing_labproducts_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: view.py:123
 msgid "listing_labproducts_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Lab Products"
 #: view.py:56
 msgid "listing_labproducts_title"
-msgstr ""
+msgstr "Labproducten"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:51
 msgid "listing_manufacturers_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:80
 msgid "listing_manufacturers_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:74
 msgid "listing_manufacturers_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:91
 msgid "listing_manufacturers_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:107
 msgid "listing_manufacturers_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:99
 msgid "listing_manufacturers_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Manufacturers"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:58
 msgid "listing_manufacturers_title"
-msgstr ""
+msgstr "Fabrikanten"
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:87
 msgid "listing_reference_samples_column_position"
-msgstr ""
+msgstr "Positie"
 
 #. Default: "Supported Services"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:79
 msgid "listing_reference_samples_column_supported_services"
-msgstr ""
+msgstr "Ondersteunde diensten"
 
 #. Default: "Reference Sample"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:72
 msgid "listing_reference_samples_column_title"
-msgstr ""
+msgstr "Referentiemonster"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:98
 msgid "listing_reference_samples_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:54
 msgid "listing_reference_samples_title"
-msgstr ""
+msgstr "Controlereferentie toevoegen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/referencesamples.py:36
 msgid "listing_referencesamples_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:51
 msgid "listing_sampleconatiners_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Capacity"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:86
 msgid "listing_sampleconatiners_column_capacity"
-msgstr ""
+msgstr "Capaciteit"
 
 #. Default: "Container Type"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:79
 msgid "listing_sampleconatiners_column_containertype"
-msgstr ""
+msgstr "Containertype"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:72
 msgid "listing_sampleconatiners_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Pre-preserved"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:93
 msgid "listing_sampleconatiners_column_pre_preserved"
-msgstr ""
+msgstr "Voorgeconserveerd"
 
 #. Default: "Security seal intact"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:100
 msgid "listing_sampleconatiners_column_security_seal_intact"
-msgstr ""
+msgstr "Veiligheidszegel intact"
 
 #. Default: "Container"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:65
 msgid "listing_sampleconatiners_column_title"
-msgstr ""
+msgstr "Container"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:111
 msgid "listing_sampleconatiners_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:127
 msgid "listing_sampleconatiners_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:119
 msgid "listing_sampleconatiners_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Containers"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:56
 msgid "listing_sampleconatiners_title"
-msgstr ""
+msgstr "Monstercontainers"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:47
 msgid "listing_sampleconditions_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:68
 msgid "listing_sampleconditions_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Condition"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:62
 msgid "listing_sampleconditions_column_title"
-msgstr ""
+msgstr "Monstertoestand"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:78
 msgid "listing_sampleconditions_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:96
 msgid "listing_sampleconditions_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:87
 msgid "listing_sampleconditions_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Conditions"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:54
 msgid "listing_sampleconditions_title"
-msgstr ""
+msgstr "Monstertoestanden"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:47
 msgid "listing_samplematrices_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:68
 msgid "listing_samplematrices_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Matrix"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:62
 msgid "listing_samplematrices_column_title"
-msgstr ""
+msgstr "Monstermatrix"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:78
 msgid "listing_samplematrices_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:94
 msgid "listing_samplematrices_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:86
 msgid "listing_samplematrices_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Matrices"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:54
 msgid "listing_samplematrices_title"
-msgstr ""
+msgstr "Monstermatrices"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:51
 msgid "listing_samplepoints_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:73
 msgid "listing_samplepoints_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:80
 msgid "listing_samplepoints_column_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Sample Point"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:66
 msgid "listing_samplepoints_column_title"
-msgstr ""
+msgstr "Monsterpunt"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:92
 msgid "listing_samplepoints_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:108
 msgid "listing_samplepoints_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:100
 msgid "listing_samplepoints_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Points"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:58
 msgid "listing_samplepoints_title"
-msgstr ""
+msgstr "Monsterpunten"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:47
 msgid "listing_samplepreservations_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:68
 msgid "listing_samplepreservations_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Preservation"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:62
 msgid "listing_samplepreservations_column_title"
-msgstr ""
+msgstr "Monsterconservering"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:78
 msgid "listing_samplepreservations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:96
 msgid "listing_samplepreservations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:87
 msgid "listing_samplepreservations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Preservations"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:54
 msgid "listing_samplepreservations_title"
-msgstr ""
+msgstr "Monsterconserveringen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:52
 msgid "listing_sampletemplates_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:73
 msgid "listing_sampletemplates_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Template"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:67
 msgid "listing_sampletemplates_column_title"
-msgstr ""
+msgstr "Monstersjabloon"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:83
 msgid "listing_sampletemplates_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:99
 msgid "listing_sampletemplates_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:91
 msgid "listing_sampletemplates_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Templates"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:59
 msgid "listing_sampletemplates_title"
-msgstr ""
+msgstr "Monstersjablonen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:52
 msgid "listing_sampletypes_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Default Container"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:109
 msgid "listing_sampletypes_column_default_container"
-msgstr ""
+msgstr "Standaardcontainer"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:72
 msgid "listing_sampletypes_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Hazardous"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:79
 msgid "listing_sampletypes_column_hazardous"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #. Default: "Minimum Volume"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:91
 msgid "listing_sampletypes_column_min_vol"
-msgstr ""
+msgstr "Minimumvolume"
 
 #. Default: "Prefix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:85
 msgid "listing_sampletypes_column_prefix"
-msgstr ""
+msgstr "Voorvoegsel"
 
 #. Default: "Retention Period"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:97
 msgid "listing_sampletypes_column_retention_period"
-msgstr ""
+msgstr "Bewaartermijn"
 
 #. Default: "SampleMatrix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:103
 msgid "listing_sampletypes_column_sample_matrix"
-msgstr ""
+msgstr "Monstermatrix"
 
 #. Default: "Sample Type"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:66
 msgid "listing_sampletypes_column_title"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:119
 msgid "listing_sampletypes_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:135
 msgid "listing_sampletypes_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:127
 msgid "listing_sampletypes_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:58
 msgid "listing_sampletypes_title"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:49
 msgid "listing_samplingdeviations_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:72
 msgid "listing_samplingdeviations_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sampling Deviation"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:65
 msgid "listing_samplingdeviations_column_title"
-msgstr ""
+msgstr "Monsternameafwijking"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:92
 msgid "listing_samplingdeviations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:84
 msgid "listing_samplingdeviations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:100
 msgid "listing_samplingdeviations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sampling Deviations"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:56
 msgid "listing_samplingdeviations_title"
-msgstr ""
+msgstr "Monsternameafwijkingen"
 
 #. Default: "Calculation"
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:70
 msgid "listing_services_column_calculation"
-msgstr ""
+msgstr "Berekening"
 
 #. Default: "Hidden"
 #: senaite/core/browser/widgets/services_widget.py:112
 msgid "listing_services_column_hidden"
-msgstr ""
+msgstr "Verborgen"
 
 #. Default: "Keyword"
 #: senaite/core/browser/widgets/services_widget.py:84
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:56
 msgid "listing_services_column_keyword"
-msgstr ""
+msgstr "Sleutelwoord"
 
 #. Default: "Methods"
 #: senaite/core/browser/widgets/services_widget.py:91
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:63
 msgid "listing_services_column_methods"
-msgstr ""
+msgstr "Methoden"
 
 #. Default: "Partition"
 #: senaite/core/browser/widgets/sampletemplate_services_widget.py:51
 msgid "listing_services_column_partition"
-msgstr ""
+msgstr "Partitie"
 
 #. Default: "Price"
 #: senaite/core/browser/widgets/services_widget.py:105
 msgid "listing_services_column_price"
-msgstr ""
+msgstr "Prijs"
 
 #. Default: "Service"
 #: senaite/core/browser/widgets/services_widget.py:76
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:48
 msgid "listing_services_column_title"
-msgstr ""
+msgstr "Dienst"
 
 #. Default: "Unit"
 #: senaite/core/browser/widgets/services_widget.py:98
 msgid "listing_services_column_unit"
-msgstr ""
+msgstr "Eenheid"
 
 #. Default: "All"
 #: senaite/core/browser/widgets/services_widget.py:127
 msgid "listing_services_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:49
 msgid "listing_storagelocations_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:75
 msgid "listing_storagelocations_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Location Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:104
 msgid "listing_storagelocations_column_location_code"
-msgstr ""
+msgstr "Locatiecode"
 
 #. Default: "Location Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:97
 msgid "listing_storagelocations_column_location_title"
-msgstr ""
+msgstr "Locatietitel"
 
 #. Default: "Shelf Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:118
 msgid "listing_storagelocations_column_shelf_code"
-msgstr ""
+msgstr "Schapcode"
 
 #. Default: "Shelf Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:111
 msgid "listing_storagelocations_column_shelf_title"
-msgstr ""
+msgstr "Schaptitel"
 
 #. Default: "Site Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:90
 msgid "listing_storagelocations_column_site_code"
-msgstr ""
+msgstr "Sitecode"
 
 #. Default: "Site Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:83
 msgid "listing_storagelocations_column_site_title"
-msgstr ""
+msgstr "Sitetitel"
 
 #. Default: "Storage Location"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:68
 msgid "listing_storagelocations_column_title"
-msgstr ""
+msgstr "Opslaglocatie"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:129
 msgid "listing_storagelocations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:147
 msgid "listing_storagelocations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:138
 msgid "listing_storagelocations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Storage Locations"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:55
 msgid "listing_storagelocations_title"
-msgstr ""
+msgstr "Opslaglocaties"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/subgroups/view.py:51
 msgid "listing_subgroup_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/subgroups/view.py:73
 msgid "listing_subgroups_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/subgroups/view.py:80
 msgid "listing_subgroups_column_sortkey"
-msgstr ""
+msgstr "Sorteersleutel"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/subgroups/view.py:67
 msgid "listing_subgroups_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/subgroups/view.py:91
 msgid "listing_subgroups_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/subgroups/view.py:109
 msgid "listing_subgroups_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/subgroups/view.py:100
 msgid "listing_subgroups_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sub-Groups"
 #: senaite/core/browser/controlpanel/subgroups/view.py:58
 msgid "listing_subgroups_title"
-msgstr ""
+msgstr "Subgroepen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:51
 msgid "listing_suppliercontacts_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Business Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:79
 msgid "listing_suppliercontacts_column_businessphone"
-msgstr ""
+msgstr "Zakelijk telefoonnummer"
 
 #. Default: "Email Address"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:73
 msgid "listing_suppliercontacts_column_emailaddress"
-msgstr ""
+msgstr "E-mailadres"
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:91
 msgid "listing_suppliercontacts_column_fax"
-msgstr ""
+msgstr "Fax"
 
 #. Default: "FullName"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:67
 msgid "listing_suppliercontacts_column_fullname"
-msgstr ""
+msgstr "Volledige naam"
 
 #. Default: "Mobile Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:85
 msgid "listing_suppliercontacts_column_mobilephone"
-msgstr ""
+msgstr "Mobiele telefoon"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:101
 msgid "listing_suppliercontacts_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Contacts"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:58
 msgid "listing_suppliercontacts_title"
-msgstr ""
+msgstr "Contactpersonen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/view.py:54
 msgid "listing_suppliers_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Email"
 #: senaite/core/browser/controlpanel/suppliers/view.py:77
 msgid "listing_suppliers_column_email"
-msgstr ""
+msgstr "E-mail"
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/view.py:91
 msgid "listing_suppliers_column_fax"
-msgstr ""
+msgstr "Fax"
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/suppliers/view.py:70
 msgid "listing_suppliers_column_name"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Phone"
 #: senaite/core/browser/controlpanel/suppliers/view.py:84
 msgid "listing_suppliers_column_phone"
-msgstr ""
+msgstr "Telefoon"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/suppliers/view.py:102
 msgid "listing_suppliers_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/view.py:118
 msgid "listing_suppliers_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/suppliers/view.py:110
 msgid "listing_suppliers_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Suppliers"
 #: senaite/core/browser/controlpanel/suppliers/view.py:61
 msgid "listing_suppliers_title"
-msgstr ""
+msgstr "Leveranciers"
 
 #. Default: "Add"
 #: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Analyst"
 #: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
-msgstr ""
+msgstr "Analist"
 
 #. Default: "Created"
 #: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
-msgstr ""
+msgstr "Aangemaakt"
 
 #. Default: "Routine Analyses"
 #: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
-msgstr ""
+msgstr "Routineanalyses"
 
 #. Default: "QC Analyses"
 #: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
-msgstr ""
+msgstr "QC-analyses"
 
 #. Default: "Samples"
 #: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
-msgstr ""
+msgstr "Monsters"
 
 #. Default: "Progress"
 #: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
-msgstr ""
+msgstr "Voortgang"
 
 #. Default: "State"
 #: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
-msgstr ""
+msgstr "Status"
 
 #. Default: "Template"
 #: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
-msgstr ""
+msgstr "Sjabloon"
 
 #. Default: "Worksheet"
 #: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
-msgstr ""
+msgstr "Werkblad"
 
 #. Default: "Active"
 #: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Mine"
 #: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
-msgstr ""
+msgstr "Mijn"
 
 #. Default: "Open"
 #: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
-msgstr ""
+msgstr "Open"
 
 #. Default: "To be verified"
 #: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
-msgstr ""
+msgstr "Te verifiëren"
 
 #. Default: "Verified"
 #: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
-msgstr ""
+msgstr "Geverifieerd"
 
 #. Default: "Worksheets"
 #: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
-msgstr ""
+msgstr "Werkbladen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:54
 msgid "listing_worksheettemplates_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:77
 msgid "listing_worksheettemplates_column_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Instrument"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:91
 msgid "listing_worksheettemplates_column_instrument"
-msgstr ""
+msgstr "Instrument"
 
 #. Default: "Method"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:84
 msgid "listing_worksheettemplates_column_method"
-msgstr ""
+msgstr "Methode"
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:70
 msgid "listing_worksheettemplates_column_name"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:103
 msgid "listing_worksheettemplates_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:119
 msgid "listing_worksheettemplates_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:111
 msgid "listing_worksheettemplates_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Worksheet Templates"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:61
 msgid "listing_worksheettemplates_title"
-msgstr ""
+msgstr "Werkbladsjablonen"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "minutes"
-msgstr ""
+msgstr "minuten"
 
 # senaite.app.listing: Saved filter presets — dirty indicator on the applied
 # preset
 msgid "modified"
-msgstr ""
+msgstr "gewijzigd"
 
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
-msgstr ""
+msgstr "maandelijks"
 
 #. Default: "No analyses added to this worksheet."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:177
 msgid "no_analyses_added_to_this_worksheet"
-msgstr ""
+msgstr "Geen analyses toegevoegd aan dit werkblad."
 
 #. Default: "No analyses were added"
 #: senaite/core/browser/worksheets/worksheet/view.py:39
 msgid "no_analyses_were_added_message"
-msgstr ""
+msgstr "Er zijn geen analyses toegevoegd"
 
 #. Default: "Instrument has no data interface selected"
 #: senaite/core/browser/worksheets/worksheet/export.py:47
 msgid "no_data_instrument_message"
-msgstr ""
+msgstr "Voor het instrument is geen data-interface geselecteerd"
 
 #. Default: "Keyword '${duplicate}' duplicate found for a Analysis Service"
 #: senaite/core/validators/interimfields.py:97
 msgid "no_dup_service_keyword_validator_error"
-msgstr ""
+msgstr "Sleutelwoord '${duplicate}' dubbel gevonden voor een Analysedienst"
 
 #. Default: "'${duplicate}' duplicates found"
 #: senaite/core/validators/interimfields.py:83
 msgid "no_dups_values_validator_error"
-msgstr ""
+msgstr "'${duplicate}' duplicaten gevonden"
 
 #. Default: "Wildcards for  are not allowed: ${wildcards}"
 #: senaite/core/validators/formula.py:45
 msgid "no_wildcards__error"
-msgstr ""
+msgstr "Jokertekens voor  zijn niet toegestaan: ${wildcards}"
 
 #. Default: "'${field_name}' is required"
 #: senaite/core/validators/interimfields.py:54
 msgid "non_blank_validator_error"
-msgstr ""
+msgstr "'${field_name}' is verplicht"
 
 #. view."
 #. Default: "Layout view '${view}' not found. Set '${default}' as layout view."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:66
+#, fuzzy
 msgid "not_found_worksheet_layout_message"
-msgstr ""
+msgstr "Lay-outweergave '${view}' niet gevonden. '${default}' ingesteld als lay-outweergave."
 
 #. Default: "Set"
 #: senaite/core/browser/form/adapters/worksheettemplate.py:239
 msgid "num_of_positions_button_title"
-msgstr ""
+msgstr "Instellen"
 
 #: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
-msgstr ""
+msgstr "van"
 
 #: senaite/core/api/remarks.py:494
 msgid "original"
-msgstr ""
+msgstr "origineel"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
-msgstr ""
+msgstr "overzicht"
 
 # senaite.app.listing: Saved filter presets — menu subtitle
 msgid "per listing"
-msgstr ""
+msgstr "per lijst"
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
-msgstr ""
+msgstr "per kwartaal"
 
 #: bika/lims/content/instrumentscheduledtask.py:137
 msgid "repeating every"
-msgstr ""
+msgstr "herhaalt elke"
 
 #: bika/lims/content/instrumentscheduledtask.py:138
 msgid "repeatperiod"
-msgstr ""
+msgstr "herhaalperiode"
 
 #. Default: "Not detected"
 #: bika/lims/content/abstractanalysis.py:1120
 msgid "result_below_llod"
-msgstr ""
+msgstr "Niet gedetecteerd"
 
 #. Default: "Detected but < ${LLOQ}"
 #: bika/lims/content/abstractanalysis.py:1131
 msgid "result_below_lloq"
-msgstr ""
+msgstr "Gedetecteerd maar < ${LLOQ}"
 
 #. Default: "Field Preservation"
 #: senaite/core/config/vocabularies.py:24
 msgid "sample_preservation_category_vocab_field"
-msgstr ""
+msgstr "Veldconservering"
 
 #. Default: "Lab Preservation"
 #: senaite/core/config/vocabularies.py:28
 msgid "sample_preservation_category_vocab_lab"
-msgstr ""
+msgstr "Labconservering"
 
 #. Default: "Only ASCII characters in prefix allowed"
 #: senaite/core/content/sampletype.py:88
 msgid "sampletype_prefix_ascii_validator_message"
-msgstr ""
+msgstr "Alleen ASCII-tekens in prefix toegestaan"
 
 #. Default: "No whitespaces in prefix allowed"
 #: senaite/core/content/sampletype.py:81
 msgid "sampletype_prefix_no_whitespace_validator_message"
-msgstr ""
+msgstr "Geen spaties in prefix toegestaan"
 
 #. Default: "You must select an instrument"
 #: senaite/core/browser/worksheets/worksheet/export.py:37
 msgid "select_instrument_message"
-msgstr ""
+msgstr "U moet een instrument selecteren"
 
 #. Default: "Condition"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:35
 msgid "set_analysis_conditions_colname_condition"
-msgstr ""
+msgstr "Voorwaarde"
 
 #. Default: "Show in report"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:37
 msgid "set_analysis_conditions_colname_report"
-msgstr ""
+msgstr "Tonen in rapport"
 
 #. Default: "Value"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:36
 msgid "set_analysis_conditions_colname_value"
-msgstr ""
+msgstr "Waarde"
 
 #. Default: "Folder to import the instrument results from"
 #: bika/lims/content/instrument.py:250
 msgid "subfield_label_instrument_import_folder"
-msgstr ""
+msgstr "Map waaruit de instrumentresultaten worden geïmporteerd"
 
 #. Default: "Interface Code"
 #: bika/lims/content/instrument.py:248
 msgid "subfield_label_instrument_interface_name"
-msgstr ""
+msgstr "Interfacecode"
 
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
-msgstr ""
+msgstr "Dit monster is verzonden door ${actor} op ${date}"
 
 #. Default: "This sample has been disposed by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
 msgid "this_sample_has_been_disposed_by"
-msgstr ""
+msgstr "Dit monster is afgevoerd door ${actor} op ${date}"
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11503,1093 +11614,1098 @@ msgstr ""
 #. ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "time_format"
-msgstr ""
+msgstr "${H}:${M}"
 
 #. Default: "Accreditation"
 #: senaite/core/content/laboratory.py:170
 msgid "title_accreditation"
-msgstr ""
+msgstr "Accreditatie"
 
 #. Default: "Accreditation Body Abbreviation"
 #: senaite/core/content/laboratory.py:149
 msgid "title_accreditation_body"
-msgstr ""
+msgstr "Afkorting accreditatie-instantie"
 
 #. Default: "Accreditation Logo"
 #: senaite/core/content/laboratory.py:195
 msgid "title_accreditation_body_logo"
-msgstr ""
+msgstr "Accreditatielogo"
 
 #. Default: "Accreditation Body URL"
 #: senaite/core/content/laboratory.py:160
 msgid "title_accreditation_body_url"
-msgstr ""
+msgstr "URL accreditatie-instantie"
 
 #. Default: "Accreditation page header"
 #: senaite/core/content/laboratory.py:216
 msgid "title_accreditation_page_header"
-msgstr ""
+msgstr "Paginakop accreditatie"
 
 #. Default: "Accreditation Reference"
 #: senaite/core/content/laboratory.py:182
 msgid "title_accreditation_reference"
-msgstr ""
+msgstr "Accreditatiereferentie"
 
 #. Default: "Address"
 #: senaite/core/content/laboratory.py:88
 #: senaite/core/content/organization.py:82
 msgid "title_addresses_tab"
-msgstr ""
+msgstr "Adres"
 
 #. Default: "Comments"
 #: senaite/core/content/analysiscategory.py:60
 msgid "title_analysiscategory_comments"
-msgstr ""
+msgstr "Opmerkingen"
 
 #. Default: "Department"
 #: senaite/core/content/analysiscategory.py:81
 msgid "title_analysiscategory_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. Default: "Description"
 #: senaite/core/content/analysiscategory.py:52
 msgid "title_analysiscategory_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Sort Key"
 #: senaite/core/content/analysiscategory.py:95
 msgid "title_analysiscategory_sort_key"
-msgstr ""
+msgstr "Sorteersleutel"
 
 #. Default: "Name"
 #: senaite/core/content/analysiscategory.py:44
 msgid "title_analysiscategory_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Commercial ID"
 #: senaite/core/content/analysisprofile.py:121
 msgid "title_analysisprofile_commercial_id"
-msgstr ""
+msgstr "Commerciële ID"
 
 #. Default: "Description"
 #: senaite/core/content/analysisprofile.py:82
 msgid "title_analysisprofile_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Profile Keyword"
 #: senaite/core/content/analysisprofile.py:90
 msgid "title_analysisprofile_profile_key"
-msgstr ""
+msgstr "Profielsleutelwoord"
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/analysisprofile.py:145
 msgid "title_analysisprofile_profile_price"
-msgstr ""
+msgstr "Prijs (exclusief btw)"
 
 #. Default: "VAT %"
 #: senaite/core/content/analysisprofile.py:157
 msgid "title_analysisprofile_profile_vat"
-msgstr ""
+msgstr "Btw %"
 
 #. Default: "Profile Analyses"
 #: senaite/core/content/analysisprofile.py:106
 msgid "title_analysisprofile_services"
-msgstr ""
+msgstr "Profielanalyses"
 
 #. Default: "Name"
 #: senaite/core/content/analysisprofile.py:74
 msgid "title_analysisprofile_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Use analysis profile price"
 #: senaite/core/content/analysisprofile.py:133
 msgid "title_analysisprofile_use_profile_price"
-msgstr ""
+msgstr "Analyseprofielprijs gebruiken"
 
 #. Default: "Analyst"
 #: senaite/core/permissions/localroles.py:30
 msgid "title_analyst_role"
-msgstr ""
+msgstr "Analist"
 
 #. Default: "Description"
 #: senaite/core/content/attachmenttype.py:44
 msgid "title_attachmenttype_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/attachmenttype.py:36
 msgid "title_attachmenttype_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Bank Details"
 #: senaite/core/content/organization.py:110
 msgid "title_bank_details_tab"
-msgstr ""
+msgstr "Bankgegevens"
 
 #. Default: "Name"
 #: senaite/core/content/batchlabel.py:36
 msgid "title_batchlabel_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "This site was built using the Plone Open Source CMS/WCM."
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "title_built_with_plone"
-msgstr ""
+msgstr "Deze site is gebouwd met het Plone Open Source CMS/WCM."
 
 #. Default: "Description"
 #: senaite/core/content/calculation.py:228
 msgid "title_calculation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/calculation.py:220
 msgid "title_calculation_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Confidence Level %"
 #: senaite/core/content/laboratory.py:123
 msgid "title_confidence_level"
-msgstr ""
+msgstr "Betrouwbaarheidsniveau %"
 
 #. Default: "Description"
 #: senaite/core/content/containertype.py:44
 msgid "title_containertype_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/containertype.py:36
 msgid "title_containertype_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Copyright"
 #: senaite/core/browser/viewlets/templates/footer.pt:11
 msgid "title_copyright"
-msgstr ""
+msgstr "Auteursrecht"
 
 #. Default: "Description"
 #: senaite/core/content/department.py:60
 msgid "title_department_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Department ID"
 #: senaite/core/content/department.py:76
 msgid "title_department_id"
-msgstr ""
+msgstr "Afdelings-ID"
 
 #. Default: "Name"
 #: senaite/core/content/department.py:48
 msgid "title_department_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "No instrument"
 #: senaite/core/vocabularies/instruments.py:43
 msgid "title_instrument_no_instrument"
-msgstr ""
+msgstr "Geen instrument"
 
 #. Default: "Description"
 #: senaite/core/content/instrumentlocation.py:44
 msgid "title_instrumentlocation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/instrumentlocation.py:36
 msgid "title_instrumentlocation_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/instrumenttype.py:44
 msgid "title_instrumenttype_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/instrumenttype.py:36
 msgid "title_instrumenttype_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/interpretationtemplate.py:51
 msgid "title_interpretationtemplate_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/interpretationtemplate.py:43
 msgid "title_interpretationtemplate_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Lab Clerk"
 #: senaite/core/permissions/localroles.py:44
 msgid "title_lab_clerk_role"
-msgstr ""
+msgstr "Labmedewerker"
 
 #. Default: "Lab Manager"
 #: senaite/core/permissions/localroles.py:79
 msgid "title_lab_manager_role"
-msgstr ""
+msgstr "Labmanager"
 
 #. Default: "Color"
 #: senaite/core/content/label.py:68
 msgid "title_label_color"
-msgstr ""
+msgstr "Kleur"
 
 #. Default: "Description"
 #: senaite/core/content/label.py:56
 msgid "title_label_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/label.py:41
 msgid "title_label_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Laboratory Accredited"
 #: senaite/core/content/laboratory.py:136
 msgid "title_laboratory_accredited"
-msgstr ""
+msgstr "Laboratorium geaccrediteerd"
 
 #. Default: "Lab URL"
 #: senaite/core/content/laboratory.py:98
 msgid "title_laboratory_lab_url"
-msgstr ""
+msgstr "Lab-URL"
 
 #. Default: "Description"
 #: senaite/core/content/labproduct.py:60
 msgid "title_labproduct_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/labproduct.py:85
 msgid "title_labproduct_price"
-msgstr ""
+msgstr "Prijs (exclusief btw)"
 
 #. Default: "Name"
 #: senaite/core/content/labproduct.py:52
 msgid "title_labproduct_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Total Price"
 #: senaite/core/content/labproduct.py:123
 msgid "title_labproduct_total_price"
-msgstr ""
+msgstr "Totaalprijs"
 
 #. Default: "Unit"
 #: senaite/core/content/labproduct.py:76
 msgid "title_labproduct_unit"
-msgstr ""
+msgstr "Eenheid"
 
 #. Default: "VAT %"
 #: senaite/core/content/labproduct.py:98
 msgid "title_labproduct_vat"
-msgstr ""
+msgstr "Btw %"
 
 #. Default: "VAT"
 #: senaite/core/content/labproduct.py:114
 msgid "title_labproduct_vat_amount"
-msgstr ""
+msgstr "Btw"
 
 #. Default: "Volume"
 #: senaite/core/content/labproduct.py:68
 msgid "title_labproduct_volume"
-msgstr ""
+msgstr "Volume"
 
 #. Default: "Blank Reference"
 #: senaite/core/content/worksheettemplate.py:132
 msgid "title_layout_record_blank_ref"
-msgstr ""
+msgstr "Blancoreferentie"
 
 #. Default: "Control Reference"
 #: senaite/core/content/worksheettemplate.py:158
 msgid "title_layout_record_control_ref"
-msgstr ""
+msgstr "Controlereferentie"
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:191
 msgid "title_layout_record_dup"
-msgstr ""
+msgstr "Duplicaat van"
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:180
 msgid "title_layout_record_dup_proxy"
-msgstr ""
+msgstr "Duplicaat van"
 
 #. Default: "Position"
 #: senaite/core/content/worksheettemplate.py:96
 msgid "title_layout_record_pos"
-msgstr ""
+msgstr "Positie"
 
 #. Default: "Reference"
 #: senaite/core/content/worksheettemplate.py:169
 msgid "title_layout_record_reference_proxy"
-msgstr ""
+msgstr "Referentie"
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
-msgstr ""
+msgstr "Analysetype"
 
 #. Default: "Manage Viewlets"
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
 msgid "title_manage_viewlets"
-msgstr ""
+msgstr "Viewlets beheren"
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
 msgid "title_manager_role"
-msgstr ""
+msgstr "Manager"
 
 #. Default: "Description"
 #: senaite/core/content/manufacturer.py:44
 msgid "title_manufacturer_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/manufacturer.py:36
 msgid "title_manufacturer_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Not specified"
 #: senaite/core/vocabularies/methods.py:43
 msgid "title_method_not_specified"
-msgstr ""
+msgstr "Niet opgegeven"
 
 #. Default: "Bank Branch"
 #: senaite/core/content/organization.py:156
 msgid "title_organization_account_bank_branch"
-msgstr ""
+msgstr "Bankfiliaal"
 
 #. Default: "Bank Name"
 #: senaite/core/content/organization.py:148
 msgid "title_organization_account_bank_name"
-msgstr ""
+msgstr "Banknaam"
 
 #. Default: "Account Name"
 #: senaite/core/content/organization.py:132
 msgid "title_organization_account_name"
-msgstr ""
+msgstr "Rekeningnaam"
 
 #. Default: "Account Number"
 #: senaite/core/content/organization.py:140
 msgid "title_organization_account_number"
-msgstr ""
+msgstr "Rekeningnummer"
 
 #. Default: "Account Type"
 #: senaite/core/content/organization.py:124
 msgid "title_organization_account_type"
-msgstr ""
+msgstr "Rekeningtype"
 
 #. Default: "Email"
 #: senaite/core/content/organization.py:93
 msgid "title_organization_email"
-msgstr ""
+msgstr "E-mail"
 
 #. Default: "Fax"
 #: senaite/core/content/organization.py:73
 msgid "title_organization_fax"
-msgstr ""
+msgstr "Fax"
 
 #. Default: "Name"
 #: senaite/core/content/organization.py:47
 msgid "title_organization_name"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Phone"
 #: senaite/core/content/organization.py:64
 msgid "title_organization_phone"
-msgstr ""
+msgstr "Telefoon"
 
 #. Default: "VAT number"
 #: senaite/core/content/organization.py:55
 msgid "title_organization_tax_number"
-msgstr ""
+msgstr "Btw-nummer"
 
 #. Default: "Owner"
 #: senaite/core/permissions/localroles.py:37
 msgid "title_owner_role"
-msgstr ""
+msgstr "Eigenaar"
 
 #. Default: "Preserver"
 #: senaite/core/permissions/localroles.py:51
 msgid "title_preserver_role"
-msgstr ""
+msgstr "Conserveerder"
 
 #. Default: "Publisher"
 #: senaite/core/permissions/localroles.py:58
 msgid "title_publisher_role"
-msgstr ""
+msgstr "Publiceerder"
 
 #. Default: "Required"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:47
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:91
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:137
 msgid "title_required"
-msgstr ""
+msgstr "Verplicht"
 
 #. Default: "Description"
 #: senaite/core/content/samplecondition.py:44
 msgid "title_samplecondition_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplecondition.py:36
 msgid "title_samplecondition_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/samplecontainer.py:52
 msgid "title_samplecontainer_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplecontainer.py:44
 msgid "title_samplecontainer_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/samplematrix.py:44
 msgid "title_samplematrix_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplematrix.py:36
 msgid "title_samplematrix_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Attachment"
 #: senaite/core/content/samplepoint.py:159
 msgid "title_samplepoint_attachment_file"
-msgstr ""
+msgstr "Bijlage"
 
 #. Default: "Composite"
 #: senaite/core/content/samplepoint.py:143
 msgid "title_samplepoint_composite"
-msgstr ""
+msgstr "Samengesteld"
 
 #. Default: "Description"
 #: senaite/core/content/samplepoint.py:64
 msgid "title_samplepoint_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Elevation"
 #: senaite/core/content/samplepoint.py:87
 msgid "title_samplepoint_elevation"
-msgstr ""
+msgstr "Hoogte"
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:72
 msgid "title_samplepoint_location"
-msgstr ""
+msgstr "Locatie"
 
 #. Default: "Sampling Frequency"
 #: senaite/core/content/samplepoint.py:99
 msgid "title_samplepoint_sampling_frequency"
-msgstr ""
+msgstr "Monsternamefrequentie"
 
 #. Default: "Sample Types"
 #: senaite/core/content/samplepoint.py:122
 msgid "title_samplepoint_sampling_sample_types"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Name"
 #: senaite/core/content/samplepoint.py:56
 msgid "title_samplepoint_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/samplepreservation.py:47
 msgid "title_samplepreservation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplepreservation.py:39
 msgid "title_samplepreservation_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Sampler"
 #: senaite/core/permissions/localroles.py:65
 msgid "title_sampler_role"
-msgstr ""
+msgstr "Monsternemer"
 
 #. Default: "Auto-partition on sample reception"
 #: senaite/core/content/sampletemplate.py:256
 msgid "title_sampletemplate_auto_partition"
-msgstr ""
+msgstr "Automatisch partitioneren bij monsterontvangst"
 
 #. Default: "Composite"
 #: senaite/core/content/sampletemplate.py:217
 msgid "title_sampletemplate_composite"
-msgstr ""
+msgstr "Samengesteld"
 
 #. Default: "Description"
 #: senaite/core/content/sampletemplate.py:167
 msgid "title_sampletemplate_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Sample collected by the laboratory"
 #: senaite/core/content/sampletemplate.py:226
 msgid "title_sampletemplate_sampling_required"
-msgstr ""
+msgstr "Monster genomen door het laboratorium"
 
 #. Default: "Services"
 #: senaite/core/content/sampletemplate.py:269
 msgid "title_sampletemplate_services"
-msgstr ""
+msgstr "Diensten"
 
 #. Default: "Name"
 #: senaite/core/content/sampletemplate.py:161
 msgid "title_sampletemplate_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Retention Period"
 #: senaite/core/content/sampletype.py:151
 msgid "title_sampletype_duration_period"
-msgstr ""
+msgstr "Bewaartermijn"
 
 #. Default: "Hazard categories"
 #: senaite/core/content/sampletype.py:178
 msgid "title_sampletype_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën"
 
 #. Default: "Hazardous"
 #: senaite/core/content/sampletype.py:166
 msgid "title_sampletype_hazardous"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #. Default: "Minimum Volume"
 #: senaite/core/content/sampletype.py:231
 msgid "title_sampletype_min_volume"
-msgstr ""
+msgstr "Minimumvolume"
 
 #. Default: "Sample Type Prefix"
 #: senaite/core/content/sampletype.py:218
 msgid "title_sampletype_prefix"
-msgstr ""
+msgstr "Monstertypeprefix"
 
 #. Default: "Description"
 #: senaite/core/content/samplingdeviation.py:44
 msgid "title_samplingdeviation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplingdeviation.py:36
 msgid "title_samplingdeviation_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Allow to set the result capture date"
 #: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Toestaan om de vastlegdatum van het resultaat in te stellen"
 
 #. Default: "Allow submission of results for unassigned analyses"
 #: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
-msgstr ""
+msgstr "Indienen van resultaten voor niet-toegewezen analyses toestaan"
 
 #. Default: "Always send publication email to responsibles"
 #: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Publicatie-e-mail altijd naar verantwoordelijken sturen"
 
 #. Default: "Automatic log-off"
 #: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
-msgstr ""
+msgstr "Automatisch afmelden"
 
 #. Default: "Automatic verification of samples"
 #: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
-msgstr ""
+msgstr "Automatische verificatie van monsters"
 
 #. Default: "Categorise analysis services"
 #: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
-msgstr ""
+msgstr "Analysediensten categoriseren"
 
 #. Default: "Categorize sample analyses"
 #: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Monsteranalyses categoriseren"
 
 #. Default: "Currency"
 #: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
-msgstr ""
+msgstr "Valuta"
 
 #. Default: "Use Dashboard as default front page"
 #: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
-msgstr ""
+msgstr "Dashboard als standaard startpagina gebruiken"
 
 #. Default: "Date sampled required"
 #: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
-msgstr ""
+msgstr "Monsternamedatum verplicht"
 
 #. Default: "Default decimal mark"
 #: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
-msgstr ""
+msgstr "Standaard decimaalteken"
 
 #. Default: "Country"
 #: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
-msgstr ""
+msgstr "Land"
 
 #. Default: "Default count of Sample to add."
 #: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
-msgstr ""
+msgstr "Standaard aantal toe te voegen monsters."
 
 #. Default: "Publication 'From' address"
 #: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
-msgstr ""
+msgstr "Publicatie 'Van'-adres"
 
 #. Default: "Add a remarks field to all analyses"
 #: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
-msgstr ""
+msgstr "Een opmerkingenveld aan alle analyses toevoegen"
 
 #. Default: "Enable Sample Specifications"
 #: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
-msgstr ""
+msgstr "Monsterspecificaties inschakelen"
 
 #. Default: "Enable the rejection workflow"
 #: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
-msgstr ""
+msgstr "De afwijzingsworkflow inschakelen"
 
 #. Default: "Exponential format threshold"
 #: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
-msgstr ""
+msgstr "Drempel voor exponentiële notatie"
 
 #. Default: "Invalidation reason required"
 #: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
-msgstr ""
+msgstr "Reden voor ongeldigverklaring verplicht"
 
 #. Default: "Landing Page"
 #: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
-msgstr ""
+msgstr "Landingspagina"
 
 #. Default: "Member discount %"
 #: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
-msgstr ""
+msgstr "Ledenkorting %"
 
 #. Default: "Minimum number of results for QC stats calculations"
 #: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
-msgstr ""
+msgstr "Minimumaantal resultaten voor QC-statistiekberekeningen"
 
 #. Default: "Number of required verifications"
 #: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
-msgstr ""
+msgstr "Aantal vereiste verificaties"
 
 #. Default: "Publication Email Text"
 #: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
-msgstr ""
+msgstr "Tekst publicatie-e-mail"
 
 #. Default: "Rejection reasons"
 #: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
-msgstr ""
+msgstr "Afwijzingsredenen"
 
 #. Default: "Restrict worksheet management to lab managers"
 #: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
-msgstr ""
+msgstr "Werkbladbeheer beperken tot labmanagers"
 
 #. Default: "Restrict worksheet access to assigned analysts"
 #: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
-msgstr ""
+msgstr "Werkbladtoegang beperken tot toegewezen analisten"
 
 #. Default: "Default decimal mark"
 #: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
-msgstr ""
+msgstr "Standaard decimaalteken"
 
 #. Default: "Allow sample duplication"
 #: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Monsterduplicatie toestaan"
 
 #. Default: "Require sample analyses"
 #: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Monsteranalyses vereisen"
 
 #. Default: "Sample view analysis columns"
 #: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
-msgstr ""
+msgstr "Analysekolommen in monsterweergave"
 
 #. Default: "Default scientific notation format for reports"
 #: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
-msgstr ""
+msgstr "Standaard wetenschappelijke notatie voor rapporten"
 
 #. Default: "Default scientific notation format for results"
 #: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
-msgstr ""
+msgstr "Standaard wetenschappelijke notatie voor resultaten"
 
 #. Default: "Allow self-verification of results"
 #: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
-msgstr ""
+msgstr "Zelfverificatie van resultaten toestaan"
 
 #. Default: "Display laboratory name in the login page"
 #: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
-msgstr ""
+msgstr "Laboratoriumnaam tonen op de aanmeldpagina"
 
 #. Default: "Display sample partitions to clients"
 #: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
-msgstr ""
+msgstr "Monsterpartities tonen aan klanten"
 
 #. Default: "Include and display pricing information"
 #: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
-msgstr ""
+msgstr "Prijsinformatie opnemen en tonen"
 
 #. Default: "Sidebar navigation folders"
 #: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
-msgstr ""
+msgstr "Navigatiemappen zijbalk"
 
 #. Default: "Sidebar navigation depth"
 #: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
-msgstr ""
+msgstr "Navigatiediepte zijbalk"
 
 #. Default: "Sidebar skipped portal types"
 #: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
-msgstr ""
+msgstr "Overgeslagen portaltypes zijbalk"
 
 #. Default: "Multi Verification type"
 #: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
-msgstr ""
+msgstr "Type multiverificatie"
 
 #. Default: "VAT %"
 #: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
-msgstr ""
+msgstr "Btw %"
 
 #. Default: "Default layout in worksheet view"
 #: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
-msgstr ""
+msgstr "Standaard lay-out in werkbladweergave"
 
 #. Default: "Worksheet view analysis columns"
 #: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
-msgstr ""
+msgstr "Analysekolommen in werkbladweergave"
 
 #. Default: "Service UID"
 #: senaite/core/content/worksheettemplate.py:86
 msgid "title_service_uid"
-msgstr ""
+msgstr "Dienst-UID"
 
 #. Default: "Description"
 #: senaite/core/content/storagelocation.py:46
 msgid "title_storagelocation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Location Code"
 #: senaite/core/content/storagelocation.py:102
 msgid "title_storagelocation_location_code"
-msgstr ""
+msgstr "Locatiecode"
 
 #. Default: "Location Description"
 #: senaite/core/content/storagelocation.py:114
 msgid "title_storagelocation_location_description"
-msgstr ""
+msgstr "Locatiebeschrijving"
 
 #. Default: "Location Title"
 #: senaite/core/content/storagelocation.py:90
 msgid "title_storagelocation_location_title"
-msgstr ""
+msgstr "Locatietitel"
 
 #. Default: "Location Type"
 #: senaite/core/content/storagelocation.py:126
 msgid "title_storagelocation_location_type"
-msgstr ""
+msgstr "Locatietype"
 
 #. Default: "Shelf Code"
 #: senaite/core/content/storagelocation.py:150
 msgid "title_storagelocation_shelf_code"
-msgstr ""
+msgstr "Schapcode"
 
 #. Default: "Shelf Description"
 #: senaite/core/content/storagelocation.py:162
 msgid "title_storagelocation_shelf_description"
-msgstr ""
+msgstr "Schapbeschrijving"
 
 #. Default: "Shelf Title"
 #: senaite/core/content/storagelocation.py:138
 msgid "title_storagelocation_shelf_title"
-msgstr ""
+msgstr "Schaptitel"
 
 #. Default: "Site Code"
 #: senaite/core/content/storagelocation.py:66
 msgid "title_storagelocation_site_code"
-msgstr ""
+msgstr "Sitecode"
 
 #. Default: "Site Description"
 #: senaite/core/content/storagelocation.py:78
 msgid "title_storagelocation_site_description"
-msgstr ""
+msgstr "Sitebeschrijving"
 
 #. Default: "Site Title"
 #: senaite/core/content/storagelocation.py:54
 msgid "title_storagelocation_site_title"
-msgstr ""
+msgstr "Sitetitel"
 
 #. Default: "Address"
 #: senaite/core/content/storagelocation.py:38
 msgid "title_storagelocation_title"
-msgstr ""
+msgstr "Adres"
 
 #. Default: "Description"
 #: senaite/core/content/subgroup.py:48
 msgid "title_subgroup_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Sort Key"
 #: senaite/core/content/subgroup.py:56
 msgid "title_subgroup_sort_key"
-msgstr ""
+msgstr "Sorteersleutel"
 
 #. Default: "Name"
 #: senaite/core/content/subgroup.py:40
 msgid "title_subgroup_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "IBAN"
 #: senaite/core/content/supplier.py:96
 msgid "title_supplier_iban"
-msgstr ""
+msgstr "IBAN"
 
 #. Default: "Lab Account Number"
 #: senaite/core/content/supplier.py:47
 msgid "title_supplier_lab_contact_number"
-msgstr ""
+msgstr "Labrekeningnummer"
 
 #. Default: "NIB"
 #: senaite/core/content/supplier.py:84
 msgid "title_supplier_nib"
-msgstr ""
+msgstr "NIB"
 
 #. Default: "Remarks"
 #: senaite/core/content/supplier.py:55
 msgid "title_supplier_remarks"
-msgstr ""
+msgstr "Opmerkingen"
 
 #. Default: "SWIFT code"
 #: senaite/core/content/supplier.py:108
 msgid "title_supplier_swift_code"
-msgstr ""
+msgstr "SWIFT-code"
 
 #. Default: "Website"
 #: senaite/core/content/supplier.py:63
 msgid "title_supplier_website"
-msgstr ""
+msgstr "Website"
 
 #. Default: "Verifier"
 #: senaite/core/permissions/localroles.py:72
 msgid "title_verifier_role"
-msgstr ""
+msgstr "Verifieerder"
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheet.py:165
 msgid "title_worksheet_analyses"
-msgstr ""
+msgstr "Analyses"
 
 #. Default: "Analyst"
 #: senaite/core/content/worksheet.py:187
 msgid "title_worksheet_analyst"
-msgstr ""
+msgstr "Analist"
 
 #. Default: "Description"
 #: senaite/core/content/worksheet.py:136
 msgid "title_worksheet_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Instrument"
 #: senaite/core/content/worksheet.py:197
 msgid "title_worksheet_instrument"
-msgstr ""
+msgstr "Instrument"
 
 #. Default: "Layout"
 #: senaite/core/content/worksheet.py:154
 msgid "title_worksheet_layout"
-msgstr ""
+msgstr "Lay-out"
 
 #. Default: "Analysis"
 #: senaite/core/content/worksheet.py:110
 msgid "title_worksheet_layout_analysis"
-msgstr ""
+msgstr "Analyse"
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheet.py:90
 msgid "title_worksheet_layout_analysis_type"
-msgstr ""
+msgstr "Analysetype"
 
 #. Default: "Container"
 #: senaite/core/content/worksheet.py:100
 msgid "title_worksheet_layout_container"
-msgstr ""
+msgstr "Container"
 
 #. Default: "Position"
 #: senaite/core/content/worksheet.py:81
 msgid "title_worksheet_layout_position"
-msgstr ""
+msgstr "Positie"
 
 #. Default: "Method"
 #: senaite/core/content/worksheet.py:176
 msgid "title_worksheet_method"
-msgstr ""
+msgstr "Methode"
 
 #. Default: "Remarks"
 #: senaite/core/content/worksheet.py:209
 msgid "title_worksheet_remarks"
-msgstr ""
+msgstr "Opmerkingen"
 
 #. Default: "Results Layout"
 #: senaite/core/content/worksheet.py:217
 msgid "title_worksheet_results_layout"
-msgstr ""
+msgstr "Resultatenlay-out"
 
 #. Default: "Name"
 #: senaite/core/content/worksheet.py:127
 msgid "title_worksheet_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Worksheet Template"
 #: senaite/core/content/worksheet.py:144
 msgid "title_worksheet_worksheettemplate"
-msgstr ""
+msgstr "Werkbladsjabloon"
 
 #. Default: "Description"
 #: senaite/core/content/worksheettemplate.py:213
 msgid "title_worksheettemplate_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Number of Positions"
 #: senaite/core/content/worksheettemplate.py:290
 msgid "title_worksheettemplate_num_of_positions"
-msgstr ""
+msgstr "Aantal posities"
 
 #. Default: "Analysis Services"
 #: senaite/core/content/worksheettemplate.py:346
 msgid "title_worksheettemplate_services"
-msgstr ""
+msgstr "Analysediensten"
 
 #. Default: "Worksheet Layout"
 #: senaite/core/content/worksheettemplate.py:311
 msgid "title_worksheettemplate_template_layout"
-msgstr ""
+msgstr "Werkbladlay-out"
 
 #. Default: "Name"
 #: senaite/core/content/worksheettemplate.py:205
 msgid "title_worksheettemplate_title"
-msgstr ""
+msgstr "Naam"
 
 #: bika/lims/content/instrumentscheduledtask.py:140
 msgid "until"
-msgstr ""
+msgstr "tot"
 
 #. Lower Limit of Quantification (LLOQ)."
 #. Default: "The Lower Limit of Detection (LLOD) cannot be greater than the Lower Limit of Quantification (LLOQ)."
 #: bika/lims/validators.py:1491
+#, fuzzy
 msgid "validator_llod_above_lloq"
-msgstr ""
+msgstr "De onderste detectielimiet (LLOD) mag niet groter zijn dan de onderste kwantificeringslimiet (LLOQ)."
 
 #. or equal to the Upper Limit of Quantification (ULOQ)."
 #. Default: "The Lower Limit of Quantification (LLOQ) cannot be greater than or equal to the Upper Limit of Quantification (ULOQ)."
 #: bika/lims/validators.py:1519
+#, fuzzy
 msgid "validator_lloq_above_uloq"
-msgstr ""
+msgstr "De onderste kwantificeringslimiet (LLOQ) mag niet groter dan of gelijk aan de bovenste kwantificeringslimiet (ULOQ) zijn."
 
 #. associated with other objects, such as QC analyses."
 #. Default: "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
 #: bika/lims/validators.py:1586
+#, fuzzy
 msgid "validator_referencesample_id_children"
-msgstr ""
+msgstr "De referentiemonster-ID kan niet worden gewijzigd omdat deze al gekoppeld is aan andere objecten, zoals QC-analyses."
 
 #. Default: "A Reference Sample with the ID '%s' already exists."
 #: bika/lims/validators.py:1601
 msgid "validator_referencesample_id_exists"
-msgstr ""
+msgstr "Er bestaat al een referentiemonster met de ID '%s'."
 
 #. letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no
 #. other Reference Sample with the same ID already exists."
 #. Default: "The Reference Sample ID is invalid. Ensure it contains only letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no other Reference Sample with the same ID already exists."
 #: bika/lims/validators.py:1576
+#, fuzzy
 msgid "validator_referencesample_id_invalid"
-msgstr ""
+msgstr "De referentiemonster-ID is ongeldig. Zorg ervoor dat deze alleen letters, cijfers, underscores ('_') of koppeltekens ('-') bevat, en controleer dat er geen ander referentiemonster met dezelfde ID al bestaat."
 
 #. the Upper Limit of Detection (ULOD)."
 #. Default: "The Upper Limit of Quantification (LLOQ) cannot be greater than the Upper Limit of Detection (ULOD)."
 #: bika/lims/validators.py:1547
+#, fuzzy
 msgid "validator_uloq_above_ulod"
-msgstr ""
+msgstr "De bovenste kwantificeringslimiet (LLOQ) mag niet groter zijn dan de bovenste detectielimiet (ULOD)."
 
 #: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
-msgstr ""
+msgstr "verificatie(s) in behandeling"
 
 #: bika/lims/content/instrumentcertification.py:251
 msgid "weekly"
-msgstr ""
+msgstr "wekelijks"
 
 #. Default: "Created worksheet ${ws_id}"
 #: senaite/core/browser/modals/sample.py:67
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:63
 msgid "worksheet_created"
-msgstr ""
+msgstr "Werkblad ${ws_id} aangemaakt"
 
 #. Default: "Worksheet not created."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:56
 msgid "worksheet_not_created"
-msgstr ""
+msgstr "Werkblad niet aangemaakt."
 
 #: bika/lims/content/instrumentcertification.py:255
 msgid "yearly"
-msgstr ""
+msgstr "jaarlijks"
 
 #: senaite/core/exportimport/instruments/importer.py:783
 msgid "{request_id}: calculated result for '{analysis_keyword}': '{analysis_result}'"
-msgstr ""
+msgstr "{request_id}: berekend resultaat voor '{analysis_keyword}': '{analysis_result}'"
 
 #: senaite/core/exportimport/instruments/importer.py:532
 msgid "{request_id}: {keywords} imported sucessfully"
-msgstr ""
+msgstr "{request_id}: {keywords} succesvol geïmporteerd"
 
 #: senaite/core/exportimport/instruments/importer.py:731
 msgid "{sid} Updated field '{field}' with '{value}'"
-msgstr ""
+msgstr "{sid} Veld '{field}' bijgewerkt met '{value}'"
 
 #: senaite/core/exportimport/instruments/importer.py:613
 msgid "{sid} result for '{analysis_keyword}:{interim_keyword}': '{value}'"
-msgstr ""
+msgstr "{sid} resultaat voor '{analysis_keyword}:{interim_keyword}': '{value}'"
 
 #: senaite/core/exportimport/instruments/importer.py:680
 msgid "{sid} result for '{keyword}': '{result}'"
-msgstr ""
+msgstr "{sid} resultaat voor '{keyword}': '{result}'"
 
 #: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
-msgstr ""
+msgstr "{} (Verouderd)"
 
 #: bika/lims/controlpanel/bika_instruments.py:173
 msgid "{} weeks and {} day(s)"
-msgstr ""
+msgstr "{} weken en {} dag(en)"

--- a/src/senaite/core/locales/nl/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/nl/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Dutch (https://app.transifex.com/senaite/teams/87045/nl/)\n"
@@ -19,84 +19,86 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: nl\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
-msgstr ""
+msgstr " <p>De ID-server levert unieke opeenvolgende ID's voor objecten zoals Monsters en Werkbladen enz., op basis van een formaat dat per inhoudstype is opgegeven.</p><p>Het formaat wordt op vergelijkbare wijze opgebouwd als de Python-formaatsyntaxis, met vooraf gedefinieerde variabelen per inhoudstype, waarbij de ID's worden opgehoogd via een volgnummer, 'seq', en de opvulling ervan als een aantal cijfers, bijv. '03d' voor een reeks ID's van 001 tot 999.</p><p>Alfanumerieke voorvoegsels voor ID's worden ongewijzigd in de formaten opgenomen, bijv. WS voor Werkblad in WS-{seq:03d} levert opeenvolgende Werkblad-ID's op: WS-001, WS-002, WS-003 enz.</p><p>Voor dynamische generatie van alfanumerieke en opeenvolgende ID's kan het jokerteken {alpha} worden gebruikt. Bijv. WS-{alpha:2a3d} levert WS-AA001, WS-AA002, WS-AB034 enz. op.</p><p>Variabelen die kunnen worden gebruikt zijn onder andere:<table><tr><th style='width:150px'>Inhoudstype</th><th>Variabelen</th></tr><tr><td>Client-ID</td><td>{clientId}</td></tr><tr><td>Jaar</td><td>{year}</td></tr><tr><td>Monster-ID</td><td>{sampleId}</td></tr><tr><td>Monstertype</td><td>{sampleType}</td></tr><tr><td>Monsternamedatum</td><td>{samplingDate}</td></tr><tr><td>Datum bemonsterd</td><td>{dateSampled}</td></tr></table></p><p>Configuratie-instellingen:<ul><li>formaat:<ul><li>een python-formaattekenreeks opgebouwd uit vooraf gedefinieerde variabelen zoals sampleId, clientId, sampleType.</li><li>de speciale variabele 'seq' moet als laatste in de formaattekenreeks worden geplaatst</li></ul></li><li>reekstype: [generated|counter]</li><li>context: bij type counter levert dit context aan de telfunctie</li><li>tellertype: [backreference|contained]</li><li>tellerreferentie: een parameter voor de telfunctie</li><li>voorvoegsel: standaardvoorvoegsel als er geen is opgegeven in de formaattekenreeks</li><li>splitslengte: het aantal delen dat in het voorvoegsel wordt opgenomen</li></ul></p>"
 
 #: bika/lims/browser/publish/templates/email.pt:143
 msgid "${amount} attachments with a total size of ${total_size}"
-msgstr ""
+msgstr "${amount} bijlagen met een totale grootte van ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
-msgstr ""
+msgstr "${back_link}"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:32
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
-msgstr ""
+msgstr "${contact_fullname} kan inloggen op de LIMS met ${contact_username} als gebruikersnaam. Contactpersonen moeten hun eigen wachtwoord wijzigen. Als een wachtwoord vergeten is, kan een contactpersoon via het inlogformulier een nieuw wachtwoord aanvragen."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:105
 msgid "${items} were successfully created."
-msgstr ""
+msgstr "${items} zijn met succes aangemaakt."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:110
 msgid "${item} was successfully created."
-msgstr ""
+msgstr "${item} is met succes aangemaakt."
 
 #: bika/lims/utils/analysisrequest.py:885
 msgid "%s has been rejected"
-msgstr ""
+msgstr "%s is afgewezen"
 
 #: senaite/core/exportimport/setupdata/__init__.py:89
 msgid "%s has no '%s' column."
-msgstr ""
+msgstr "%s heeft geen '%s'-kolom."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
-msgstr ""
+msgstr "&larr; Terug"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "&larr; Back to the ${back_link}"
-msgstr ""
+msgstr "&larr; Terug naar de ${back_link}"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:30
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:35
 msgid "&larr; Go back"
-msgstr ""
+msgstr "&larr; Ga terug"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:46
 msgid "&larr; Go back to see all samples"
-msgstr ""
+msgstr "&larr; Ga terug om alle monsters te bekijken"
 
 #: bika/lims/validators.py:884
 msgid "'Max' value must be above 'Min' value"
-msgstr ""
+msgstr "De waarde 'Max' moet boven de waarde 'Min' liggen"
 
 #: bika/lims/validators.py:879
 msgid "'Max' value must be numeric"
-msgstr ""
+msgstr "De waarde 'Max' moet numeriek zijn"
 
 #: bika/lims/validators.py:877
 msgid "'Min' value must be numeric"
-msgstr ""
+msgstr "De waarde 'Min' moet numeriek zijn"
 
 #: bika/lims/validators.py:898
 msgid "'Warn Max' value must be above 'Max' value"
-msgstr ""
+msgstr "De waarde 'Waarschuw Max' moet boven de waarde 'Max' liggen"
 
 #: bika/lims/validators.py:895
 msgid "'Warn Max' value must be numeric or empty"
-msgstr ""
+msgstr "De waarde 'Waarschuw Max' moet numeriek of leeg zijn"
 
 #: bika/lims/validators.py:891
 msgid "'Warn Min' value must be below 'Min' value"
-msgstr ""
+msgstr "De waarde 'Waarschuw Min' moet onder de waarde 'Min' liggen"
 
 #: bika/lims/validators.py:888
 msgid "'Warn Min' value must be numeric or empty"
-msgstr ""
+msgstr "De waarde 'Waarschuw Min' moet numeriek of leeg zijn"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:255
 msgid "(Blank)"
@@ -116,73 +118,77 @@ msgstr "(Vereist)"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:26
 msgid "*** This is an automatically generated email, please do not reply to this message. ***"
-msgstr ""
+msgstr "*** Dit is een automatisch gegenereerd e-mailbericht, gelieve niet op dit bericht te antwoorden. ***"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:91
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr "-- Selecteren --"
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
-msgstr ""
+msgstr "... Kies een Instrument ..."
 
 #: bika/lims/browser/fields/resultrangefield.py:40
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:126
 msgid "< Min"
-msgstr ""
+msgstr "< Min"
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:61
 msgid "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Go to worksheet template setup"
-msgstr ""
+msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Ga naar werkbladsjabloon-instellingen"
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:15
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
-msgstr ""
+msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Welkom bij SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
-msgstr ""
+msgstr "<p>De ID-server levert unieke opeenvolgende ID's voor objecten zoals Monsters en Werkbladen enz., op basis van een formaat dat per inhoudstype is opgegeven. Het formaat wordt op vergelijkbare wijze opgebouwd als de Python-formaatsyntaxis, bijv. <code>WS-{seq:03d}</code> levert <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> enz. op.</p><p>De huidige persistente tellerwaarden worden beheerd in de <a href='ng'>weergave Nummergenerator</a>.</p><details class='id-server-cheatsheet'><summary>Beschikbare variabelen</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variabele</th><th>Beschrijving</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeriek volgnummer, optioneel met voorloopnullen.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alfanumerieke teller, bijv. <code>{alpha:2a3d}</code> levert AA001, AA002, ..., AB001, ... op</td></tr><tr><td><code>{year}</code></td><td>Huidig jaar met twee cijfers (bijv. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Huidige datum als <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client-ID (alleen monsters).</td></tr><tr><td><code>{sampleType}</code></td><td>Voorvoegsel monstertype.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Monsterdata (Python <code>strftime</code>-specificaties zijn van toepassing).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>Voor partities/hertesten/secundairen: de bovenliggende monster-ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Partitieteller per bovenliggend monster.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Tellers voor hertesten, secundairen en totaal aantal testen.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuratievelden</summary><ul><li><strong>Formaat</strong>: het ID-sjabloon.</li><li><strong>Reekstype</strong>: <code>generated</code> gebruikt de persistente nummerteller; <code>counter</code> gebruikt het aantal gerelateerde objecten.</li><li><strong>Context</strong>: alleen gebruikt door het type <code>counter</code>; de benoemde context waarop de teller van toepassing is.</li><li><strong>Tellertype</strong>: <code>backreference</code> (verouderd) of <code>contained</code>.</li><li><strong>Tellerreferentie</strong>: relatienaam (backreference) of metatype (contained).</li><li><strong>Voorvoegsel</strong>: standaardvoorvoegsel als er geen in het formaat staat.</li><li><strong>Splitslengte</strong>: hoeveel segmenten van het formaat het voorvoegsel van de opslagsleutel worden. Bepaalt hoe de teller wordt gepartitioneerd (bijv. per jaar, per monstertype).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 
 #: bika/lims/content/calculation.py:133
 msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-msgstr ""
+msgstr "<p>De formule die u hier typt, wordt dynamisch berekend wanneer een analyse die deze berekening gebruikt wordt weergegeven.</p><p>Om een Berekening in te voeren, gebruikt u standaard rekenkundige operatoren,  + - * / ( ), en alle beschikbare sleutelwoorden, zowel van andere Analysediensten als van de hier opgegeven Tussentijdse velden, als variabelen. Plaats ze tussen vierkante haken [ ].</p><p>Bijv. de berekening voor Totale hardheid, het totaal van Calcium (ppm)- en Magnesium (ppm)-ionen in water, wordt ingevoerd als [Ca] + [Mg], waarbij Ca en MG de sleutelwoorden zijn voor die twee Analysediensten.</p>"
 
 #: bika/lims/browser/fields/resultrangefield.py:41
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:131
 msgid "> Max"
-msgstr ""
+msgstr "> Max"
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "A Document/File attachment"
-msgstr ""
+msgstr "Een document-/bestandsbijlage"
 
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "A published results report"
-msgstr ""
+msgstr "Een gepubliceerd resultatenrapport"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:66
 msgid "A short title for the site. This will be shown in the title of the browser window on each page."
-msgstr ""
+msgstr "Een korte titel voor de site. Deze wordt op elke pagina in de titel van het browservenster weergegeven."
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "A simple file attachment"
-msgstr ""
+msgstr "Een eenvoudige bestandsbijlage"
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "A simple image attachment"
-msgstr ""
+msgstr "Een eenvoudige afbeeldingsbijlage"
 
 #: bika/lims/profiles/default/types/ARTemplate.xml
 msgid "AR Template"
-msgstr ""
+msgstr "AR-sjabloon"
 
 #: bika/lims/profiles/default/types/ARTemplates.xml
 msgid "AR Templates"
-msgstr ""
+msgstr "AR-sjablonen"
 
 #: bika/lims/profiles/default/types/ARReport.xml
 msgid "ARReport"
-msgstr ""
+msgstr "ARReport"
 
 #: bika/lims/content/organisation.py:130
 msgid "Account Name"
@@ -197,9 +203,9 @@ msgid "Account Type"
 msgstr "Rekeningtype"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
-msgstr ""
+msgstr "Boekhouding"
 
 #: senaite/core/content/laboratory.py:109
 msgid "Accreditation"
@@ -215,7 +221,7 @@ msgstr "Accreditatie-instelling URL"
 
 #: bika/lims/content/laboratory.py:162
 msgid "Accreditation Logo"
-msgstr ""
+msgstr "Accreditatielogo"
 
 #: bika/lims/content/laboratory.py:152
 msgid "Accreditation Reference"
@@ -223,7 +229,7 @@ msgstr "Accreditatie referentie"
 
 #: bika/lims/content/laboratory.py:175
 msgid "Accreditation page header"
-msgstr ""
+msgstr "Koptekst accreditatiepagina"
 
 #: senaite/core/browser/widgets/services_widget.py:323
 msgid "Accredited"
@@ -238,25 +244,25 @@ msgstr "Actie"
 #: senaite/core/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
 msgid "Activate"
-msgstr ""
+msgstr "Activeren"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Actieve"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
-msgstr ""
+msgstr "Actor"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
-msgstr ""
+msgstr "Volledige naam actor"
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Toevoegen"
 
@@ -266,7 +272,7 @@ msgstr "Toevoegen van Analyses"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:301
 msgid "Add Attachment"
-msgstr ""
+msgstr "Bijlage toevoegen"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Blank Reference"
@@ -274,87 +280,94 @@ msgstr "Lege verwijzing toevoegen"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Control Reference"
-msgstr ""
+msgstr "Controlereferentie toevoegen"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Duplicate"
-msgstr ""
+msgstr "Duplicaat toevoegen"
 
 #: senaite/core/browser/viewlets/templates/add_samples.pt:22
 msgid "Add Samples"
-msgstr ""
+msgstr "Monsters toevoegen"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr "Een opmerking toevoegen..."
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
-msgstr ""
+msgstr "Een opmerkingenveld toevoegen aan alle analyses"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
-msgstr ""
+msgstr "Voeg aangepaste CSS-regels toe voor het logo, bijv. height:15px; width:150px;"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
-msgstr ""
+msgstr "Standaard selecteerbare labels toevoegen"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:205
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:38
 msgid "Add new Attachment"
-msgstr ""
+msgstr "Nieuwe bijlage toevoegen"
 
 #: bika/lims/content/analysisrequest.py:1026
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
-msgstr ""
+msgstr "Voeg een of meer bijlagen toe om het monster in dit monster te beschrijven of om uw aanvraag te specificeren."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr "Labels toevoegen aan of verwijderen van de geselecteerde monsters"
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
-msgstr ""
+msgstr "Opmerkingen toevoegen"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:169
 msgid "Add-ons"
-msgstr ""
+msgstr "Add-ons"
 
 #: bika/lims/content/calculation.py:111
 msgid "Additional Python Libraries"
-msgstr ""
+msgstr "Aanvullende Python-bibliotheken"
 
 #: bika/lims/content/analysisrequest.py:237
 msgid "Additional email addresses to be notified"
-msgstr ""
+msgstr "Aanvullende e-mailadressen die op de hoogte moeten worden gebracht"
 
 #: bika/lims/content/analysisservice.py:117
 msgid "Additional result values"
-msgstr ""
+msgstr "Aanvullende resultaatwaarden"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:137
 #: senaite/core/z3cform/widgets/address.py:119
 msgid "Address"
-msgstr ""
+msgstr "Adres"
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Adds the ability to add/remove labels"
-msgstr ""
+msgstr "Voegt de mogelijkheid toe om labels toe te voegen/te verwijderen"
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "Adds the ability to share a content across clients"
-msgstr ""
+msgstr "Voegt de mogelijkheid toe om inhoud te delen tussen klanten"
 
 #: bika/lims/content/sampletype.py:231
 msgid "Admitted sticker templates"
-msgstr ""
+msgstr "Toegestane stickersjablonen"
 
 #: bika/lims/content/sampletype.py:204
 msgid "Admitted stickers for the sample type"
-msgstr ""
+msgstr "Toegestane stickers voor het monstertype"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:138
 msgid "Advanced"
-msgstr ""
+msgstr "Geavanceerd"
 
 #: bika/lims/browser/instrument.py:660
 #: bika/lims/content/instrumentcertification.py:92
 msgid "Agency"
-msgstr ""
+msgstr "Instantie"
 
 #: senaite/core/browser/clients/client/attachments/view.py:87
 #: senaite/core/browser/clients/client/contacts/view.py:95
@@ -364,78 +377,102 @@ msgstr "Alle"
 
 #: bika/lims/browser/accreditation.py:75
 msgid "All Accredited analysis services are listed here."
-msgstr ""
+msgstr "Alle geaccrediteerde analysediensten worden hier vermeld."
 
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:41
 msgid "All Analyses of Service"
-msgstr ""
+msgstr "Alle analyses van dienst"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Alle analyses toegewezen"
 
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr "Alle kolommen zijn verborgen."
+
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
-msgstr ""
+msgstr "Handmatige invoer van detectiegrens toestaan"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr "Handmatige invoer toestaan"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
-msgstr ""
+msgstr "Leeg toestaan"
 
 #: bika/lims/content/abstractbaseanalysis.py:685
 msgid "Allow manual uncertainty value input"
-msgstr ""
+msgstr "Handmatige invoer van onzekerheidswaarde toestaan"
 
 #: senaite/core/vocabularies/setup.py:175
 msgid "Allow same user to verify multiple times"
-msgstr ""
+msgstr "Dezelfde gebruiker toestaan meerdere keren te verifiëren"
 
 #: senaite/core/vocabularies/setup.py:177
 msgid "Allow same user to verify multiple times, but not consecutively"
-msgstr ""
+msgstr "Dezelfde gebruiker toestaan meerdere keren te verifiëren, maar niet achtereenvolgens"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
-msgstr ""
+msgstr "Zelfverificatie van resultaten toestaan"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
-msgstr ""
+msgstr "Indiening van resultaten voor niet-toegewezen analyses toestaan"
 
 #: bika/lims/content/abstractbaseanalysis.py:336
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
-msgstr ""
+msgstr "De analist toestaan de standaard detectiegrenzen (LDL en UDL) handmatig te vervangen in de weergaven voor resultaatinvoer"
 
 #: bika/lims/content/abstractbaseanalysis.py:686
 msgid "Allow the analyst to manually replace the default uncertainty value."
-msgstr ""
+msgstr "De analist toestaan de standaard onzekerheidswaarde handmatig te vervangen."
 
 #: bika/lims/content/abstractbaseanalysis.py:379
 msgid "Allow to introduce analysis results manually"
-msgstr ""
+msgstr "Toestaan analyseresultaten handmatig in te voeren"
 
 #: senaite/core/exportimport/instruments/importer.py:371
 msgid "Allowed analysis states: {allowed_states}, "
-msgstr ""
+msgstr "Toegestane analysestatussen: {allowed_states}, "
 
 #: senaite/core/exportimport/instruments/importer.py:368
 msgid "Allowed sample states: {allowed_states}, "
-msgstr ""
+msgstr "Toegestane monsterstatussen: {allowed_states}, "
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:60
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:60
 msgid "Analysed by"
-msgstr ""
+msgstr "Geanalyseerd door"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analyses"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr "Analyses toegewezen aan een werkblad, in afwachting van resultaten"
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr "Analyses opgenomen in een gepubliceerd rapport"
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr "Analyses die nog niet aan een werkblad zijn toegewezen"
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
-msgstr ""
+msgstr "Aangevraagde analyses"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr "Analyses die zijn geverifieerd"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -445,46 +482,46 @@ msgstr "Analyse"
 
 #: senaite/core/exportimport/instruments/importer.py:657
 msgid "Analysis '{keyword}' of sample '{sid}' has the result '{result}' set, which is kept due to the selected override option"
-msgstr ""
+msgstr "Analyse '{keyword}' van monster '{sid}' heeft het resultaat '{result}' ingesteld, dat behouden blijft vanwege de geselecteerde overschrijfoptie"
 
 #: bika/lims/content/abstractbaseanalysis.py:362
 msgid "Analysis Keyword"
-msgstr ""
+msgstr "Analyse-sleutelwoord"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:93
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Profiles"
-msgstr ""
+msgstr "Analyseprofielen"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:22
 msgid "Analysis Report"
-msgstr ""
+msgstr "Analyserapport"
 
 #: bika/lims/browser/publish/reports_listing.py:55
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Reports"
-msgstr ""
+msgstr "Analyserapporten"
 
 #: bika/lims/browser/publish/emailview.py:310
 msgid "Analysis Results for {}"
-msgstr ""
+msgstr "Analyseresultaten voor {}"
 
 #: bika/lims/browser/fields/referenceresultsfield.py:34
 #: bika/lims/browser/fields/resultrangefield.py:33
 #: bika/lims/browser/referencesample.py:222
 msgid "Analysis Service"
-msgstr ""
+msgstr "Analysedienst"
 
 #: bika/lims/config.py:61
 #: bika/lims/controlpanel/bika_analysisservices.py:149
 #: bika/lims/profiles/default/types/AnalysisServices.xml
 msgid "Analysis Services"
-msgstr ""
+msgstr "Analysediensten"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:76
 #: bika/lims/profiles/default/types/AnalysisSpec.xml
 msgid "Analysis Specification"
-msgstr ""
+msgstr "Analysespecificatie"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:64
 #: bika/lims/profiles/default/types/AnalysisSpecs.xml
@@ -498,35 +535,35 @@ msgstr "Soort analyse"
 
 #: bika/lims/content/analysisservice.py:266
 msgid "Analysis conditions"
-msgstr ""
+msgstr "Analysecondities"
 
 #: senaite/core/browser/modals/conditions.py:165
 msgid "Analysis conditions updated: {}"
-msgstr ""
+msgstr "Analysecondities bijgewerkt: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
-msgstr ""
+msgstr "Analysespecificaties die rechtstreeks op het monster worden bewerkt."
 
 #: senaite/core/content/interpretationtemplate.py:59
 msgid "Analysis templates"
-msgstr ""
+msgstr "Analysesjablonen"
 
 #: senaite/core/profiles/default/types/AnalysisCategories.xml
 msgid "AnalysisCategories"
-msgstr ""
+msgstr "AnalysisCategories"
 
 #: senaite/core/profiles/default/types/AnalysisCategory.xml
 msgid "AnalysisCategory"
-msgstr ""
+msgstr "AnalysisCategory"
 
 #: senaite/core/profiles/default/types/AnalysisProfile.xml
 msgid "AnalysisProfile"
-msgstr ""
+msgstr "AnalysisProfile"
 
 #: senaite/core/profiles/default/types/AnalysisProfiles.xml
 msgid "AnalysisProfiles"
-msgstr ""
+msgstr "AnalysisProfiles"
 
 #: senaite/core/browser/modals/analysis/schema.py:87
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:35
@@ -535,69 +572,69 @@ msgstr "Analist"
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:42
 msgid "Analyst must be specified."
-msgstr ""
+msgstr "Analist moet worden opgegeven."
 
 #: bika/lims/browser/fields/partitionsetupfield.py:57
 msgid "Any"
 msgstr "Elke"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
-msgstr ""
+msgstr "Weergave"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:217
 msgid "Apply"
-msgstr ""
+msgstr "Toepassen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Sjabloon toepassen"
 
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr "Deze filter toepassen"
+
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
-msgstr ""
+msgstr "Breed toepassen"
 
 #: bika/lims/content/instrument.py:308
 msgid "Asset Number"
-msgstr ""
+msgstr "Inventarisnummer"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Assign"
-msgstr ""
+msgstr "Toewijzen"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Toegewezen"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr ""
+msgstr "Toegewezen aan: ${worksheet_id}"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
-msgstr ""
+msgstr "Er zijn ten minste twee opties voor het keuzeveld vereist"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:244
 msgid "Attach to Sample"
-msgstr ""
+msgstr "Aan monster koppelen"
 
 #: senaite/core/exportimport/instruments/importer.py:815
 msgid "Attached file '{filename}' to worksheet {worksheet}"
-msgstr ""
+msgstr "Bestand '{filename}' gekoppeld aan werkblad {worksheet}"
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
-msgstr ""
+msgstr "Gekoppelde labels"
 
 #: senaite/core/exportimport/instruments/importer.py:854
 msgid "Attaching '{attachment}' to Analysis '{analysis}'"
-msgstr ""
+msgstr "'{attachment}' wordt gekoppeld aan analyse '{analysis}'"
 
 #: bika/lims/content/analysisrequest.py:1025
 #: bika/lims/content/attachment.py:52
@@ -607,7 +644,7 @@ msgstr "Bijlage"
 
 #: senaite/core/exportimport/instruments/importer.py:860
 msgid "Attachment '{attachment}' was already linked to analysis {analysis}"
-msgstr ""
+msgstr "Bijlage '{attachment}' was al gekoppeld aan analyse {analysis}"
 
 #: bika/lims/content/attachment.py:91
 msgid "Attachment Keys"
@@ -623,31 +660,31 @@ msgstr "Bijlagentypen"
 
 #: senaite/core/browser/attachment/attachment.py:215
 msgid "Attachment added to all '{}' analyses"
-msgstr ""
+msgstr "Bijlage toegevoegd aan alle '{}'-analyses"
 
 #: senaite/core/browser/attachment/attachment.py:182
 msgid "Attachment added to analysis '{}'"
-msgstr ""
+msgstr "Bijlage toegevoegd aan analyse '{}'"
 
 #: senaite/core/browser/attachment/attachment.py:281
 msgid "Attachment added to the current sample"
-msgstr ""
+msgstr "Bijlage toegevoegd aan het huidige monster"
 
 #: senaite/core/browser/widgets/services_widget.py:326
 msgid "Attachment required"
-msgstr ""
+msgstr "Bijlage vereist"
 
 #: bika/lims/content/abstractbaseanalysis.py:348
 msgid "Attachment required for verification"
-msgstr ""
+msgstr "Bijlage vereist voor verificatie"
 
 #: senaite/core/browser/attachment/attachment.py:349
 msgid "Attachment(s) deleted"
-msgstr ""
+msgstr "Bijlage(n) verwijderd"
 
 #: senaite/core/browser/attachment/attachment.py:138
 msgid "Attachment(s) updated"
-msgstr ""
+msgstr "Bijlage(n) bijgewerkt"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:10
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:10
@@ -657,207 +694,215 @@ msgstr "Bijlagen"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Audit Log"
-msgstr ""
+msgstr "Auditlogboek"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:215
 msgid "Authorized by"
-msgstr ""
+msgstr "Geautoriseerd door"
 
 #: senaite/core/exportimport/import.pt:56
 msgid "Auto Import"
-msgstr ""
+msgstr "Automatisch importeren"
 
 #: bika/lims/browser/instrument.py:759
 msgid "Auto Import Logs of %s"
-msgstr ""
+msgstr "Logboeken automatisch importeren van %s"
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Auto-Generate ID Behavior for Dexterity Contents"
-msgstr ""
+msgstr "Gedrag voor automatisch genereren van ID voor Dexterity-inhoud"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Auto-Import Logs"
-msgstr ""
+msgstr "Logboeken automatisch importeren"
+
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr "Automatisch toepassen bij openen"
 
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
-msgstr ""
+msgstr "Automatisch partitioneren bij ontvangst"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
-msgstr ""
+msgstr "Monsters automatisch ontvangen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:166
 msgid "Autofill"
-msgstr ""
+msgstr "Automatisch invullen"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
-msgstr ""
+msgstr "Automatisch stickers afdrukken"
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
-msgstr ""
+msgstr "Automatisch afmelden"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
-msgstr ""
+msgstr "Automatische verificatie van monsters"
 
 #: bika/lims/content/artemplate.py:242
 msgid "Automatically redirect the user to the partitions creation view when Sample is received."
-msgstr ""
+msgstr "Leid de gebruiker automatisch naar de weergave voor het aanmaken van partities wanneer het monster wordt ontvangen."
 
 #: bika/lims/content/analysisservice.py:76
 msgid "Available instruments based on the selected methods."
-msgstr ""
+msgstr "Beschikbare instrumenten op basis van de geselecteerde methoden."
 
 #: bika/lims/content/analysisservice.py:61
 msgid "Available methods to perform the test"
-msgstr ""
+msgstr "Beschikbare methoden om de test uit te voeren"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:119
 msgid "Available templates"
-msgstr ""
+msgstr "Beschikbare sjablonen"
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:46
 msgid "Back"
-msgstr ""
+msgstr "Terug"
 
 #: bika/lims/content/organisation.py:154
 msgid "Bank branch"
-msgstr ""
+msgstr "Bankfiliaal"
 
 #: bika/lims/content/organisation.py:146
 msgid "Bank name"
-msgstr ""
+msgstr "Banknaam"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:138
 msgid "Base configuration"
-msgstr ""
+msgstr "Basisconfiguratie"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:44
 #: bika/lims/browser/templates/referencesample_analyses.pt:42
 msgid "Basis"
-msgstr ""
+msgstr "Basis"
 
 #: bika/lims/browser/publish/reports_listing.py:76
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/vocabularies/__init__.py:128
 msgid "Batch"
-msgstr ""
+msgstr "Batch"
 
 #: bika/lims/profiles/default/types/Batch.xml
 msgid "Batch Book"
-msgstr ""
+msgstr "Batchboek"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
-msgstr ""
+msgstr "Batch-ID"
 
 #: senaite/core/profiles/default/types/BatchLabel.xml
 msgid "Batch Label"
-msgstr ""
+msgstr "Batchlabel"
 
 #: senaite/core/profiles/default/types/BatchLabels.xml
 msgid "Batch Labels"
-msgstr ""
+msgstr "Batchlabels"
 
 #: bika/lims/browser/batchfolder.py:49
 #: bika/lims/profiles/default/types/BatchFolder.xml
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Batches"
-msgstr ""
+msgstr "Batches"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:19
 msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges defined in the Specifications list below."
-msgstr ""
+msgstr "Houd er rekening mee dat de bereiken die in het spreadsheetbestand van de dynamische specificatie worden opgegeven, de bereiken die in de onderstaande Specificatielijst zijn gedefinieerd, kunnen overschrijven."
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:19
 msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges manually defined in the list below."
-msgstr ""
+msgstr "Houd er rekening mee dat de bereiken die in het spreadsheetbestand van de dynamische specificatie worden opgegeven, de bereiken die handmatig in de onderstaande lijst zijn gedefinieerd, kunnen overschrijven."
 
 #: bika/lims/browser/fields/coordinatefield.py:39
 msgid "Bearing"
-msgstr ""
+msgstr "Richting"
+
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr "Halfjaarlijks"
 
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
-msgstr ""
+msgstr "Factuuradres"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:593
 msgid "Blank"
-msgstr ""
+msgstr "Blanco"
 
 #: bika/lims/config.py:88
 msgid "Blank QC analyses"
-msgstr ""
+msgstr "Blanco QC-analyses"
 
 #: bika/lims/controlpanel/bika_instruments.py:80
 msgid "Brand"
-msgstr ""
+msgstr "Merk"
 
 #: bika/lims/browser/clientfolder.py:90
 msgid "Bulk Discount"
-msgstr ""
+msgstr "Bulkkorting"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
-msgstr ""
+msgstr "Bulkkorting is van toepassing"
 
 #: bika/lims/content/abstractbaseanalysis.py:561
 msgid "Bulk price (excluding VAT)"
-msgstr ""
+msgstr "Bulkprijs (exclusief btw)"
 
 #: senaite/core/browser/clients/client/contacts/view.py:78
 #: senaite/core/browser/controlpanel/contacts/view.py:66
 msgid "Business Phone"
-msgstr ""
+msgstr "Zakelijk telefoonnummer"
 
 #: senaite/core/z3cform/widgets/address.py:123
 msgid "Business address"
-msgstr ""
+msgstr "Zakelijk adres"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
-msgstr ""
+msgstr "Op 'Weergavewaarde' oplopend"
+
+#: bika/lims/content/abstractbaseanalysis.py:760
+msgid "By 'Display Value' descending"
+msgstr "Op 'Weergavewaarde' aflopend"
 
 #: bika/lims/content/abstractbaseanalysis.py:757
-msgid "By 'Display Value' descending"
-msgstr ""
-
-#: bika/lims/content/abstractbaseanalysis.py:754
 msgid "By 'Result Value' ascending"
-msgstr ""
+msgstr "Op 'Resultaatwaarde' oplopend"
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
-msgstr ""
+msgstr "Op 'Resultaatwaarde' aflopend"
 
 #: bika/lims/content/analysisrequest.py:348
 msgid "CBID"
-msgstr ""
+msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
-msgstr ""
+msgstr "CC-contactpersonen"
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
-msgstr ""
+msgstr "CC-e-mails"
 
 #: bika/lims/content/abstractbaseanalysis.py:663
 msgid "Calculate Precision from Uncertainties"
-msgstr ""
+msgstr "Precisie berekenen op basis van onzekerheden"
 
 #: senaite/core/profiles/default/types/Calculation.xml
 msgid "Calculation"
-msgstr ""
+msgstr "Berekening"
 
 #: senaite/core/browser/form/adapters/method.py:100
 msgid "Calculation '{}' is used by service '{}'"
-msgstr ""
+msgstr "Berekening '{}' wordt gebruikt door dienst '{}'"
 
 #: bika/lims/content/calculation.py:132
 msgid "Calculation Formula"
@@ -870,7 +915,7 @@ msgstr "Berekeningvelden Interim"
 
 #: bika/lims/content/analysisservice.py:106
 msgid "Calculation to be assigned to this content."
-msgstr ""
+msgstr "Berekening die aan deze inhoud moet worden toegewezen."
 
 #: senaite/core/profiles/default/types/Calculations.xml
 msgid "Calculations"
@@ -878,100 +923,100 @@ msgstr "Berekeningen"
 
 #: bika/lims/content/instrumentscheduledtask.py:118
 msgid "Calibration"
-msgstr ""
+msgstr "Kalibratie"
 
 #: bika/lims/browser/instrument.py:637
 #: bika/lims/browser/templates/instrument_certifications.pt:40
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Calibration Certificates"
-msgstr ""
+msgstr "Kalibratiecertificaten"
 
 #: bika/lims/content/instrumentcalibration.py:69
 msgid "Calibration report date"
-msgstr ""
+msgstr "Datum kalibratierapport"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Calibrations"
-msgstr ""
+msgstr "Kalibraties"
 
 #: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentcalibration.py:96
 msgid "Calibrator"
-msgstr ""
+msgstr "Kalibrator"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
-msgstr ""
+msgstr "Kan verifiëren, maar ingediend door huidige gebruiker"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
-msgstr ""
+msgstr "Kan verifiëren, maar al geverifieerd door huidige gebruiker"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
-msgstr ""
+msgstr "Annuleren"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Geannuleerd"
 
 #: bika/lims/content/calculation.py:460
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
-msgstr ""
+msgstr "Kan berekening niet activeren, omdat de volgende dienstafhankelijkheden inactief zijn: ${inactive_services}"
 
 #: bika/lims/content/calculation.py:480
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
-msgstr ""
+msgstr "Kan berekening niet deactiveren, omdat deze in gebruik is door de volgende diensten: ${calc_services}"
 
 #: senaite/core/browser/samples/invalidate_samples.py:93
 msgid "Cannot invalidate ${sample_id}: ${error}"
-msgstr ""
+msgstr "Kan ${sample_id} niet ongeldig maken: ${error}"
 
 #: senaite/core/browser/samples/invalidate_samples.py:262
 msgid "Cannot send email for ${sample_id}: ${error}"
-msgstr ""
+msgstr "Kan geen e-mail verzenden voor ${sample_id}: ${error}"
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
-msgstr ""
+msgstr "Kan niet verifiëren, laatst geverifieerd door huidige gebruiker"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
-msgstr ""
+msgstr "Kan niet verifiëren, ingediend door huidige gebruiker"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
-msgstr ""
+msgstr "Kan niet verifiëren, is geverifieerd door huidige gebruiker"
 
 #: senaite/core/content/samplecontainer.py:78
 msgid "Capacity"
-msgstr ""
+msgstr "Capaciteit"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:112
 msgid "Captured"
-msgstr ""
+msgstr "Vastgelegd"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:45
 #: bika/lims/browser/templates/referencesample_analyses.pt:43
 msgid "Cardinal"
-msgstr ""
+msgstr "Hoofdrichting"
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Catalog Dexterity contents in multiple catalogs"
-msgstr ""
+msgstr "Dexterity-inhoud in meerdere catalogi catalogiseren"
 
 #: bika/lims/browser/templates/referencesample_view.pt:57
 #: bika/lims/content/referencesample.py:151
 msgid "Catalogue Number"
 msgstr "Catalogusnummer"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
-msgstr ""
+msgstr "Analysediensten categoriseren"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:59
 #: bika/lims/browser/worksheet/views/add_analyses.py:107
@@ -981,118 +1026,132 @@ msgstr "Categorie"
 
 #: bika/lims/content/analysiscategory.py:118
 msgid "Category cannot be deactivated because it contains Analysis Services"
-msgstr ""
+msgstr "Categorie kan niet worden gedeactiveerd omdat deze analysediensten bevat"
 
 #: bika/lims/browser/instrument.py:659
 msgid "Cert. Num"
-msgstr ""
+msgstr "Cert.nr."
 
 #: bika/lims/content/instrumentcertification.py:209
 msgid "Certificate Code"
-msgstr ""
+msgstr "Certificaatcode"
 
 #: bika/lims/browser/auditlog.py:96
 #: bika/lims/controlpanel/auditlog.py:103
 msgid "Changes"
-msgstr ""
+msgstr "Wijzigingen"
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:64
 msgid "Changes Saved"
-msgstr ""
+msgstr "Wijzigingen opgeslagen"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
-msgstr ""
+msgstr "Wijzigingen opgeslagen."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
-msgstr ""
+msgstr "Wijzigingen worden doorgevoerd naar partities"
 
 #: bika/lims/content/method.py:67
 msgid "Check if the method has been accredited"
-msgstr ""
+msgstr "Aanvinken als de methode is geaccrediteerd"
 
 #: bika/lims/content/abstractbaseanalysis.py:495
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
-msgstr ""
+msgstr "Vink dit vakje aan als de analysedienst is opgenomen in het overzicht van geaccrediteerde analyses van het laboratorium"
 
 #: bika/lims/content/samplepoint.py:122
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
-msgstr ""
+msgstr "Vink dit vakje aan als de monsters die op dit punt worden genomen 'samengesteld' zijn en zijn samengesteld uit meer dan één deelmonster, bijv. meerdere oppervlaktemonsters van een stuwmeer die samen zijn gemengd tot een representatief monster voor het stuwmeer. De standaardinstelling, niet aangevinkt, duidt op 'grijpmonsters'"
 
 #: senaite/core/content/samplecontainer.py:86
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
-msgstr ""
+msgstr "Vink dit vakje aan als deze container al geconserveerd is. Hiermee wordt de conserveringsworkflow voor monsterpartities die in deze container zijn opgeslagen, overgeslagen."
 
 #: bika/lims/content/laboratory.py:112
 msgid "Check this box if your laboratory is accredited"
-msgstr ""
+msgstr "Vink dit vakje aan als uw laboratorium geaccrediteerd is"
 
 #: bika/lims/content/analysisservice.py:130
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
-msgstr ""
+msgstr "Vink dit vakje aan om ervoor te zorgen dat er een aparte monstercontainer wordt gebruikt voor deze analysedienst"
 
 #: bika/lims/content/analysisservice.py:260
 msgid "Checkbox"
-msgstr ""
+msgstr "Selectievakje"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:55
 #: bika/lims/content/analysisservice.py:223
 msgid "Choices"
-msgstr ""
+msgstr "Keuzes"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
-msgstr ""
+msgstr "Kies het standaardsjabloon voor 'grote' stickers. Let op: monsterspecifieke 'grote' stickers worden geconfigureerd op basis van hun monstertype."
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
-msgstr ""
+msgstr "Kies het standaardsjabloon voor 'grote' stickers.<br/><strong>Let op:</strong> monsterspecifieke 'grote' stickers worden geconfigureerd op basis van hun monstertype."
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
-msgstr ""
+msgstr "Kies het standaardsjabloon voor 'kleine' stickers. Let op: monsterspecifieke 'kleine' stickers worden geconfigureerd op basis van hun monstertype."
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
-msgstr ""
+msgstr "Kies het standaardsjabloon voor 'kleine' stickers.<br/><strong>Let op:</strong> monsterspecifieke 'kleine' stickers worden geconfigureerd op basis van hun monstertype."
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
-msgstr ""
+msgstr "Kies het type meervoudige verificatie voor dezelfde gebruiker. Met deze instelling kan meer dan één keer verifiëren/achtereenvolgens verifiëren voor dezelfde gebruiker worden in-/uitgeschakeld."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
-msgstr ""
+msgstr "Kies wanneer stickers automatisch moeten worden afgedrukt:<br/><ul><li><strong>Registreren:</strong> Stickers worden automatisch afgedrukt wanneer nieuwe monsters worden aangemaakt.</li><li><strong>Ontvangen:</strong> Stickers worden automatisch afgedrukt wanneer monsters worden ontvangen.</li><li><strong>Geen:</strong> Schakelt automatisch afdrukken van stickers uit.</li></ul>"
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
-msgstr ""
+msgstr "Kies wanneer stickers automatisch moeten worden afgedrukt:<br/><ul><li><strong>Registreren:</strong> Stickers worden automatisch afgedrukt wanneer nieuwe monsters worden aangemaakt.</li><li><strong>Ontvangen:</strong> Stickers worden automatisch afgedrukt wanneer monsters worden ontvangen.</li><li><strong>Geen:</strong> Schakelt automatisch afdrukken van stickers uit.</li></ul>"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:113
 #: senaite/core/z3cform/widgets/address.py:225
 msgid "City"
-msgstr ""
+msgstr "Plaats"
 
 #: bika/lims/config.py:125
 msgid "Classic"
 msgstr "Classic"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr "Filter wissen"
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr "Zoekopdracht wissen"
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
-msgstr ""
+msgstr "Selectie wissen"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
-msgstr ""
+msgstr "Klik om deze categorie uit te vouwen"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr "Klik om deze filter op te heffen"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
-msgstr ""
+msgstr "Klik om de zichtbaarheid te wisselen of sleep om de volgorde te wijzigen"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Client"
@@ -1100,33 +1159,33 @@ msgstr "Client"
 #: bika/lims/browser/batchfolder.py:84
 #: bika/lims/content/batch.py:101
 msgid "Client Batch ID"
-msgstr ""
+msgstr "Client-batch-ID"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Client-ID"
 
 #: bika/lims/profiles/default/registry.xml
 msgid "Client Landing Page"
-msgstr ""
+msgstr "Client-landingspagina"
 
 #: senaite/core/behaviors/clientshareable.py:85
 msgid "Client Name"
-msgstr ""
+msgstr "Clientnaam"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
-msgstr ""
+msgstr "Clientorder"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:115
 #: bika/lims/browser/batch/batchbook.py:81
 #: bika/lims/content/analysisrequest.py:817
 msgid "Client Order Number"
-msgstr ""
+msgstr "Clientordernummer"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Client Ref"
 
@@ -1135,7 +1194,7 @@ msgstr "Client Ref"
 msgid "Client Reference"
 msgstr "Referentie voor client"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Client MID"
 
@@ -1145,11 +1204,11 @@ msgstr "Client Monster-ID"
 
 #: senaite/core/registry/schema.py:39
 msgid "Client Settings"
-msgstr ""
+msgstr "Clientinstellingen"
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "ClientShareableBehavior"
-msgstr ""
+msgstr "ClientShareableBehavior"
 
 #: senaite/core/behaviors/clientshareable.py:58
 msgid "Clients"
@@ -1157,81 +1216,81 @@ msgstr "Klanten"
 
 #: senaite/core/behaviors/clientshareable.py:59
 msgid "Clients with whom this content will be shared across. This content will become available on searches to users that belong to any of the selected clients thanks to the role 'ClientGuest'"
-msgstr ""
+msgstr "Klanten met wie deze inhoud wordt gedeeld. Deze inhoud wordt beschikbaar in zoekopdrachten voor gebruikers die tot een van de geselecteerde klanten behoren dankzij de rol 'ClientGuest'"
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:13
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 msgid "Close"
-msgstr ""
+msgstr "Sluiten"
 
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 msgid "Closed"
-msgstr ""
+msgstr "Gesloten"
 
 #: bika/lims/content/storagelocation.py:59
 msgid "Code for the location"
-msgstr ""
+msgstr "Code voor de locatie"
 
 #: bika/lims/content/storagelocation.py:44
 msgid "Code for the site"
-msgstr ""
+msgstr "Code voor de site"
 
 #: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
-msgstr ""
+msgstr "Code voor de plank"
 
 #: senaite/core/registry/schema.py:133
 msgid "Collapse field analysis table"
-msgstr ""
+msgstr "Veldanalysetabel inklappen"
 
 #: senaite/core/registry/schema.py:134
 msgid "Collapse field analysis table in sample view"
-msgstr ""
+msgstr "Veldanalysetabel inklappen in monsterweergave"
 
 #: senaite/core/registry/schema.py:140
 msgid "Collapse lab analysis table"
-msgstr ""
+msgstr "Labanalysetabel inklappen"
 
 #: senaite/core/registry/schema.py:141
 msgid "Collapse lab analysis table in sample view"
-msgstr ""
+msgstr "Labanalysetabel inklappen in monsterweergave"
 
 #: senaite/core/registry/schema.py:147
 msgid "Collapse qc analysis table"
-msgstr ""
+msgstr "QC-analysetabel inklappen"
 
 #: senaite/core/registry/schema.py:148
 msgid "Collapse qc analysis table in sample view"
-msgstr ""
+msgstr "QC-analysetabel inklappen in monsterweergave"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:117
 msgid "Collected"
-msgstr ""
+msgstr "Verzameld"
 
 #: senaite/core/content/dynamicanalysisspec.py:94
 msgid "Column '{}' is missing"
-msgstr ""
+msgstr "Kolom '{}' ontbreekt"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
 msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
-msgstr ""
+msgstr "Kolom {} van de koprij heeft geen naam. Verwijder lege kolommen uit de spreadsheet en upload deze opnieuw."
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
-msgstr ""
+msgstr "Komma (,)"
 
 #: bika/lims/content/analysiscategory.py:51
 msgid "Comments"
-msgstr ""
+msgstr "Opmerkingen"
 
 #: bika/lims/content/analysisrequest.py:1368
 msgid "Comments or results interpretation"
-msgstr ""
+msgstr "Opmerkingen of interpretatie van resultaten"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
-msgstr ""
+msgstr "Commerciële ID"
 
 #: bika/lims/content/analysisrequest.py:957
 #: bika/lims/content/samplepoint.py:121
@@ -1240,39 +1299,43 @@ msgstr "Composiet"
 
 #: bika/lims/content/artemplate.py:109
 msgid "Composite sample"
-msgstr ""
+msgstr "Samengesteld monster"
 
 #: bika/lims/content/analysisservice.py:267
 msgid "Conditions to ask for this analysis on sample registration. For instance, laboratory may want the user to input the temperature, the ramp and flow when a thermogravimetric (TGA) analysis is selected on sample registration. The information provided will be later considered by the laboratory personnel when performing the test."
-msgstr ""
+msgstr "Condities om voor deze analyse op te vragen bij monsterregistratie. Zo kan het laboratorium bijvoorbeeld willen dat de gebruiker de temperatuur, de opwarmsnelheid en de flow invoert wanneer een thermogravimetrische (TGA-)analyse wordt geselecteerd bij monsterregistratie. De verstrekte informatie wordt later door het laboratoriumpersoneel in aanmerking genomen bij het uitvoeren van de test."
 
 #: bika/lims/content/laboratory.py:99
 msgid "Confidence Level %"
-msgstr ""
+msgstr "Betrouwbaarheidsniveau %"
 
 # senaite.app.listing: Configuration
 msgid "Configuration"
-msgstr ""
+msgstr "Configuratie"
 
 #: senaite/core/registry/schema.py:227
 msgid "Configuration for Generic Setup"
-msgstr ""
+msgstr "Configuratie voor Generic Setup"
 
 #: senaite/core/registry/schema.py:161
 msgid "Configuration for the sample header information"
-msgstr ""
+msgstr "Configuratie voor de kopinformatie van het monster"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:119
 msgid "Configuration restored to default values."
-msgstr ""
+msgstr "Configuratie hersteld naar standaardwaarden."
+
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr "Configureren"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
-msgstr ""
+msgstr "Tabelkolommen configureren"
 
 #: bika/lims/content/artemplate.py:173
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
-msgstr ""
+msgstr "Configureer de monsterpartities en conserveringen voor dit sjabloon. Wijs analyses toe aan de verschillende partities op het tabblad Analyses van het sjabloon"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:253
 msgid "Confirm password"
@@ -1282,20 +1345,20 @@ msgstr "Bevestig wachtwoord"
 #: bika/lims/content/instrumentmaintenancetask.py:93
 #: bika/lims/content/instrumentscheduledtask.py:86
 msgid "Considerations"
-msgstr ""
+msgstr "Overwegingen"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contact"
 
 #: bika/lims/browser/analysisrequest/add2.py:2066
 msgid "Contact does not belong to the selected client"
-msgstr ""
+msgstr "Contactpersoon behoort niet tot de geselecteerde client"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:118
 msgid "Contact is deactivated. User cannot be unlinked."
-msgstr ""
+msgstr "Contactpersoon is gedeactiveerd. Gebruiker kan niet worden ontkoppeld."
 
 #: senaite/core/browser/clients/client/contacts/view.py:65
 #: senaite/core/profiles/default/types/Contacts.xml
@@ -1305,766 +1368,804 @@ msgstr "Contactpersonen"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:72
 msgid "Contained Samples"
-msgstr ""
+msgstr "Bevatte monsters"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:175
 msgid "Container"
-msgstr ""
+msgstr "Container"
 
 #: senaite/core/content/samplecontainer.py:70
 #: senaite/core/profiles/default/types/ContainerType.xml
 msgid "Container Type"
-msgstr ""
+msgstr "Containertype"
 
 #: senaite/core/profiles/default/types/ContainerTypes.xml
 msgid "Container Types"
-msgstr ""
+msgstr "Containertypen"
 
 #: bika/lims/controlpanel/bika_containers.py:58
 msgid "Containers"
-msgstr ""
+msgstr "Containers"
 
 #: bika/lims/browser/dynamic_analysisspec.py:45
 msgid "Contents of the file {}"
-msgstr ""
+msgstr "Inhoud van het bestand {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
-msgstr ""
+msgstr "Context"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:590
 msgid "Control"
-msgstr ""
+msgstr "Controle"
 
 #: bika/lims/config.py:89
 msgid "Control QC analyses"
-msgstr ""
+msgstr "Controle-QC-analyses"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:56
 #: bika/lims/content/analysisservice.py:222
 msgid "Control type"
-msgstr ""
+msgstr "Controletype"
 
 #: bika/lims/validators.py:441
 msgid "Control type is not supported for empty choices"
-msgstr ""
+msgstr "Controletype wordt niet ondersteund voor lege keuzes"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:54
 msgid "Copy"
-msgstr ""
+msgstr "Kopiëren"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:11
 msgid "Copy analysis services"
-msgstr ""
+msgstr "Analysediensten kopiëren"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:49
 msgid "Copy from"
-msgstr ""
+msgstr "Kopiëren van"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
-msgstr ""
+msgstr "Kopieer de momenteel weergegeven kolomwaarde naar de andere kolommen rechts"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
-msgstr ""
+msgstr "Kopieer de waarde van het eerste monster naar de andere"
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
-msgstr ""
+msgstr "Kopiëren naar nieuw"
 
 #: senaite/core/browser/idserver/view.py:131
 msgid "Could not convert {} value(s) to integer: {}"
-msgstr ""
+msgstr "Kon {} waarde(n) niet naar een geheel getal converteren: {}"
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
-msgstr ""
+msgstr "Kon de volgende monster(s) niet aanmaken vanwege transactieconflicten, probeer ze opnieuw: ${rows}"
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
+msgstr "Kon gebruiker niet koppelen: ${error}"
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
-msgstr ""
+msgstr "Kon PDF voor monster {} niet laden"
 
 #: bika/lims/browser/publish/emailview.py:558
 msgid "Could not send email to {0} ({1})"
-msgstr ""
+msgstr "Kon geen e-mail verzenden naar {0} ({1})"
 
 #: bika/lims/browser/workflow/analysisrequest.py:217
 msgid "Could not transition samples to the sampled state"
-msgstr ""
+msgstr "Kon monsters niet overzetten naar de status bemonsterd"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:103
 msgid "Counter <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Teller <span class=\"sort-indicator\" />"
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
-msgstr ""
+msgstr "Tellerreferentie"
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
-msgstr ""
+msgstr "Tellertype"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:28
 #: senaite/core/z3cform/widgets/address.py:222
 msgid "Country"
-msgstr ""
+msgstr "Land"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Create Invoice PDF"
-msgstr ""
+msgstr "Factuur-PDF aanmaken"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
-msgstr ""
+msgstr "Partities aanmaken"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:214
 msgid "Create SENAITE Site"
-msgstr ""
+msgstr "SENAITE-site aanmaken"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
-msgstr ""
+msgstr "Werkblad aanmaken"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:134
 msgid "Create a new SENAITE site"
-msgstr ""
+msgstr "Een nieuwe SENAITE-site aanmaken"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:215
 msgid "Create a new User"
-msgstr ""
+msgstr "Een nieuwe gebruiker aanmaken"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
-msgstr ""
+msgstr "Een nieuw werkblad aanmaken voor de geselecteerde monsters"
 
 #: senaite/core/browser/worksheets/templates/view.pt:26
 msgid "Create new worksheet"
-msgstr ""
+msgstr "Nieuw werkblad aanmaken"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Create partitions"
-msgstr ""
+msgstr "Partities aanmaken"
 
 #: senaite/core/browser/clients/client/attachments/view.py:71
 msgid "Created"
-msgstr ""
+msgstr "Aangemaakt"
 
 #: bika/lims/browser/instrument.py:404
 msgid "Created by"
-msgstr ""
+msgstr "Aangemaakt door"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:46
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:46
 msgid "Created on"
-msgstr ""
+msgstr "Aangemaakt op"
 
 #: senaite/core/browser/samples/partition_magic.py:113
 msgid "Created {} partitions: {}"
-msgstr ""
+msgstr "{} partities aangemaakt: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
-msgstr ""
+msgstr "Aanmaker"
 
 #: bika/lims/browser/instrument.py:403
 #: bika/lims/content/instrumentscheduledtask.py:76
 msgid "Criteria"
-msgstr ""
+msgstr "Criteria"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
-msgstr ""
+msgstr "Valuta"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Current"
-msgstr ""
+msgstr "Huidig"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr "Huidige weergave verschilt van de opgeslagen weergave"
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
-msgstr ""
+msgstr "Aangepast decimaalteken"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
-msgstr ""
+msgstr "DL"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr "Dagelijks"
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
-msgstr ""
+msgstr "Data-interface"
 
 #: bika/lims/content/instrument.py:291
 msgid "Data Interface Options"
-msgstr ""
+msgstr "Data-interface-opties"
 
 #: senaite/core/browser/form/adapters/data_import.py:72
 msgid "Data import successful"
-msgstr ""
+msgstr "Data-import geslaagd"
 
 #: bika/lims/browser/batchfolder.py:76
 #: bika/lims/browser/instrument.py:661
 #: bika/lims/content/abstractbaseanalysis.py:700
 msgid "Date"
-msgstr ""
+msgstr "Datum"
 
 #: bika/lims/browser/analyses/view.py:126
 msgid "Date Created"
-msgstr ""
+msgstr "Aanmaakdatum"
 
 #: bika/lims/content/referencesample.py:204
 msgid "Date Disposed"
-msgstr ""
+msgstr "Datum afgevoerd"
 
 #: bika/lims/content/referencesample.py:197
 msgid "Date Expired"
-msgstr ""
+msgstr "Vervaldatum"
 
 #: bika/lims/content/attachment.py:100
 msgid "Date Loaded"
-msgstr ""
+msgstr "Datum geladen"
 
 #: bika/lims/browser/auditlog.py:82
 #: bika/lims/controlpanel/auditlog.py:76
 msgid "Date Modified"
-msgstr ""
+msgstr "Datum gewijzigd"
 
 #: bika/lims/browser/referencesample.py:364
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:98
 msgid "Date Opened"
-msgstr ""
+msgstr "Datum geopend"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
-msgstr ""
+msgstr "Datum geconserveerd"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
-msgstr ""
+msgstr "Datum afgedrukt"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
-msgstr ""
+msgstr "Datum gepubliceerd"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
-msgstr ""
+msgstr "Datum ontvangen"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
-msgstr ""
+msgstr "Datum geregistreerd"
 
 #: bika/lims/browser/worksheet/views/add_duplicate.py:76
 msgid "Date Requested"
-msgstr ""
+msgstr "Datum aangevraagd"
 
 #: bika/lims/content/analysisrequest.py:1075
 msgid "Date Sample Received"
-msgstr ""
+msgstr "Datum monster ontvangen"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
-msgstr ""
+msgstr "Datum bemonsterd"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
-msgstr ""
+msgstr "Datum geverifieerd"
 
 #: bika/lims/content/instrumentcalibration.py:79
 msgid "Date from which the instrument is under calibration"
-msgstr ""
+msgstr "Datum vanaf wanneer het instrument in kalibratie is"
 
 #: bika/lims/content/instrumentmaintenancetask.py:66
 msgid "Date from which the instrument is under maintenance"
-msgstr ""
+msgstr "Datum vanaf wanneer het instrument in onderhoud is"
 
 #: bika/lims/content/instrumentvalidation.py:61
 msgid "Date from which the instrument is under validation"
-msgstr ""
+msgstr "Datum vanaf wanneer het instrument in validatie is"
 
 #: bika/lims/content/instrumentcertification.py:100
 msgid "Date granted"
-msgstr ""
+msgstr "Datum verleend"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:112
 msgid "Date received"
-msgstr ""
+msgstr "Datum ontvangen"
 
 #: bika/lims/content/instrumentcertification.py:137
 msgid "Date until the certificate is valid"
-msgstr ""
+msgstr "Datum tot wanneer het certificaat geldig is"
 
 #: bika/lims/content/instrumentcalibration.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:76
 #: bika/lims/content/instrumentvalidation.py:71
 msgid "Date until the instrument will not be available"
-msgstr ""
+msgstr "Datum tot wanneer het instrument niet beschikbaar is"
 
 #: bika/lims/content/instrumentcertification.py:101
 msgid "Date when the calibration certificate was granted"
-msgstr ""
+msgstr "Datum waarop het kalibratiecertificaat werd verleend"
 
 #: bika/lims/content/instrumentcertification.py:127
 msgid "Date when the certificate is valid"
-msgstr ""
+msgstr "Datum waarop het certificaat geldig is"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
-msgstr ""
+msgstr "Datum waarop het rapport werd afgedrukt"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:101
 #: bika/lims/content/abstractbaseanalysis.py:701
 msgid "Datetime"
-msgstr ""
+msgstr "Datum-tijd"
 
 #: bika/lims/browser/fields/durationfield.py:36
 msgid "Days"
-msgstr ""
+msgstr "Dagen"
 
 #: bika/lims/content/instrument.py:186
 msgid "De-activate until next calibration test"
-msgstr ""
+msgstr "Deactiveren tot de volgende kalibratietest"
 
 #: senaite/core/profiles/default/workflows/senaite_client_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
 msgid "Deactivate"
-msgstr ""
+msgstr "Deactiveren"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
-msgstr ""
+msgstr "Decimaalteken dat gebruikt wordt in de rapporten van deze client."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
-msgstr ""
+msgstr "Standaard CC-contactpersonen voor nieuwe monsters. Indien ingesteld, worden deze contactpersonen automatisch geselecteerd in het formulier voor het toevoegen van monsters."
 
 #: bika/lims/content/analysisservice.py:165
 msgid "Default Container"
-msgstr ""
+msgstr "Standaard container"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:80
 msgid "Default Department"
-msgstr ""
+msgstr "Standaard afdeling"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
-msgstr ""
+msgstr "Standaard e-mailadressen om alle gepubliceerde monsters voor deze client in CC te zetten"
 
 #: bika/lims/content/abstractbaseanalysis.py:414
 msgid "Default Instrument"
-msgstr ""
+msgstr "Standaard instrument"
 
 #: bika/lims/content/abstractbaseanalysis.py:430
 msgid "Default Method"
-msgstr ""
+msgstr "Standaard methode"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
-msgstr ""
+msgstr "Standaard aantal kopieën"
 
 #: bika/lims/content/analysisservice.py:145
 msgid "Default Preservation"
-msgstr ""
+msgstr "Standaard conservering"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
-msgstr ""
+msgstr "Standaard stickersjabloon"
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
-msgstr ""
+msgstr "Standaard contactpersoon voor nieuwe monsters. Indien ingesteld, wordt deze contactpersoon automatisch geselecteerd in het formulier voor het toevoegen van monsters."
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
-msgstr ""
+msgstr "Standaard aantal toe te voegen monsters."
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
-msgstr ""
+msgstr "Standaard decimaalteken"
 
 #: bika/lims/content/abstractbaseanalysis.py:415
 msgid "Default instrument used for analyses of this type"
-msgstr ""
+msgstr "Standaard instrument dat gebruikt wordt voor analyses van dit type"
 
 #: bika/lims/content/sampletype.py:208
 msgid "Default large sticker"
-msgstr ""
+msgstr "Standaard grote sticker"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
-msgstr ""
+msgstr "Standaard lay-out in werkbladweergave"
 
 #: bika/lims/content/abstractbaseanalysis.py:431
 msgid "Default method used for analyses of this type"
-msgstr ""
+msgstr "Standaard methode die gebruikt wordt voor analyses van dit type"
 
 #: senaite/core/registry/schema.py:110
 msgid "Default printing templates order for worksheet"
-msgstr ""
+msgstr "Standaardvolgorde van afdruksjablonen voor werkblad"
 
 #: bika/lims/content/analysisservice.py:195
 msgid "Default result"
-msgstr ""
+msgstr "Standaard resultaat"
 
 #: bika/lims/validators.py:1379
 msgid "Default result is not a valid date"
-msgstr ""
+msgstr "Standaard resultaat is geen geldige datum"
 
 #: bika/lims/validators.py:1383
 msgid "Default result is not numeric"
-msgstr ""
+msgstr "Standaard resultaat is niet numeriek"
 
 #: bika/lims/validators.py:1389
 msgid "Default result must be one of the following result options: {}"
-msgstr ""
+msgstr "Standaard resultaat moet een van de volgende resultaatopties zijn: {}"
 
 #: bika/lims/content/analysisservice.py:196
 msgid "Default result to display on result entry"
-msgstr ""
+msgstr "Standaard resultaat om weer te geven bij resultaatinvoer"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
-msgstr ""
+msgstr "Standaard bewaartermijn voor monsters"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
-msgstr ""
+msgstr "Standaard wetenschappelijke notatie-indeling voor rapporten"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
-msgstr ""
+msgstr "Standaard wetenschappelijke notatie-indeling voor resultaten"
 
 #: bika/lims/content/sampletype.py:206
 msgid "Default small sticker"
-msgstr ""
+msgstr "Standaard kleine sticker"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:97
 msgid "Default timezone"
-msgstr ""
+msgstr "Standaard tijdzone"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
-msgstr ""
+msgstr "Standaard doorlooptijd voor analyses."
 
 #: bika/lims/browser/fields/interimfieldsfield.py:54
 #: bika/lims/content/analysisservice.py:224
 msgid "Default value"
-msgstr ""
+msgstr "Standaardwaarde"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-msgstr ""
+msgstr "Standaardwaarde van het 'Aantal monsters' wanneer gebruikers op de knop 'TOEVOEGEN' klikken om nieuwe monsters aan te maken"
 
 #: bika/lims/content/method.py:57
 msgid "Define an identifier code for the method. It must be unique."
-msgstr ""
+msgstr "Definieer een identificatiecode voor de methode. Deze moet uniek zijn."
 
 #: bika/lims/content/calculation.py:60
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
-msgstr ""
+msgstr "Definieer tussenvelden zoals vaatmassa of verdunningsfactoren, mocht uw berekening deze nodig hebben. De hier opgegeven veldtitel wordt gebruikt als kolomkop en veldbeschrijving waar de tussenvelden worden weergegeven. Als 'Breed toepassen' is ingeschakeld, wordt het veld weergegeven in een keuzevak bovenaan het werkblad, zodat een specifieke waarde op alle overeenkomstige velden op het blad kan worden toegepast."
 
 #: bika/lims/content/abstractbaseanalysis.py:177
 msgid "Define the number of decimals to be used for this result."
-msgstr ""
+msgstr "Definieer het aantal decimalen dat voor dit resultaat gebruikt moet worden."
 
 #: bika/lims/content/abstractbaseanalysis.py:191
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
-msgstr ""
+msgstr "Definieer de precisie bij het omzetten van waarden naar exponentnotatie.  De standaardwaarde is 7."
 
 #: bika/lims/content/analysisrequest.py:494
 msgid "Define the sampler supposed to do the sample in the scheduled date"
-msgstr ""
+msgstr "Definieer de monsternemer die het monster op de geplande datum moet nemen"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
-msgstr ""
+msgstr "Definieer het sjabloon voor de e-mailtekst die automatisch wordt verstuurd naar primaire contactpersonen en laboratoriummanagers wanneer een monster ongeldig wordt verklaard. De volgende plaatshouders worden ondersteund: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 
 #: bika/lims/content/sampletype.py:232
 msgid "Defines the stickers to use for this sample type."
-msgstr ""
+msgstr "Definieert de stickers die voor dit monstertype gebruikt moeten worden."
 
 #: bika/lims/browser/fields/coordinatefield.py:36
 msgid "Degrees"
-msgstr ""
+msgstr "Graden"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
-msgstr ""
+msgstr "Verwijderen"
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr "Filter verwijderen"
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
+msgstr "Deze opmerking verwijderen?"
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
 msgid "Department"
-msgstr ""
+msgstr "Afdeling"
 
 #: senaite/core/browser/controlpanel/departments/view.py:68
 msgid "Department ID"
-msgstr ""
+msgstr "Afdelings-ID"
 
 #: senaite/core/content/department.py:134
 msgid "Department ID must be unique"
-msgstr ""
+msgstr "Afdelings-ID moet uniek zijn"
 
 #: bika/lims/content/abstractbaseanalysis.py:601
 #: bika/lims/content/analysiscategory.py:72
 msgid "Department Name"
-msgstr ""
+msgstr "Afdelingsnaam"
 
 #: senaite/core/profiles/default/types/Departments.xml
 msgid "Departments"
-msgstr ""
+msgstr "Afdelingen"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:201
 msgid "Dependent Analyses"
-msgstr ""
+msgstr "Afhankelijke analyses"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
-msgstr ""
+msgstr "Beschrijving"
 
 #: bika/lims/content/instrumentcalibration.py:119
 msgid "Description of the actions made during the calibration"
-msgstr ""
+msgstr "Beschrijving van de tijdens de kalibratie uitgevoerde acties"
 
 #: bika/lims/content/instrumentmaintenancetask.py:104
 msgid "Description of the actions made during the maintenance process"
-msgstr ""
+msgstr "Beschrijving van de tijdens het onderhoudsproces uitgevoerde acties"
 
 #: bika/lims/content/instrumentvalidation.py:101
 msgid "Description of the actions made during the validation"
-msgstr ""
+msgstr "Beschrijving van de tijdens de validatie uitgevoerde acties"
 
 #: bika/lims/content/storagelocation.py:64
 msgid "Description of the location"
-msgstr ""
+msgstr "Beschrijving van de locatie"
 
 #: bika/lims/content/storagelocation.py:84
 msgid "Description of the shelf"
-msgstr ""
+msgstr "Beschrijving van de plank"
 
 #: bika/lims/content/storagelocation.py:49
 msgid "Description of the site"
-msgstr ""
+msgstr "Beschrijving van de site"
 
 msgid "Deselect all"
-msgstr ""
+msgstr "Alles deselecteren"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Detach"
-msgstr ""
+msgstr "Loskoppelen"
 
 #: senaite/core/browser/modals/analysis/schema.py:105
 msgid "Detection Limit"
-msgstr ""
+msgstr "Detectielimiet"
 
 # senaite.app.listing: Disable auto fetch transitions
 msgid "Disable auto fetch transitions"
-msgstr ""
+msgstr "Automatisch ophalen van overgangen uitschakelen"
 
 #: senaite/core/vocabularies/setup.py:180
 msgid "Disable multi-verification for the same user"
-msgstr ""
+msgstr "Meervoudige verificatie voor dezelfde gebruiker uitschakelen"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr "Bewerkingen verwerpen en voorinstelling herstellen"
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
-msgstr ""
+msgstr "Korting"
 
 #: bika/lims/content/pricelist.py:66
 msgid "Discount %"
-msgstr ""
+msgstr "Korting %"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:78
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatch"
-msgstr ""
+msgstr "Verzenden"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:15
 msgid "Dispatch samples"
-msgstr ""
+msgstr "Monsters verzenden"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
-msgstr ""
+msgstr "Verzonden"
 
 # bika.lims.bikalisting.js
 msgid "Display Columns"
-msgstr ""
+msgstr "Kolommen weergeven"
 
 #: bika/lims/content/abstractbaseanalysis.py:727
 msgid "Display Value"
-msgstr ""
+msgstr "Weergavewaarde"
 
 #: bika/lims/validators.py:675
 msgid "Display Value is required"
-msgstr ""
+msgstr "Weergavewaarde is vereist"
 
 #: bika/lims/validators.py:687
 msgid "Display Value must be unique"
-msgstr ""
+msgstr "Weergavewaarde moet uniek zijn"
 
 #: bika/lims/content/abstractbaseanalysis.py:316
 msgid "Display a Detection Limit selector"
-msgstr ""
+msgstr "Een detectielimietselector weergeven"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
-msgstr ""
+msgstr "Monsterpartities aan clients tonen"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
-msgstr ""
+msgstr "Afvoeren"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr "Monsters afvoeren"
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
-msgstr ""
+msgstr "Afgevoerd"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:87
 #: senaite/core/z3cform/widgets/address.py:224
 msgid "District"
-msgstr ""
+msgstr "District"
 
 #: bika/lims/browser/instrument.py:664
 #: bika/lims/content/multifile.py:47
 msgid "Document"
-msgstr ""
+msgstr "Document"
 
 #: bika/lims/browser/instrument.py:809
 #: bika/lims/content/multifile.py:39
 msgid "Document ID"
-msgstr ""
+msgstr "Document-ID"
 
 #: bika/lims/browser/instrument.py:812
 #: bika/lims/content/multifile.py:63
 msgid "Document Location"
-msgstr ""
+msgstr "Documentlocatie"
 
 #: bika/lims/browser/instrument.py:813
 #: bika/lims/content/multifile.py:73
 msgid "Document Type"
-msgstr ""
+msgstr "Documenttype"
 
 #: bika/lims/browser/instrument.py:811
 #: bika/lims/content/multifile.py:55
 msgid "Document Version"
-msgstr ""
+msgstr "Documentversie"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Documents"
-msgstr ""
+msgstr "Documenten"
 
 #: senaite/core/exportimport/instruments/importer.py:375
 msgid "Don't override analysis results"
-msgstr ""
+msgstr "Analyseresultaten niet overschrijven"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:79
 msgid "Done"
-msgstr ""
+msgstr "Klaar"
 
 #: senaite/core/vocabularies/setup.py:113
 msgid "Dot (.)"
-msgstr ""
+msgstr "Punt (.)"
 
 #: bika/lims/browser/instrument.py:87
 msgid "Down from"
-msgstr ""
+msgstr "Omlaag vanaf"
 
 #: bika/lims/browser/instrument.py:88
 msgid "Down to"
-msgstr ""
+msgstr "Omlaag tot"
 
 #: bika/lims/browser/publish/reports_listing.py:150
 msgid "Download"
-msgstr ""
+msgstr "Downloaden"
 
 #: bika/lims/browser/publish/reports_listing.py:80
 msgid "Download PDF"
-msgstr ""
+msgstr "PDF downloaden"
 
 #: bika/lims/browser/publish/reports_listing.py:145
 msgid "Download selected reports"
-msgstr ""
+msgstr "Geselecteerde rapporten downloaden"
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr "Sleep om te herordenen"
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Verschuldigd"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
-msgstr ""
+msgstr "Vervaldatum"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:199
 msgid "Dup Var"
-msgstr ""
+msgstr "Dup Var"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:556
 msgid "Duplicate"
-msgstr ""
+msgstr "Dupliceren"
 
 #: bika/lims/profiles/default/types/DuplicateAnalysis.xml
 msgid "Duplicate Analysis"
-msgstr ""
+msgstr "Duplicaatanalyse"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
-msgstr ""
+msgstr "Dubbele ID-indeling voor portaltype '${pt}' (rijen ${a} en ${b}). Alleen de eerste rij wordt gebruikt; verwijder of voeg het duplicaat samen."
 
 #: bika/lims/content/worksheettemplate.py:59
 msgid "Duplicate Of"
-msgstr ""
+msgstr "Duplicaat van"
 
 #: bika/lims/config.py:90
 msgid "Duplicate QC analyses"
-msgstr ""
+msgstr "QC-analyses dupliceren"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr ""
+msgstr "Monster dupliceren"
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
-msgstr ""
+msgstr "Duplicaatvariatie %"
 
 #: bika/lims/validators.py:461
 msgid "Duplicate keys in choices field"
-msgstr ""
+msgstr "Dubbele sleutels in keuzeveld"
 
 #: bika/lims/browser/workflow/analysisrequest.py:443
 msgid "Duplicated samples: {}"
-msgstr ""
+msgstr "Gedupliceerde monsters: {}"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpec.xml
 msgid "Dynamic Analysis Specification"
-msgstr ""
+msgstr "Dynamische analysespecificatie"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpecs.xml
 msgid "Dynamic Analysis Specifications"
-msgstr ""
+msgstr "Dynamische analysespecificaties"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:82
 msgid "Dynamic Specification"
-msgstr ""
+msgstr "Dynamische specificatie"
 
 #: bika/lims/content/laboratory.py:122
 msgid "E.g. SANAS, APLAC, etc."
-msgstr ""
+msgstr "Bijv. SANAS, APLAC, enz."
 
 #: senaite/core/exportimport/import.pt:165
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
-msgstr ""
+msgstr "Elke import-interface kan een map definiëren waar het systeem naar de resultaatbestanden zoekt bij het automatisch importeren van resultaten wanneer de <code>auto_import_results</code>-weergave wordt aangeroepen."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
-msgstr ""
+msgstr "Bewerken"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:15
 msgid "Edit Multiple Analyses Results"
-msgstr ""
+msgstr "Resultaten van meerdere analyses bewerken"
 
 #: bika/lims/content/samplepoint.py:74
 msgid "Elevation"
@@ -2072,204 +2173,216 @@ msgstr "Hoogte"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "E-mail"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "E-mailadres"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
-msgstr ""
+msgstr "E-mailbijlagen"
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
-msgstr ""
+msgstr "E-mailtekst"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:96
 msgid "Email Log"
-msgstr ""
+msgstr "E-maillogboek"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
-msgstr ""
+msgstr "E-mailontvangers"
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
-msgstr ""
+msgstr "E-mailverantwoordelijken"
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
-msgstr ""
+msgstr "Verzenddatum e-mail"
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
-msgstr ""
+msgstr "E-mailonderwerp"
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
-msgstr ""
+msgstr "E-mailtekst voor meldingen van monsterongeldigverklaring"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
-msgstr ""
+msgstr "E-mailtekst voor meldingen van monsterafwijzing"
 
 #: bika/lims/browser/publish/emailview.py:158
 msgid "Email cancelled"
-msgstr ""
+msgstr "E-mail geannuleerd"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:126
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:129
 msgid "Email notification"
-msgstr ""
+msgstr "E-mailmelding"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
-msgstr ""
+msgstr "E-mailmelding bij monsterafwijzing"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
-msgstr ""
+msgstr "Logboek van verzonden e-mails"
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
-msgstr ""
+msgstr "E-mail verzonden"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr "Leeg"
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
-msgstr ""
+msgstr "Lege sleutels worden niet ondersteund"
 
 #: bika/lims/content/worksheettemplate.py:140
 msgid "Enable Multiple Use of Instrument in Worksheets."
-msgstr ""
+msgstr "Meervoudig gebruik van instrument in werkbladen inschakelen."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
-msgstr ""
+msgstr "Monsterconservering inschakelen"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
-msgstr ""
+msgstr "Monsterspecificaties inschakelen"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
-msgstr ""
+msgstr "Monstername inschakelen"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
-msgstr ""
+msgstr "Planning van monstername inschakelen"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
-msgstr ""
+msgstr "Globaal auditlogboek inschakelen"
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
-msgstr ""
+msgstr "Globaal auditlogboek inschakelen"
 
 #: bika/lims/content/artemplate.py:119
 msgid "Enable sampling workflow for the created sample"
-msgstr ""
+msgstr "Monsternameworkflow inschakelen voor het aangemaakte monster"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
-msgstr ""
+msgstr "De workflow voor het afdrukken van resultaatrapporten inschakelen"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr "De workflow voor monsterverzending inschakelen"
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr "De workflow voor monsterafvoer inschakelen"
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
-msgstr ""
+msgstr "Einddatum"
 
 #: bika/lims/content/instrumentmaintenancetask.py:165
 #: bika/lims/content/instrumentscheduledtask.py:119
 msgid "Enhancement"
-msgstr ""
+msgstr "Verbetering"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:231
 msgid "Enter a user name, usually something like 'jsmith'. No spaces or special characters. Usernames and passwords are case sensitive, make sure the caps lock key is not enabled. This is the name used to log in."
-msgstr ""
+msgstr "Voer een gebruikersnaam in, meestal iets als 'jsmith'. Geen spaties of speciale tekens. Gebruikersnamen en wachtwoorden zijn hoofdlettergevoelig; zorg ervoor dat Caps Lock niet is ingeschakeld. Dit is de naam die wordt gebruikt om aan te melden."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:268
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
-msgstr ""
+msgstr "Voer een e-mailadres in. Dit is nodig voor het geval het wachtwoord verloren gaat. Wij respecteren uw privacy en geven het adres niet door aan derden en maken het nergens openbaar."
 
 #: bika/lims/content/pricelist.py:67
 msgid "Enter discount percentage value"
-msgstr ""
+msgstr "Voer de kortingspercentagewaarde in"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
-msgstr ""
+msgstr "Voer voor dit veld individuele waarden per monster in"
 
 #: bika/lims/content/abstractbaseanalysis.py:576
 #: bika/lims/content/labproduct.py:48
 msgid "Enter percentage value eg. 14.0"
-msgstr ""
+msgstr "Voer de percentagewaarde in, bijv. 14.0"
 
 #: bika/lims/content/analysisprofile.py:123
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
-msgstr ""
+msgstr "Voer de percentagewaarde in, bijv. 14.0. Dit percentage wordt alleen op het analyseprofiel toegepast en overschrijft de systeem-btw"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
-msgstr ""
+msgstr "Voer de percentagewaarde in, bijv. 14.0. Dit percentage wordt systeembreed toegepast, maar kan op individuele items worden overschreven"
 
 #: bika/lims/content/analysisrequest.py:1120
 msgid "Enter percentage value eg. 33.0"
-msgstr ""
+msgstr "Voer de percentagewaarde in, bijv. 33.0"
 
 #: bika/lims/content/samplepoint.py:57
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
-msgstr ""
+msgstr "Voer de breedtegraad van het monsterpunt in graden 0-90, minuten 0-59, seconden 0-59 en N/Z-indicator in"
 
 #: bika/lims/content/samplepoint.py:66
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
-msgstr ""
+msgstr "Voer de lengtegraad van het monsterpunt in graden 0-180, minuten 0-59, seconden 0-59 en O/W-indicator in"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:18
 msgid "Enter the details of each of the analysis services you want to copy."
-msgstr ""
+msgstr "Voer de gegevens in van elke analysedienst die u wilt kopiëren."
 
 #: bika/lims/content/laboratory.py:176
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
-msgstr ""
+msgstr "Voer hier de gegevens van de dienstaccreditaties van uw lab in. De volgende velden zijn beschikbaar:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
-msgstr ""
+msgstr "Voer het resultaat in decimale of wetenschappelijke notatie in, bijv. 0.00005 of 1e-5, 10000 of 1e5"
 
 #: bika/lims/content/analysisrequest.py:939
 msgid "Environmental conditions"
-msgstr ""
+msgstr "Omgevingscondities"
 
 #: senaite/core/browser/samples/invalidate_samples.py:282
 msgid "Erroneous result publication: ${sample_id}"
-msgstr ""
+msgstr "Foutieve resultaatpublicatie: ${sample_id}"
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
-msgstr ""
+msgstr "Evolutie van analyses"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
-msgstr ""
+msgstr "Evolutie van monsters"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
-msgstr ""
+msgstr "Evolutie van werkbladen"
 
 #: senaite/core/exportimport/import.pt:172
 msgid "Example Cronjob to execute the auto import every 10 minutes"
-msgstr ""
+msgstr "Voorbeeld-cronjob om de automatische import elke 10 minuten uit te voeren"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:125
 msgid "Example content"
-msgstr ""
+msgstr "Voorbeeldinhoud"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Uitsluiten van factuur"
 
@@ -2279,17 +2392,17 @@ msgstr "Uitsluiten van factuur"
 msgid "Expected Result"
 msgstr "Verwachte resultaat"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
-msgstr ""
+msgstr "Verwachte monsternamedatum"
 
 #: bika/lims/content/referencesample.py:214
 msgid "Expected Values"
-msgstr ""
+msgstr "Verwachte waarden"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Expire"
-msgstr ""
+msgstr "Verlopen"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Expired"
@@ -2303,27 +2416,27 @@ msgstr "Vervaldatum"
 
 #: bika/lims/content/abstractbaseanalysis.py:190
 msgid "Exponential format precision"
-msgstr ""
+msgstr "Precisie van exponentiële notatie"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
-msgstr ""
+msgstr "Drempel van exponentiële notatie"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Export"
-msgstr ""
+msgstr "Exporteren"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
-msgstr ""
+msgstr "Kon sticker niet laden"
 
 #: bika/lims/browser/publish/emailview.py:150
 msgid "Failed to send Email(s)"
-msgstr ""
+msgstr "Kon e-mail(s) niet verzenden"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:101
 msgid "Failed to update registry records. Please check the server log for details."
-msgstr ""
+msgstr "Kon registerrecords niet bijwerken. Raadpleeg het serverlogboek voor details."
 
 #: bika/lims/browser/clientfolder.py:86
 #: bika/lims/content/organisation.py:66
@@ -2333,7 +2446,7 @@ msgstr "Fax"
 
 #: bika/lims/content/person.py:118
 msgid "Fax (business)"
-msgstr ""
+msgstr "Fax (zakelijk)"
 
 #: bika/lims/config.py:77
 msgid "Female"
@@ -2341,7 +2454,7 @@ msgstr "Vrouw"
 
 # senaite.app.listing: Fetch transitions
 msgid "Fetch Transitions"
-msgstr ""
+msgstr "Overgangen ophalen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:191
 msgid "Field"
@@ -2349,7 +2462,7 @@ msgstr "Veld"
 
 #: bika/lims/browser/analysisrequest/add2.py:2122
 msgid "Field '{}' is required"
-msgstr ""
+msgstr "Veld '{}' is vereist"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:125
 #: senaite/core/browser/viewlets/sampleanalyses.py:69
@@ -2358,11 +2471,11 @@ msgstr "Veld Analyses"
 
 #: senaite/core/registry/schema.py:214
 msgid "Field Name"
-msgstr ""
+msgstr "Veldnaam"
 
 #: bika/lims/config.py:56
 msgid "Field Preservation"
-msgstr ""
+msgstr "Veldconservering"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:53
 msgid "Field Title"
@@ -2370,11 +2483,11 @@ msgstr "Veld Titel"
 
 #: bika/lims/browser/analysisrequest/add2.py:1460
 msgid "Field flushed"
-msgstr ""
+msgstr "Veld leeggemaakt"
 
 #: senaite/core/registry/schema.py:212
 msgid "Field visibility"
-msgstr ""
+msgstr "Veldzichtbaarheid"
 
 #: bika/lims/browser/instrument.py:814
 msgid "File"
@@ -2382,43 +2495,55 @@ msgstr "Bestand"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:194
 msgid "File Deleted"
-msgstr ""
+msgstr "Bestand verwijderd"
 
 #: bika/lims/content/analysisservice.py:262
 msgid "File upload"
-msgstr ""
+msgstr "Bestand uploaden"
 
 #: bika/lims/content/multifile.py:48
 msgid "File upload "
-msgstr ""
+msgstr "Bestand uploaden "
 
 #: senaite/core/browser/clients/client/attachments/view.py:59
 msgid "Filename"
-msgstr ""
+msgstr "Bestandsnaam"
 
 #: bika/lims/browser/publish/reports_listing.py:82
 msgid "Filesize"
-msgstr ""
+msgstr "Bestandsgrootte"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
-msgstr ""
+msgstr "Analyses op naam filteren..."
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:190
 msgid "Filter by template method"
-msgstr ""
+msgstr "Filteren op sjabloonmethode"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:175
 msgid "Filter by template services"
-msgstr ""
+msgstr "Filteren op sjabloondiensten"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
-msgstr ""
+msgstr "Sleutels filteren (regex ondersteund)"
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr "Filternaam"
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr "Monsters op deze analyse filteren"
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
+msgstr "Filteren..."
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
-msgstr ""
+msgstr "Het eerste blad bevat geen geldige kolomdefinitie"
 
 #: bika/lims/content/person.py:51
 msgid "Firstname"
@@ -2428,15 +2553,15 @@ msgstr "Voornaam"
 #: bika/lims/content/analysiscategory.py:83
 #: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
-msgstr ""
+msgstr "Kommagetal van 0.0 - 1000.0 dat de sorteervolgorde aangeeft. Dubbele waarden worden alfabetisch geordend."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
-msgstr ""
+msgstr "Indeling"
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
-msgstr ""
+msgstr "Opmaakconfiguratie"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:183
 #: bika/lims/controlpanel/bika_calculations.py:79
@@ -2445,17 +2570,21 @@ msgstr "Formule"
 
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:239
 msgid "Found Dynamic Analysis Specification for '{}' in '{}'"
-msgstr ""
+msgstr "Dynamische analysespecificatie gevonden voor '{}' in '{}'"
 
 #: senaite/core/vocabularies/setup.py:160
 msgid "Friday"
-msgstr ""
+msgstr "Vrijdag"
 
 #: bika/lims/browser/publish/templates/email.pt:47
 #: bika/lims/content/instrumentcalibration.py:78
 #: bika/lims/content/instrumentmaintenancetask.py:65
 msgid "From"
-msgstr ""
+msgstr "Van"
+
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr "Van ${from} tot ${to} (elke 2 uur bijgewerkt)"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
@@ -2463,85 +2592,97 @@ msgstr ""
 msgid "Full Name"
 msgstr "Volledige naam"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
-msgstr ""
+msgstr "Volledige naam"
 
 #: bika/lims/content/calculation.py:100
 msgid "Function"
-msgstr ""
+msgstr "Functie"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
-msgstr ""
+msgstr "Monster met datum in de toekomst"
 
 #: senaite/core/browser/dexterity/views.py:206
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:27
 msgid "General"
-msgstr ""
+msgstr "Algemeen"
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Generates an ID with the IDServer"
-msgstr ""
+msgstr "Genereert een ID met de IDServer"
 
 #: senaite/core/registry/schema.py:226
 msgid "Generic Setup"
-msgstr ""
+msgstr "Generieke instellingen"
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:11
 msgid "Global Audit Log is disabled"
-msgstr ""
+msgstr "Globaal auditlogboek is uitgeschakeld"
 
 #: senaite/core/profiles/default/types/Contacts.xml
 msgid "Global contacts container"
-msgstr ""
+msgstr "Globale contactpersonencontainer"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:44
 msgid "Go to your instance"
-msgstr ""
+msgstr "Ga naar uw instantie"
 
 #: bika/lims/content/person.py:43
 msgid "Greeting title eg. Mr, Mrs, Dr"
-msgstr ""
+msgstr "Aanhef, bijv. Dhr., Mevr., Dr."
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
-msgstr ""
+msgstr "Groepeer analysediensten per categorie in de LIMS-tabellen, handig wanneer de lijst lang is"
 
 #: bika/lims/content/arreport.py:134
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: bika/lims/content/referencesample.py:105
 #: bika/lims/content/sampletype.py:127
 msgid "Hazardous"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
-msgstr ""
+msgstr "Verborgen"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:60
 msgid "Hidden Field"
-msgstr ""
+msgstr "Verborgen veld"
 
 #: senaite/core/browser/modals/analysis/schema.py:114
 msgid "Hidden from report"
-msgstr ""
+msgstr "Verborgen in rapport"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
-msgstr ""
+msgstr "Aanvullende velden verbergen"
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr "Alles verbergen"
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr "Geschiedenis verbergen"
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
+msgstr "Deze kolom verbergen"
 
 #: bika/lims/config.py:140
 msgid "High"
-msgstr ""
+msgstr "Hoog"
 
 #: bika/lims/config.py:139
 msgid "Highest"
-msgstr ""
+msgstr "Hoogst"
 
 #: bika/lims/browser/fields/durationfield.py:37
 msgid "Hours"
@@ -2549,479 +2690,483 @@ msgstr "Uur"
 
 #: bika/lims/content/supplier.py:75
 msgid "IBN"
-msgstr ""
+msgstr "IBN"
 
 #: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_view.pt:43
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
-msgstr ""
+msgstr "ID-server"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:17
 msgid "ID Server Settings"
-msgstr ""
+msgstr "ID-serverinstellingen"
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
-msgstr ""
+msgstr "ID-serverwaarden"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:113
 msgid "ID Template <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "ID-sjabloon <span class=\"sort-indicator\" />"
 
 #: bika/lims/content/samplepoint.py:84
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
-msgstr ""
+msgstr "Als er periodiek een monster wordt genomen op dit monsterpunt, voer hier de frequentie in, bijv. wekelijks"
 
 #: bika/lims/content/abstractbaseanalysis.py:317
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
-msgstr ""
+msgstr "Indien aangevinkt, wordt er een keuzelijst weergegeven naast het resultaatveld van de analyse in de resultaatinvoerweergaven. Met deze selector kan de analist de waarde instellen als detectielimiet (LDL of UDL) in plaats van een gewoon resultaat"
 
 #: bika/lims/content/instrument.py:187
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
-msgstr ""
+msgstr "Indien aangevinkt, is het instrument niet beschikbaar totdat de volgende geldige kalibratie is uitgevoerd. Dit selectievakje wordt automatisch uitgevinkt."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
-msgstr ""
+msgstr "Indien ingeschakeld, wordt er een vrijetekstveld weergegeven bij elke analyse in de resultaatinvoerweergave"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
-msgstr ""
+msgstr "Indien ingeschakeld, kan een gebruiker die een resultaat voor deze analyse heeft ingediend het ook verifiëren. Deze instelling geldt voor gebruikers met een toegewezen rol waarmee zij resultaten mogen verifiëren (standaard managers, labmanagers en verifiëerders). De hier ingestelde optie heeft voorrang op de optie die is ingesteld in Bika Setup"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-msgstr ""
+msgstr "Indien ingeschakeld, kan een gebruiker die een resultaat heeft ingediend het ook verifiëren. Deze instelling geldt alleen voor gebruikers met een toegewezen rol waarmee zij resultaten mogen verifiëren (standaard managers, labmanagers en verifiëerders). Deze instelling kan voor een bepaalde analyse worden overschreven in de bewerkweergave van de analysedienst. Standaard uitgeschakeld."
 
 #: bika/lims/content/abstractbaseanalysis.py:96
 msgid "If enabled, the name of the analysis will be written in italics."
-msgstr ""
+msgstr "Indien ingeschakeld, wordt de naam van de analyse cursief weergegeven."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
-msgstr ""
+msgstr "Indien ingeschakeld, worden deze analyse en de resultaten ervan standaard niet weergegeven in rapporten. Deze instelling kan worden overschreven in het analyseprofiel en/of monster"
 
 #: bika/lims/content/batch.py:138
 msgid "If no Title value is entered, the Batch ID will be used."
-msgstr ""
+msgstr "Als er geen titelwaarde wordt ingevoerd, wordt de batch-ID gebruikt."
 
 #: bika/lims/content/batch.py:134
 msgid "If no value is entered, the Batch ID will be auto-generated."
-msgstr ""
+msgstr "Als er geen waarde wordt ingevoerd, wordt de batch-ID automatisch gegenereerd."
 
 #: bika/lims/content/method.py:128
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
-msgstr ""
+msgstr "Selecteer indien nodig een berekening voor de analysediensten die aan deze methode zijn gekoppeld. Berekeningen kunnen worden geconfigureerd onder het item berekeningen in de LIMS-instellingen"
 
 #: senaite/core/content/interpretationtemplate.py:72
 msgid "If set, this interpretation template will only be available for selection on samples from these types"
-msgstr ""
+msgstr "Indien ingesteld, is dit interpretatiesjabloon alleen selecteerbaar voor monsters van deze types"
 
 #: senaite/core/content/interpretationtemplate.py:60
 msgid "If set, this interpretation template will only be available for selection on samples that have assigned any of these analysis templates"
-msgstr ""
+msgstr "Indien ingesteld, is dit interpretatiesjabloon alleen selecteerbaar voor monsters waaraan een van deze analysesjablonen is toegewezen"
 
 #: bika/lims/content/abstractbaseanalysis.py:69
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
-msgstr ""
+msgstr "Als hier tekst wordt ingevoerd, wordt deze in plaats van de titel gebruikt wanneer de dienst in kolomkoppen wordt vermeld. HTML-opmaak is toegestaan."
 
 #: senaite/core/exportimport/import.pt:74
 msgid "If the system doesn't find any match (Sample, Reference Analysis or Duplicate), it will use the record's identifier to find matches for Reference Sample IDs. <br /> If a Reference Sample ID is found, the system will automatically create a Calibration Test (Reference Analysis) and will link it to the selected Instrument."
-msgstr ""
+msgstr "Als het systeem geen overeenkomst vindt (monster, referentieanalyse of duplicaat), gebruikt het de identificatie van het record om overeenkomsten voor referentiemonster-ID's te vinden. <br /> Als er een referentiemonster-ID wordt gevonden, maakt het systeem automatisch een kalibratietest (referentieanalyse) aan en koppelt het deze aan het geselecteerde instrument."
 
 #: bika/lims/content/worksheettemplate.py:141
 msgid "If unchecked, Lab Managers won't be able to assign the same Instrument more than one Analyses while creating a Worksheet."
-msgstr ""
+msgstr "Indien niet aangevinkt, kunnen labmanagers hetzelfde instrument niet aan meer dan één analyse toewijzen bij het aanmaken van een werkblad."
 
 #: bika/lims/content/calculation.py:112
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
-msgstr ""
+msgstr "Als uw formule een speciale functie uit een externe Python-bibliotheek nodig heeft, kunt u die hier importeren. Bijvoorbeeld als u de functie 'floor' uit de Python-module 'math' wilt gebruiken, voegt u 'math' toe aan het veld Module en 'floor' aan het functieveld. Het equivalent in Python zou 'from math import floor' zijn. In uw berekening zou u dan 'floor([Ca] + [Mg])' kunnen gebruiken. "
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
-msgstr ""
+msgstr "Directe invoer van resultaten"
 
 #: senaite/core/exportimport/import.pt:14
 #: senaite/core/profiles/default/actions.xml
 msgid "Import"
-msgstr ""
+msgstr "Importeren"
 
 #: bika/lims/content/instrument.py:235
 msgid "Import Data Interface"
-msgstr ""
+msgstr "Data-interface voor import"
 
 #: senaite/core/exportimport/instruments/importer.py:548
 msgid "Import finished successfully: {updated_ars} Samples and {updated_results} results updated"
-msgstr ""
+msgstr "Import succesvol voltooid: {updated_ars} Monsters en {updated_results} resultaten bijgewerkt"
 
 #: senaite/core/exportimport/instruments/importer.py:541
 msgid "Import finished successfully: {updated_ars} Samples, {updated_instruments} Instruments and {updated_results} results updated"
-msgstr ""
+msgstr "Import succesvol voltooid: {updated_ars} Monsters, {updated_instruments} Instrumenten en {updated_results} resultaten bijgewerkt"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:59
 msgid "Imported File"
-msgstr ""
+msgstr "Geïmporteerd bestand"
 
 #: bika/lims/content/instrument.py:200
 msgid "In-lab calibration procedure"
-msgstr ""
+msgstr "Kalibratieprocedure in het lab"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
-msgstr ""
+msgstr "Inactief"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
-msgstr ""
+msgstr "Prijsinformatie opnemen en weergeven"
 
 #: bika/lims/content/pricelist.py:75
 msgid "Include descriptions"
-msgstr ""
+msgstr "Beschrijvingen opnemen"
 
 #: senaite/core/content/supplier.py:170
 msgid "Incorrect IBAN number: %s"
-msgstr ""
+msgstr "Onjuist IBAN-nummer: %s"
 
 #: senaite/core/content/supplier.py:132
 msgid "Incorrect NIB number: %s"
-msgstr ""
+msgstr "Onjuist NIB-nummer: %s"
 
 #: bika/lims/content/analysisrequest.py:1404
 msgid "Indicates if the last SampleReport is printed,"
-msgstr ""
+msgstr "Geeft aan of het laatste SampleReport is afgedrukt,"
 
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:22
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Initialize"
-msgstr ""
+msgstr "Initialiseren"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:13
 msgid "Install SENAITE LIMS"
-msgstr ""
+msgstr "SENAITE LIMS installeren"
 
 #: bika/lims/content/instrument.py:356
 msgid "Installation Certificate"
-msgstr ""
+msgstr "Installatiecertificaat"
 
 #: bika/lims/content/instrument.py:357
 msgid "Installation certificate upload"
-msgstr ""
+msgstr "Installatiecertificaat uploaden"
 
 #: bika/lims/content/instrument.py:347
 msgid "InstallationDate"
-msgstr ""
+msgstr "InstallationDate"
 
 #: bika/lims/content/method.py:77
 msgid "Instructions"
-msgstr ""
+msgstr "Instructies"
 
 #: bika/lims/content/instrument.py:201
 msgid "Instructions for in-lab regular calibration routines intended for analysts"
-msgstr ""
+msgstr "Instructies voor reguliere kalibratieroutines in het lab, bedoeld voor analisten"
 
 #: bika/lims/content/instrument.py:213
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
-msgstr ""
+msgstr "Instructies voor reguliere preventieve en onderhoudsroutines, bedoeld voor analisten"
 
 #: senaite/core/browser/modals/analysis/schema.py:78
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:107
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:64
 msgid "Instrument"
-msgstr ""
+msgstr "Instrument"
 
 #: senaite/core/browser/form/adapters/method.py:74
 msgid "Instrument '{}' is used by service '{}'"
-msgstr ""
+msgstr "Instrument '{}' wordt gebruikt door dienst '{}'"
 
 #: bika/lims/browser/instrument.py:193
 msgid "Instrument Calibrations"
-msgstr ""
+msgstr "Instrumentkalibraties"
 
 #: bika/lims/browser/instrument.py:791
 msgid "Instrument Files"
-msgstr ""
+msgstr "Instrumentbestanden"
 
 #: senaite/core/exportimport/import.pt:37
 msgid "Instrument Import"
-msgstr ""
+msgstr "Instrumentimport"
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 msgid "Instrument Location"
-msgstr ""
+msgstr "Instrumentlocatie"
 
 #: senaite/core/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
-msgstr ""
+msgstr "Instrumentlocaties"
 
 #: bika/lims/browser/instrument.py:65
 msgid "Instrument Maintenance"
-msgstr ""
+msgstr "Instrumentonderhoud"
 
 #: bika/lims/browser/instrument.py:382
 msgid "Instrument Scheduled Tasks"
-msgstr ""
+msgstr "Geplande instrumenttaken"
 
 #: bika/lims/browser/instrument.py:290
 msgid "Instrument Validations"
-msgstr ""
+msgstr "Instrumentvalidaties"
 
 #: bika/lims/content/abstractbaseanalysis.py:392
 msgid "Instrument assignment is allowed"
-msgstr ""
+msgstr "Instrumenttoewijzing is toegestaan"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:35
 msgid "Instrument disabled until successful calibration:"
-msgstr ""
+msgstr "Instrument uitgeschakeld tot succesvolle kalibratie:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:54
 msgid "Instrument disposed until new calibration tests being done:"
-msgstr ""
+msgstr "Instrument afgevoerd tot nieuwe kalibratietests zijn uitgevoerd:"
 
 #: bika/lims/browser/worksheet/views/export.py:53
 msgid "Instrument exporter not found"
-msgstr ""
+msgstr "Instrumentexporteur niet gevonden"
 
 #: bika/lims/browser/workflow/analysis.py:141
 msgid "Instrument failed reference test"
-msgstr ""
+msgstr "Instrument is niet geslaagd voor referentietest"
 
 #: bika/lims/browser/worksheet/views/export.py:40
 msgid "Instrument has no data interface selected"
-msgstr ""
+msgstr "Voor het instrument is geen data-interface geselecteerd"
 
 #: senaite/core/browser/form/adapters/data_import.py:96
 msgid "Instrument import finished"
-msgstr ""
+msgstr "Instrumentimport voltooid"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:92
 msgid "Instrument in calibration progress:"
-msgstr ""
+msgstr "Instrument in kalibratieproces:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:73
 msgid "Instrument in validation progress:"
-msgstr ""
+msgstr "Instrument in validatieproces:"
 
 #: senaite/core/exportimport/instruments/importer.py:402
 msgid "Instrument not found"
-msgstr ""
+msgstr "Instrument niet gevonden"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:16
 msgid "Instrument's calibration certificate expired:"
-msgstr ""
+msgstr "Kalibratiecertificaat van instrument verlopen:"
 
 #: senaite/core/profiles/default/types/InstrumentType.xml
 msgid "InstrumentType"
-msgstr ""
+msgstr "InstrumentType"
 
 #: senaite/core/profiles/default/types/InstrumentTypes.xml
 msgid "InstrumentTypes"
-msgstr ""
+msgstr "InstrumentTypes"
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 #: senaite/core/profiles/default/types/InstrumentType.xml
 #: senaite/core/profiles/default/types/Manufacturer.xml
 msgid "Instruments"
-msgstr ""
+msgstr "Instrumenten"
 
 #: senaite/core/exportimport/import.pt:162
 msgid "Instruments can be configured with one or multiple import data interfaces."
-msgstr ""
+msgstr "Instrumenten kunnen worden geconfigureerd met één of meerdere data-interfaces voor import."
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:39
 msgid "Instruments disabled until successful calibration:"
-msgstr ""
+msgstr "Instrumenten uitgeschakeld tot succesvolle kalibratie:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:58
 msgid "Instruments disposed until new calibration tests being done:"
-msgstr ""
+msgstr "Instrumenten afgevoerd tot nieuwe kalibratietests zijn uitgevoerd:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:96
 msgid "Instruments in calibration progress:"
-msgstr ""
+msgstr "Instrumenten in kalibratieproces:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:77
 msgid "Instruments in validation progress:"
-msgstr ""
+msgstr "Instrumenten in validatieproces:"
 
 #: bika/lims/content/method.py:103
 msgid "Instruments supporting this method"
-msgstr ""
+msgstr "Instrumenten die deze methode ondersteunen"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:20
 msgid "Instruments' calibration certificates expired:"
-msgstr ""
+msgstr "Kalibratiecertificaten van instrumenten verlopen:"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:55
 msgid "Interface"
-msgstr ""
+msgstr "Interface"
 
 #: bika/lims/browser/instrument.py:494
 msgid "Internal Calibration Tests"
-msgstr ""
+msgstr "Interne kalibratietests"
 
 #: bika/lims/content/instrumentcertification.py:84
 msgid "Internal Certificate"
-msgstr ""
+msgstr "Intern certificaat"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
-msgstr ""
+msgstr "Intern gebruik"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:42
 #: bika/lims/browser/templates/referencesample_analyses.pt:40
 msgid "Interpolation"
-msgstr ""
+msgstr "Interpolatie"
 
 #: senaite/core/profiles/default/types/InterpretationTemplate.xml
 msgid "Interpretation Template"
-msgstr ""
+msgstr "Interpretatiesjabloon"
 
 #: senaite/core/profiles/default/types/InterpretationTemplates.xml
 msgid "Interpretation Templates"
-msgstr ""
+msgstr "Interpretatiesjablonen"
 
 #: bika/lims/content/instrumentcertification.py:110
 msgid "Interval"
-msgstr ""
+msgstr "Interval"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
-msgstr ""
+msgstr "Ongeldig"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
-msgstr ""
+msgstr "Ongeldig ID-formaat op rij ${i} ('${pt}'): ${err}"
 
 #: senaite/core/content/person.py:236
 msgid "Invalid email address"
-msgstr ""
+msgstr "Ongeldig e-mailadres"
 
 #: senaite/core/content/dynamicanalysisspec.py:65
 msgid "Invalid specifications file detected. Please upload an Excel spreadsheet with at least the following columns defined: '{}', "
-msgstr ""
+msgstr "Ongeldig specificatiebestand gedetecteerd. Upload een Excel-spreadsheet waarin ten minste de volgende kolommen zijn gedefinieerd: '{}', "
 
 #: bika/lims/validators.py:1324
 msgid "Invalid value: Please enter a value without spaces."
-msgstr ""
+msgstr "Ongeldige waarde: Voer een waarde zonder spaties in."
 
 #: bika/lims/validators.py:528
 msgid "Invalid wildcards found: ${wildcards}"
-msgstr ""
+msgstr "Ongeldige jokertekens gevonden: ${wildcards}"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:152
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalidate"
-msgstr ""
+msgstr "Ongeldig maken"
 
 #: bika/lims/browser/workflow/analysisrequest.py:162
 msgid "Invalidated items: {}"
-msgstr ""
+msgstr "Ongeldig gemaakte items: {}"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:90
 msgid "Invalidation reason"
-msgstr ""
+msgstr "Reden voor ongeldigverklaring"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:18
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 #: bika/lims/profiles/default/types/Invoice.xml
 msgid "Invoice"
-msgstr ""
+msgstr "Factuur"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:55
 msgid "Invoice Date"
-msgstr ""
+msgstr "Factuurdatum"
 
 #: bika/lims/content/analysisrequest.py:973
 msgid "Invoice Exclude"
-msgstr ""
+msgstr "Uitsluiten van facturatie"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:44
 msgid "Invoice ID"
-msgstr ""
+msgstr "Factuur-ID"
 
 #: bika/lims/content/invoice.py:41
 msgid "Invoice PDF"
-msgstr ""
+msgstr "Factuur-PDF"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:35
 msgid "Invoice To"
-msgstr ""
+msgstr "Factureren aan"
 
 #: bika/lims/browser/analysisrequest/invoice.py:187
 msgid "Invoice {} created"
-msgstr ""
+msgstr "Factuur {} aangemaakt"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
-msgstr ""
+msgstr "InvoiceBatch heeft geen einddatum"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
-msgstr ""
+msgstr "InvoiceBatch heeft geen startdatum"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
-msgstr ""
+msgstr "InvoiceBatch heeft geen titel"
 
 #: senaite/core/config/widgets.py:60
 msgid "Job Title"
-msgstr ""
+msgstr "Functietitel"
 
 #: bika/lims/content/person.py:141
 msgid "Job title"
-msgstr ""
+msgstr "Functietitel"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
-msgstr ""
+msgstr "Volgorde hierboven behouden"
 
 #: bika/lims/content/instrument.py:287
 msgid "Key"
-msgstr ""
+msgstr "Sleutel"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:98
 msgid "Key <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Sleutel <span class=\"sort-indicator\" />"
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
-msgstr ""
+msgstr "Sleutelwoord"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:51
 msgid "Keyword is used in active analyses and can not be changed anymore"
-msgstr ""
+msgstr "Sleutelwoord wordt gebruikt in actieve analyses en kan niet meer worden gewijzigd"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:187
 msgid "Keyword required"
-msgstr ""
+msgstr "Sleutelwoord vereist"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
-msgstr ""
+msgstr "Sleutelwoorden"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr "Sleutelwoorden van de analyses in het monster"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
 #: bika/lims/content/analysisspec.py:142
 msgid "Lab"
-msgstr ""
+msgstr "Lab"
 
 #: bika/lims/content/supplier.py:98
 msgid "Lab Account Number"
-msgstr ""
+msgstr "Lab-rekeningnummer"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:134
 msgid "Lab Analyses"
@@ -3029,7 +3174,7 @@ msgstr "Lab Analyses"
 
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
-msgstr ""
+msgstr "Labcontact"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:65
 #: bika/lims/profiles/default/types/LabContacts.xml
@@ -3042,11 +3187,11 @@ msgstr "Lab afdelingen"
 
 #: bika/lims/config.py:57
 msgid "Lab Preservation"
-msgstr ""
+msgstr "Labconservering"
 
 #: senaite/core/profiles/default/types/LabProduct.xml
 msgid "Lab Product"
-msgstr ""
+msgstr "Labproduct"
 
 #: senaite/core/profiles/default/types/LabProducts.xml
 msgid "Lab Products"
@@ -3056,33 +3201,33 @@ msgstr "Lab producten"
 msgid "Lab URL"
 msgstr "Lab URL"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
-msgstr ""
+msgstr "Label"
 
 #: senaite/core/registry/schema.py:69
 msgid "Label configuration"
-msgstr ""
+msgstr "Labelconfiguratie"
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
-msgstr ""
+msgstr "Labelnamen moeten uniek zijn"
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Label schema extender"
-msgstr ""
+msgstr "Labelschema-uitbreider"
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
-msgstr ""
+msgstr "Gelabelde objecten"
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
-msgstr ""
+msgstr "Labels"
 
 #: senaite/core/content/laboratory.py:244
 #: senaite/core/profiles/default/types/Laboratory.xml
@@ -3093,35 +3238,35 @@ msgstr "Laboratorium"
 msgid "Laboratory Accredited"
 msgstr "Geaccrediteerd laboratorium"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
-msgstr ""
+msgstr "Werkdagen laboratorium"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:74
 msgid "Language"
-msgstr ""
+msgstr "Taal"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Large Sticker"
-msgstr ""
+msgstr "Grote sticker"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
-msgstr ""
+msgstr "Sjabloon grote sticker"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:42
 msgid "Last Auto-Import Logs"
-msgstr ""
+msgstr "Logboeken laatste automatische import"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:97
 msgid "Last Login Time"
-msgstr ""
+msgstr "Tijdstip laatste aanmelding"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Laat"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Late Analyses"
 
@@ -3135,98 +3280,106 @@ msgstr "Latitude"
 
 #: senaite/core/schema/gpscoordinatesfield.py:103
 msgid "Latitude must be within -90 and 90 degrees"
-msgstr ""
+msgstr "Breedtegraad moet tussen -90 en 90 graden liggen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:104
 msgid "Layout"
-msgstr ""
+msgstr "Lay-out"
 
 #: bika/lims/browser/worksheet/views/results.py:68
 msgid "Layout view '{}' not found. Set '{}' as layout view."
-msgstr ""
+msgstr "Lay-outweergave '{}' niet gevonden. Stel '{}' in als lay-outweergave."
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:63
 msgid "Legacy LIMS Setup"
-msgstr ""
+msgstr "Verouderde LIMS-instellingen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:153
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:120
 msgid "Legend: Results in <em>italic</em> font are pending, results in <strong>bold</strong> font are verified."
-msgstr ""
+msgstr "Legenda: Resultaten in <em>cursief</em> zijn in behandeling, resultaten in <strong>vet</strong> zijn geverifieerd."
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:46
 #: bika/lims/browser/templates/referencesample_analyses.pt:44
 msgid "Linear"
-msgstr ""
+msgstr "Lineair"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:203
 msgid "Link User"
-msgstr ""
+msgstr "Gebruiker koppelen"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:144
 msgid "Link an existing User"
-msgstr ""
+msgstr "Een bestaande gebruiker koppelen"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
-msgstr ""
+msgstr "Alle objecten met labels weergeven"
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
-msgstr ""
+msgstr "Lijst van mogelijke eindresultaten. Indien ingesteld, is geen aangepast resultaat toegestaan bij de resultaatinvoer en moet de gebruiker uit deze waarden kiezen"
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
-msgstr ""
+msgstr "Lijst van vooraf gedefinieerde afwijzingsredenen. Voer één reden per regel in."
 
 #: senaite/core/exportimport/import.pt:47
 msgid "Load Setup Data"
-msgstr ""
+msgstr "Instellingsgegevens laden"
 
 #: bika/lims/content/method.py:89
 msgid "Load documents describing the method here"
-msgstr ""
+msgstr "Laad hier documenten die de methode beschrijven"
 
 #: senaite/core/exportimport/import.pt:121
 msgid "Load from file"
-msgstr ""
+msgstr "Laden uit bestand"
 
 #: bika/lims/content/instrumentcertification.py:195
 msgid "Load the certificate document here"
-msgstr ""
+msgstr "Laad hier het certificaatdocument"
 
 # senaite.core: Sidebar loading state
 msgid "Loading navigation..."
-msgstr ""
+msgstr "Navigatie laden..."
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
-msgstr ""
+msgstr "Laden..."
 
 #: senaite/core/browser/clients/client/attachments/view.py:79
 #: senaite/core/browser/controlpanel/contacts/view.py:70
 msgid "Location"
-msgstr ""
+msgstr "Locatie"
 
 #: bika/lims/content/storagelocation.py:58
 msgid "Location Code"
-msgstr ""
+msgstr "Locatiecode"
 
 #: bika/lims/content/storagelocation.py:63
 msgid "Location Description"
-msgstr ""
+msgstr "Locatiebeschrijving"
 
 #: bika/lims/content/storagelocation.py:53
 msgid "Location Title"
-msgstr ""
+msgstr "Locatietitel"
 
 #: bika/lims/content/storagelocation.py:68
 msgid "Location Type"
-msgstr ""
+msgstr "Locatietype"
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
-msgstr ""
+msgstr "Locatie waar de documentenset is opgeborgen"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr "Vergrendelen"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr "Vergrendeld"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3243,7 +3396,7 @@ msgstr "Lengtegraad"
 
 #: senaite/core/schema/gpscoordinatesfield.py:110
 msgid "Longitude must be within -180 and 180 degrees"
-msgstr ""
+msgstr "Lengtegraad moet tussen -180 en 180 graden liggen"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:62
@@ -3253,11 +3406,11 @@ msgstr "Lotnummer"
 
 #: bika/lims/config.py:142
 msgid "Low"
-msgstr ""
+msgstr "Laag"
 
 #: bika/lims/config.py:143
 msgid "Lowest"
-msgstr ""
+msgstr "Laagste"
 
 #: bika/lims/config.py:82
 msgid "Mailing address"
@@ -3266,20 +3419,20 @@ msgstr "Mailing adres"
 #: bika/lims/browser/instrument.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:83
 msgid "Maintainer"
-msgstr ""
+msgstr "Beheerder"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Maintenance"
-msgstr ""
+msgstr "Onderhoud"
 
 #. Default: "Type"
 #: bika/lims/content/instrumentmaintenancetask.py:55
 msgid "Maintenance type"
-msgstr ""
+msgstr "Type"
 
 #: bika/lims/content/abstractbaseanalysis.py:349
 msgid "Make attachments mandatory for verification"
-msgstr ""
+msgstr "Bijlagen verplicht maken voor verificatie"
 
 #: bika/lims/config.py:76
 msgid "Male"
@@ -3288,43 +3441,43 @@ msgstr "Mannetje"
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:14
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Manage Analyses"
-msgstr ""
+msgstr "Analyses beheren"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
-msgstr ""
+msgstr "Formuliervelden beheren"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:12
 msgid "Manage Number Generator"
-msgstr ""
+msgstr "Nummergenerator beheren"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:21
 msgid "Manage Partitions"
-msgstr ""
+msgstr "Partities beheren"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Manage Results"
-msgstr ""
+msgstr "Resultaten beheren"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:10
 msgid "Manage Sample Form Fields"
-msgstr ""
+msgstr "Monsterformuliervelden beheren"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:41
 msgid "Manage linked User"
-msgstr ""
+msgstr "Gekoppelde gebruiker beheren"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
-msgstr ""
+msgstr "Monstervelden beheren"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:38
 msgid "Manage the order and visibility of the fields displayed in analysis request add forms."
-msgstr ""
+msgstr "Beheer de volgorde en zichtbaarheid van de velden die worden weergegeven in de toevoegformulieren voor analyseaanvragen."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:16
 msgid "Manage the order and visibility of the sample fields."
-msgstr ""
+msgstr "Beheer de volgorde en zichtbaarheid van de monstervelden."
 
 #: senaite/core/browser/controlpanel/departments/view.py:75
 msgid "Manager"
@@ -3338,22 +3491,22 @@ msgstr "E-mail manager"
 msgid "Manager Phone"
 msgstr "Manager telefoon"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
-msgstr ""
+msgstr "Handmatig"
 
 #: bika/lims/content/abstractbaseanalysis.py:378
 #: bika/lims/content/method.py:148
 msgid "Manual entry of results"
-msgstr ""
+msgstr "Handmatige invoer van resultaten"
 
 #: bika/lims/browser/publish/reports_listing.py:161
 msgid "Manually publish all contained samples of the selected reports."
-msgstr ""
+msgstr "Publiceer handmatig alle monsters in de geselecteerde rapporten."
 
 #: senaite/core/exportimport/import.pt:192
 msgid "Manually trigger auto import"
-msgstr ""
+msgstr "Automatische import handmatig starten"
 
 #: senaite/core/profiles/default/types/Manufacturer.xml
 msgid "Manufacturer"
@@ -3361,13 +3514,13 @@ msgstr "Fabrikant"
 
 #: senaite/core/profiles/default/types/Manufacturers.xml
 msgid "Manufacturers"
-msgstr ""
+msgstr "Fabrikanten"
 
 #: bika/lims/content/analysisrequest.py:1417
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
-msgstr ""
+msgstr "Markeer het monster als uitsluitend voor intern gebruik. Dit betekent dat het alleen toegankelijk is voor labpersoneel en niet voor klanten."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3380,25 +3533,25 @@ msgstr "Max tijd"
 #: bika/lims/browser/fields/resultrangefield.py:36
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:121
 msgid "Max operator"
-msgstr ""
+msgstr "Max-operator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
-msgstr ""
+msgstr "Max-waarschuwing"
 
 #: senaite/core/content/samplecontainer.py:79
 msgid "Maximum possible size or volume of samples"
-msgstr ""
+msgstr "Maximaal mogelijke grootte of volume van monsters"
 
 #: bika/lims/content/container.py:75
 msgid "Maximum possible size or volume of samples."
-msgstr ""
+msgstr "Maximaal mogelijke grootte of volume van monsters."
 
 #: bika/lims/content/abstractbaseanalysis.py:443
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
-msgstr ""
+msgstr "Maximaal toegestane tijd voor het voltooien van de analyse. Er wordt een waarschuwing voor een te late analyse gegeven wanneer deze periode verstrijkt"
 
 #: bika/lims/content/abstractbaseanalysis.py:442
 msgid "Maximum turn-around time"
@@ -3406,36 +3559,36 @@ msgstr "Maximale turn-around tijd"
 
 #: bika/lims/config.py:141
 msgid "Medium"
-msgstr ""
+msgstr "Gemiddeld"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:153
 msgid "Meet the community, browse the code and get support on"
-msgstr ""
+msgstr "Ontmoet de community, bekijk de code en krijg ondersteuning op"
 
 #: bika/lims/browser/clientfolder.py:94
 msgid "Member Discount"
-msgstr ""
+msgstr "Ledenkorting"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Lid korting %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Lid korting geldt"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
-msgstr ""
+msgstr "Lid geregistreerd en gekoppeld aan het huidige contact."
 
 #: bika/lims/browser/publish/emailview.py:146
 msgid "Message sent to {}, "
-msgstr ""
+msgstr "Bericht verzonden naar {}, "
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
-msgstr ""
+msgstr "Metadata"
 
 #: senaite/core/browser/modals/analysis/schema.py:69
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:103
@@ -3448,3424 +3601,3674 @@ msgstr "Methode Document"
 
 #: bika/lims/content/method.py:56
 msgid "Method ID"
-msgstr ""
+msgstr "Methode-ID"
 
 #: bika/lims/browser/methodfolder.py:48
 #: bika/lims/browser/templates/analysisservice_info.pt:119
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:80
 msgid "Methods"
-msgstr ""
+msgstr "Methoden"
 
 #: bika/lims/content/person.py:59
 msgid "Middle initial"
-msgstr ""
+msgstr "Tweede voorletter"
 
 #: bika/lims/content/person.py:67
 msgid "Middle name"
-msgstr ""
+msgstr "Tweede naam"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
-msgstr ""
+msgstr "Min"
 
 #: bika/lims/browser/fields/resultrangefield.py:34
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:106
 msgid "Min operator"
-msgstr ""
+msgstr "Min-operator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
-msgstr ""
+msgstr "Min-waarschuwing"
 
 #: bika/lims/browser/worksheet/views/folder.py:183
 msgid "Mine"
-msgstr ""
+msgstr "Van mij"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:245
 msgid "Minimum 5 characters."
-msgstr ""
+msgstr "Minimaal 5 tekens."
 
 #: bika/lims/content/sampletype.py:165
 msgid "Minimum Volume"
-msgstr ""
+msgstr "Minimumvolume"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
-msgstr ""
+msgstr "Minimumaantal resultaten voor QC-statistiekberekeningen"
 
 #: bika/lims/browser/fields/coordinatefield.py:37
 #: bika/lims/browser/fields/durationfield.py:38
 msgid "Minutes"
-msgstr ""
+msgstr "Minuten"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:92
 msgid "Mobile Phone"
-msgstr ""
+msgstr "Mobiele telefoon"
 
 #: senaite/core/browser/clients/client/contacts/view.py:80
 #: senaite/core/browser/controlpanel/contacts/view.py:68
 msgid "MobilePhone"
-msgstr ""
+msgstr "MobilePhone"
 
 #: bika/lims/content/instrument.py:137
 #: bika/lims/controlpanel/bika_instruments.py:84
 msgid "Model"
-msgstr ""
+msgstr "Model"
 
 #: bika/lims/content/calculation.py:100
 msgid "Module"
-msgstr ""
+msgstr "Module"
 
 #: senaite/core/vocabularies/setup.py:156
 msgid "Monday"
-msgstr ""
+msgstr "Maandag"
+
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr "Maandelijks"
 
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
-msgstr ""
+msgstr "Meer dan één analyse gevonden voor {sid} en sleutelwoord '{keyword}'"
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Multi Catalog Behavior for Dexterity Contents"
-msgstr ""
+msgstr "Multi-catalogusgedrag voor Dexterity-inhoud"
 
 #: senaite/core/browser/samples/multi_results_transposed.py:66
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Multi Results"
-msgstr ""
+msgstr "Meerdere resultaten"
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
-msgstr ""
+msgstr "Type multi-verificatie"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
-msgstr ""
+msgstr "Multi-verificatie vereist"
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "Multifile"
-msgstr ""
+msgstr "Meerdere bestanden"
 
 #: senaite/core/config/vocabularies.py:60
 msgid "Multiple choices"
-msgstr ""
+msgstr "Meerdere keuzes"
 
 #: senaite/core/config/vocabularies.py:58
 msgid "Multiple selection"
-msgstr ""
+msgstr "Meervoudige selectie"
 
 #: senaite/core/config/vocabularies.py:59
 msgid "Multiple selection (with duplicates)"
-msgstr ""
+msgstr "Meervoudige selectie (met duplicaten)"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:108
 msgid "Multiple values"
-msgstr ""
+msgstr "Meerdere waarden"
 
 #: bika/lims/validators.py:469
 msgid "Multiple values control type is not supported for choices"
-msgstr ""
+msgstr "Het besturingstype met meerdere waarden wordt niet ondersteund voor keuzes"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Organization"
-msgstr ""
+msgstr "Mijn organisatie"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Profile"
-msgstr ""
+msgstr "Mijn profiel"
+
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr "Mijn filter"
 
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
-msgstr ""
+msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
-msgstr ""
+msgstr "Naam"
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:67
 msgid "New LIMS Setup"
-msgstr ""
+msgstr "Nieuwe LIMS-instellingen"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
-msgstr ""
+msgstr "Nieuwe bereiken worden noch op nieuwe noch op huidige analyses toegepast. Wijs de specificatie opnieuw toe als u de laatste wijzigingen wilt toepassen."
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
+msgstr "Nieuwste eerst"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Volgende ID <span class=\"sort-indicator\" />"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:168
 #: senaite/core/browser/widgets/services_widget.py:305
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:9
 msgid "No"
-msgstr ""
+msgstr "Nee"
 
 #: senaite/core/exportimport/instruments/eltra/cs/cs2000.py:51
 msgid "No Analysis Services defined"
-msgstr ""
+msgstr "Geen analysediensten gedefinieerd"
 
 #: bika/lims/browser/publish/templates/email.pt:70
 msgid "No Email Address"
-msgstr ""
+msgstr "Geen e-mailadres"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:43
 msgid "No Method selected for this Service"
-msgstr ""
+msgstr "Geen methode geselecteerd voor deze dienst"
 
 #: senaite/core/exportimport/instruments/importer.py:415
 msgid "No Sample found for {sid}"
-msgstr ""
+msgstr "Geen monster gevonden voor {sid}"
 
 #: senaite/core/exportimport/instruments/importer.py:403
 msgid "No Sample with '{allowed_ar_states}' statesfound, and no QC analyses found for {sid}, "
-msgstr ""
+msgstr "Geen monster met status '{allowed_ar_states}' gevonden, en geen QC-analyses gevonden voor {sid}, "
 
 #: bika/lims/browser/analysisrequest/add2.py:2189
 msgid "No Samples could be created."
-msgstr ""
+msgstr "Er konden geen monsters worden aangemaakt."
 
 #: bika/lims/browser/batch/batchbook.py:175
 msgid "No Subgroup"
-msgstr ""
+msgstr "Geen subgroep"
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
-msgstr ""
+msgstr "Geen actie gedefinieerd."
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr "Geen acties beschikbaar. Neem contact op met uw laboratoriummanager om rechten toegewezen te krijgen."
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
-msgstr ""
+msgstr "Geen analyses gevonden voor {sid} en sleutelwoord '{keyword}'"
 
 #: senaite/core/exportimport/instruments/importer.py:434
 msgid "No analyses found for {sid} in the states '{allowed_sample_states}' , "
-msgstr ""
+msgstr "Geen analyses gevonden voor {sid} in de statussen '{allowed_sample_states}' , "
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:75
 msgid "No analyses were added"
-msgstr ""
+msgstr "Er zijn geen analyses toegevoegd"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:152
 msgid "No analyses were added to this worksheet."
-msgstr ""
+msgstr "Er zijn geen analyses aan dit werkblad toegevoegd."
 
 #: senaite/core/browser/attachment/attachment.py:219
 msgid "No analysis found for service '{}'"
-msgstr ""
+msgstr "Geen analyse gevonden voor dienst '{}'"
 
 #: senaite/core/exportimport/instruments/biodrop/ulite/ulite.py:53
 #: senaite/core/exportimport/instruments/lifetechnologies/qubit/qubit.py:54
 msgid "No analysis selected"
-msgstr ""
+msgstr "Geen analyse geselecteerd"
 
 #: senaite/core/exportimport/instruments/thermoscientific/multiskan/go.py:51
 msgid "No analysis service selected"
-msgstr ""
+msgstr "Geen analysedienst geselecteerd"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:27
 msgid "No analysis services were selected."
-msgstr ""
+msgstr "Er zijn geen analysediensten geselecteerd."
 
 #: senaite/core/browser/idserver/view.py:135
 msgid "No changes"
-msgstr ""
+msgstr "Geen wijzigingen"
 
 #: senaite/core/browser/workflow/worksheet.py:50
 msgid "No changes made"
-msgstr ""
+msgstr "Geen wijzigingen aangebracht"
 
 #: bika/lims/browser/workflow/__init__.py:166
 #: bika/lims/browser/workflow/analysisrequest.py:94
 msgid "No changes made."
-msgstr ""
+msgstr "Geen wijzigingen aangebracht."
+
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr "Geen gegevens voor de geselecteerde periode"
 
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
-msgstr ""
+msgstr "Geen datum ingesteld"
 
 #: bika/lims/browser/workflow/analysisrequest.py:435
 msgid "No duplicate created"
-msgstr ""
+msgstr "Geen duplicaat aangemaakt"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:135
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:138
 msgid "No email recipients available for this sample"
-msgstr ""
+msgstr "Geen e-mailontvangers beschikbaar voor dit monster"
 
 #: bika/lims/browser/publish/emailview.py:167
 msgid "No email recipients selected"
-msgstr ""
+msgstr "Geen e-mailontvangers geselecteerd"
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:47
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:59
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:47
 msgid "No file selected"
-msgstr ""
+msgstr "Geen bestand geselecteerd"
 
 #: senaite/core/browser/form/adapters/data_import.py:81
 msgid "No importer not found for interface '{}'"
-msgstr ""
+msgstr "Geen importeur gevonden voor interface '{}'"
 
 #: senaite/core/browser/form/adapters/data_import.py:126
 msgid "No instrument import interfaces available for {}"
-msgstr ""
+msgstr "Geen instrumentimportinterfaces beschikbaar voor {}"
 
 #: bika/lims/browser/workflow/client.py:120
 msgid "No items published"
-msgstr ""
+msgstr "Geen items gepubliceerd"
 
 #: senaite/core/browser/samples/partition_magic.py:64
 #: senaite/core/browser/samples/rejection/reject_samples.py:78
 msgid "No items selected"
-msgstr ""
+msgstr "Geen items geselecteerd"
 
 #: bika/lims/browser/workflow/__init__.py:129
 msgid "No items selected."
-msgstr ""
+msgstr "Geen items geselecteerd."
+
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr "Geen overeenkomsten in verborgen kolommen."
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr "Geen overeenkomsten in zichtbare kolommen."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
-msgstr ""
+msgstr "Er zijn geen nieuwe items aangemaakt."
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
-msgstr ""
+msgstr "Er zijn geen partities aangemaakt"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr "Nog geen opmerkingen"
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
-msgstr ""
+msgstr "Geen rapporten gevonden"
 
 #: senaite/core/browser/samples/invalidate_samples.py:110
 msgid "No samples were invalidated. Please ensure samples are selected and meet the criteria for invalidation."
-msgstr ""
+msgstr "Er zijn geen monsters ongeldig gemaakt. Zorg ervoor dat er monsters zijn geselecteerd die aan de criteria voor ongeldigverklaring voldoen."
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:112
 msgid "No samples were rejected"
-msgstr ""
+msgstr "Er zijn geen monsters afgewezen"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
-msgstr ""
+msgstr "Geen monsternameworkflow"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr "Nog geen opgeslagen filters."
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
-msgstr ""
+msgstr "Er konden geen diensten worden gevonden voor de verwerkte sleutelwoorden"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:133
 msgid "No user exists for ${contact_fullname} and they will not be able to log in. Fill in the form below to create one for them."
-msgstr ""
+msgstr "Er bestaat geen gebruiker voor ${contact_fullname} en deze zal niet kunnen aanmelden. Vul het onderstaande formulier in om er een voor hen aan te maken."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:49
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
-msgstr ""
+msgstr "Er kon geen gebruikersprofiel worden gevonden voor de gekoppelde gebruiker. Neem contact op met de labbeheerder voor verdere ondersteuning of probeer de gebruiker opnieuw te koppelen."
 
 #: bika/lims/browser/analysisrequest/add2.py:2057
 msgid "No valid contact"
-msgstr ""
+msgstr "Geen geldig contact"
 
 #: bika/lims/validators.py:448
 msgid "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
-msgstr ""
+msgstr "Geen geldig formaat in het keuzeveld. Ondersteund formaat is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:115
 msgid "No visible analyses for this sample"
-msgstr ""
+msgstr "Geen zichtbare analyses voor dit monster"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
-msgstr ""
+msgstr "Geen"
 
 #: bika/lims/browser/publish/emailview.py:216
 msgid "Not all contacts are equal for the selected Reports. Please manually select recipients for this email."
-msgstr ""
+msgstr "Niet alle contacten zijn gelijk voor de geselecteerde rapporten. Selecteer de ontvangers voor deze e-mail handmatig."
 
 #: senaite/core/browser/modals/conditions.py:133
 msgid "Not allowed to update conditions: {}"
-msgstr ""
+msgstr "Niet toegestaan om voorwaarden bij te werken: {}"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:86
 msgid "Not defined"
-msgstr ""
+msgstr "Niet gedefinieerd"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
-msgstr ""
+msgstr "Niet afgedrukt"
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
-msgstr ""
+msgstr "Niet ingesteld"
 
 #: bika/lims/content/worksheet.py:291
 msgid "Not specified"
-msgstr ""
+msgstr "Niet gespecificeerd"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:42
 msgid "Note: The settings apply to all Sample Add forms; Required fields can not be deselected."
-msgstr ""
+msgstr "Let op: De instellingen gelden voor alle formulieren voor het toevoegen van monsters; Verplichte velden kunnen niet worden gedeselecteerd."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:19
 msgid "Note: The settings are global and apply to all sample views."
-msgstr ""
+msgstr "Let op: De instellingen zijn globaal en gelden voor alle monsterweergaven."
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:168
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
-msgstr ""
+msgstr "Let op: U kunt de bijlagerijen ook slepen en neerzetten om de volgorde waarin ze in het rapport verschijnen te wijzigen."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
-msgstr ""
+msgstr "Meldingen"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:126
 msgid "Num columns"
-msgstr ""
+msgstr "Aantal kolommen"
 
 #: bika/lims/content/analysisservice.py:259
 msgid "Number"
-msgstr ""
+msgstr "Nummer"
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
-msgstr ""
+msgstr "Aantal analyses"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:82
 msgid "Number of Partitions to create"
-msgstr ""
+msgstr "Aantal aan te maken partities"
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:39
 msgid "Number of copies"
-msgstr ""
+msgstr "Aantal exemplaren"
 
 #: senaite/core/registry/schema.py:180
 msgid "Number of prominent columns"
-msgstr ""
+msgstr "Aantal prominente kolommen"
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
-msgid "Number of required verifications"
-msgstr ""
-
+#: bika/lims/content/abstractbaseanalysis.py:839
 #: bika/lims/content/bikasetup.py:513
-msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-msgstr ""
+msgid "Number of required verifications"
+msgstr "Aantal vereiste verificaties"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/bikasetup.py:514
+msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
+msgstr "Aantal vereiste verificaties voordat een bepaald resultaat als 'geverifieerd' wordt beschouwd. Deze instelling kan voor elke analyse worden overschreven in de bewerkingsweergave van de analysedienst. Standaard 1"
+
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
-msgstr ""
+msgstr "Aantal vereiste verificaties van verschillende gebruikers met voldoende rechten voordat een bepaald resultaat voor deze analyse als 'geverifieerd' wordt beschouwd. De hier ingestelde optie heeft voorrang op de optie die in Bika Setup is ingesteld"
 
 #: senaite/core/registry/schema.py:189
 msgid "Number of standard columns"
-msgstr ""
+msgstr "Aantal standaardkolommen"
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
-msgstr ""
+msgstr "Numeriek"
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
+msgstr "Oudste eerst"
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
-msgstr ""
+msgstr "Na conservering moet het monster binnen deze periode worden afgevoerd. Indien niet gespecificeerd, wordt de bewaartermijn van het monstertype gebruikt."
 
 #: senaite/core/content/dynamicanalysisspec.py:51
 msgid "Only Excel files supported"
-msgstr ""
+msgstr "Alleen Excel-bestanden worden ondersteund"
 
 #: bika/lims/content/attachment.py:81
 msgid "Only images can be rendered in the report directly"
-msgstr ""
+msgstr "Alleen afbeeldingen kunnen direct in het rapport worden weergegeven"
 
 #: senaite/core/exportimport/import.pt:95
 msgid "Only instruments that have an import interface configured are displayed"
-msgstr ""
+msgstr "Alleen instrumenten waarvoor een importinterface is geconfigureerd, worden weergegeven"
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
-msgstr ""
+msgstr "Alleen werkdagen van het laboratorium worden meegenomen bij de berekening van de doorlooptijd van de analyse."
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
-msgstr ""
+msgstr "Alleen werkdagen van het laboratorium worden meegenomen bij de berekening van de doorlooptijd van de analyse. "
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:216
 msgid "Only to empty or zero fields"
-msgstr ""
+msgstr "Alleen op lege of nulvelden"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
-msgstr ""
+msgstr "Openen"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
-msgstr ""
+msgstr "Open / Te verifiëren / Geverifieerd / Totaal"
 
 #: bika/lims/profiles.zcml:15
 msgid "Open Source Web based Laboratory Information Management System"
-msgstr ""
+msgstr "Open source webgebaseerd laboratoriuminformatiemanagementsysteem"
+
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr "Open werkbladen"
 
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
-msgstr ""
+msgstr "Open het e-mailformulier om de geselecteerde rapporten naar de ontvangers te verzenden. Hiermee worden ook de in de rapporten opgenomen monsters gepubliceerd nadat de e-mail succesvol is verzonden."
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr "Open werkbladen met analyses die op resultaten wachten"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
-msgstr ""
+msgstr "Volgorde"
 
 #: bika/lims/content/instrumentcertification.py:93
 msgid "Organization responsible of granting the calibration certificate"
-msgstr ""
+msgstr "Organisatie die verantwoordelijk is voor het verlenen van het kalibratiecertificaat"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:51
 msgid "Orientation"
-msgstr ""
+msgstr "Oriëntatie"
 
 #: senaite/core/z3cform/widgets/address.py:124
 msgid "Other address"
-msgstr ""
+msgstr "Ander adres"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:100
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:70
 msgid "Other reasons"
-msgstr ""
+msgstr "Andere redenen"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:22
 msgid "Other reasons:"
-msgstr ""
+msgstr "Andere redenen:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
-msgstr ""
+msgstr "Andere status"
 
 #: senaite/core/browser/widgets/selectotherwidget.py:114
 #: senaite/core/z3cform/widgets/selectother/widget.py:138
 msgid "Other..."
-msgstr ""
+msgstr "Andere..."
 
 #: bika/lims/browser/instrument.py:733
 #: bika/lims/controlpanel/bika_instruments.py:170
 msgid "Out of date"
-msgstr ""
+msgstr "Verouderd"
 
 #: senaite/core/exportimport/instruments/importer.py:377
 msgid "Override non-empty analysis results"
-msgstr ""
+msgstr "Niet-lege analyseresultaten overschrijven"
 
 #: senaite/core/exportimport/instruments/importer.py:379
 msgid "Override non-empty analysis results, also with empty"
-msgstr ""
-
-#: senaite/core/content/resultsreport.py:197
-msgid "PDF"
-msgstr ""
+msgstr "Niet-lege analyseresultaten overschrijven, ook met lege"
 
 #: senaite/core/content/resultsreport.py:198
+msgid "PDF"
+msgstr "PDF"
+
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
-msgstr ""
+msgstr "PDF-bestand van het rapport"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:42
 msgid "Paperformat"
-msgstr ""
+msgstr "Papierformaat"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:130
 msgid "Partition"
-msgstr ""
+msgstr "Partitie"
 
 #: senaite/core/browser/samples/partition_magic.py:120
 msgid "Partitioning canceled"
-msgstr ""
+msgstr "Partitionering geannuleerd"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:242
 msgid "Password"
-msgstr ""
+msgstr "Wachtwoord"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:50
 msgid "Path identifier"
-msgstr ""
+msgstr "Padidentificatie"
 
 #: bika/lims/browser/fields/referenceresultsfield.py:36
 #: bika/lims/browser/referencesample.py:228
 #: bika/lims/browser/widgets/referenceresultswidget.py:71
 msgid "Permitted Error %"
-msgstr ""
+msgstr "Toegestane fout %"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:23
 msgid "Persistent counters used by the ID Server. Adjust a counter to change the next ID that will be issued for the matching prefix. Setting a counter to 0 removes the entry from the storage."
-msgstr ""
+msgstr "Persistente tellers die door de ID-server worden gebruikt. Pas een teller aan om de volgende ID te wijzigen die voor de overeenkomende prefix wordt uitgegeven. Een teller op 0 zetten verwijdert de vermelding uit de opslag."
 
 #: bika/lims/browser/clientfolder.py:81
 #: bika/lims/browser/templates/batch_publish.pt:68
 #: bika/lims/content/organisation.py:59
 msgid "Phone"
-msgstr ""
+msgstr "Telefoon"
 
 #: bika/lims/content/person.py:110
 msgid "Phone (business)"
-msgstr ""
+msgstr "Telefoon (zakelijk)"
 
 #: bika/lims/content/person.py:126
 msgid "Phone (home)"
-msgstr ""
+msgstr "Telefoon (thuis)"
 
 #: bika/lims/content/person.py:134
 msgid "Phone (mobile)"
-msgstr ""
+msgstr "Telefoon (mobiel)"
 
 #: bika/lims/content/instrument.py:338
 msgid "Photo image file"
-msgstr ""
+msgstr "Foto-afbeeldingsbestand"
 
 #: bika/lims/content/instrument.py:339
 msgid "Photo of the instrument"
-msgstr ""
+msgstr "Foto van het instrument"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:87
 #: senaite/core/z3cform/widgets/address.py:120
 msgid "Physical address"
-msgstr ""
+msgstr "Fysiek adres"
 
 #: bika/lims/browser/publish/emailview.py:170
 msgid "Please add an email subject"
-msgstr ""
+msgstr "Voeg een e-mailonderwerp toe"
 
 #: bika/lims/browser/publish/emailview.py:173
 msgid "Please add an email text"
-msgstr ""
+msgstr "Voeg een e-mailtekst toe"
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:11
 msgid "Please check that the sample has been physically collected and the value for \"Sampled Date\" field has been set in accordance."
-msgstr ""
+msgstr "Controleer of het monster fysiek is verzameld en of de waarde voor het veld \"Monsternamedatum\" hierop is afgestemd."
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:165
 msgid "Please click the update button after your changes."
-msgstr ""
+msgstr "Klik op de bijwerkknop na uw wijzigingen."
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:11
 msgid "Please find attached the analysis result(s) for ${client_name}"
-msgstr ""
+msgstr "In de bijlage vindt u het analyseresultaat/de analyseresultaten voor ${client_name}"
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:44
 msgid "Please follow the link to the retest ${retest_id}."
-msgstr ""
+msgstr "Volg de link naar de hertest ${retest_id}."
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:95
 msgid "Please provide a comment explaining the reason for invalidating the sample. If the email notification option is selected, the sample contact will be informed, and this comment will be included in the email content."
-msgstr ""
+msgstr "Geef een opmerking met de reden voor het ongeldig verklaren van het monster. Als de optie voor e-mailmelding is geselecteerd, wordt het contact van het monster geïnformeerd en wordt deze opmerking in de e-mailinhoud opgenomen."
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:109
 msgid "Please provide the reason for invalidating the sample."
-msgstr ""
+msgstr "Geef de reden op voor het ongeldig verklaren van het monster."
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
-msgstr ""
+msgstr "Selecteer een gebruiker uit de lijst"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
-msgstr ""
+msgstr "Selecteer een stickersjabloon"
 
 #: senaite/core/browser/attachment/attachment.py:224
 msgid "Please select an analysis or service for the attachment"
-msgstr ""
+msgstr "Selecteer een analyse of dienst voor de bijlage"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:111
 msgid "Please select number of partitions to create and press the preview button"
-msgstr ""
+msgstr "Selecteer het aantal aan te maken partities en klik op de voorbeeldknop"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
-msgstr ""
+msgstr "Geef een reden op"
 
 #: bika/lims/content/analysisservice.py:183
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
-msgstr ""
+msgstr "Geef hier de conserveringen op die afwijken van de standaardconservering van de analysedienst per monstertype."
 
 #: bika/lims/content/laboratory.py:163
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
-msgstr ""
+msgstr "Upload het logo dat u van uw accreditatie-instantie op uw website en resultaatrapporten mag gebruiken. Maximale grootte is 175 x 175 pixels."
 
 #: bika/lims/content/analysisservice.py:229
 msgid "Please use the following format for select options: key1:value1|key2:value2|...|keyN:valueN"
-msgstr ""
+msgstr "Gebruik het volgende formaat voor keuzeopties: key1:value1|key2:value2|...|keyN:valueN"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:71
 msgid "Please write a comment where the listed sample(s) are dispatched"
-msgstr ""
+msgstr "Schrijf een opmerking waar de vermelde monster(s) naartoe worden verzonden"
+
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr "Schrijf een opmerking waar de vermelde monster(s) worden afgevoerd"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
-msgstr ""
+msgstr "Verzamelpunt"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
-msgstr ""
+msgstr "Portaaltype"
 
 #: bika/lims/content/identifiertype.py:39
 msgid "Portal Types"
-msgstr ""
+msgstr "Portaaltypes"
 
 #: senaite/core/browser/samples/multi_results_transposed.py:97
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:75
 #: senaite/core/browser/worksheets/worksheet/analyses_transposed_listing.py:89
 msgid "Position"
-msgstr ""
+msgstr "Positie"
 
 #: senaite/core/z3cform/widgets/address.py:121
 msgid "Postal address"
-msgstr ""
+msgstr "Postadres"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:125
 #: senaite/core/z3cform/widgets/address.py:226
 msgid "Postal code"
-msgstr ""
+msgstr "Postcode"
 
 #: senaite/core/content/samplecontainer.py:85
 msgid "Pre-preserved"
-msgstr ""
+msgstr "Voorgeconserveerd"
 
 #: senaite/core/content/samplecontainer.py:100
 msgid "Pre-preserved containers must have a preservation selected"
-msgstr ""
+msgstr "Voorgeconserveerde containers moeten een conservering geselecteerd hebben"
 
 #: bika/lims/content/abstractbaseanalysis.py:176
 msgid "Precision as number of decimals"
-msgstr ""
+msgstr "Precisie als aantal decimalen"
 
 #: bika/lims/content/abstractbaseanalysis.py:664
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
-msgstr ""
+msgstr "Precisie als het aantal significante cijfers volgens de onzekerheid. De decimale positie wordt bepaald door het eerste cijfer dat verschilt van nul in de onzekerheid; op die positie rondt het systeem de onzekerheid en resultaten af. Bij een resultaat van 5.243 en een onzekerheid van 0.22 toont het systeem bijvoorbeeld correct 5.2+-0.2. Als er geen onzekerheidsbereik voor het resultaat is ingesteld, gebruikt het systeem de ingestelde vaste precisie."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
-msgstr ""
+msgstr "Voorgedefinieerde resultaten"
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
-msgstr ""
+msgstr "Voorkeursdecimaalteken voor rapporten."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
-msgstr ""
+msgstr "Voorkeursdecimaalteken voor resultaten"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-msgstr ""
+msgstr "Voorkeursindeling van de resultaatinvoertabel in de werkbladweergave. De klassieke indeling toont de monsters in rijen en de analyses in kolommen. De getransponeerde indeling toont de monsters in kolommen en de analyses in rijen."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
-msgstr ""
+msgstr "Voorkeursformaat voor wetenschappelijke notatie voor rapporten"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
-msgstr ""
+msgstr "Voorkeursformaat voor wetenschappelijke notatie voor resultaten"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
-msgstr ""
+msgstr "Prefix"
 
 #: bika/lims/content/sampletype.py:157
 msgid "Prefixes can not contain spaces."
-msgstr ""
+msgstr "Prefixen mogen geen spaties bevatten."
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Prepublish"
-msgstr ""
+msgstr "Voorpubliceren"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:195
 #: senaite/core/content/samplecontainer.py:114
 msgid "Preservation"
-msgstr ""
+msgstr "Conservering"
 
 #: bika/lims/content/preservation.py:45
 msgid "Preservation Category"
-msgstr ""
+msgstr "Conserveringscategorie"
 
 #: senaite/core/content/samplecontainer.py:117
 msgid "Preservation method of this container"
-msgstr ""
+msgstr "Conserveringsmethode van deze container"
 
 #: bika/lims/content/analysisservice.py:182
 msgid "Preservation per sample type"
-msgstr ""
+msgstr "Conservering per monstertype"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Preserve"
-msgstr ""
+msgstr "Conserveren"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
-msgstr ""
+msgstr "Conserveerder"
 
 #: senaite/core/browser/viewlets/templates/toolbar.pt:44
 msgid "Press Ctrl+Space to trigger the Spotlight search"
-msgstr ""
+msgstr "Druk op Ctrl+Space om de Spotlight-zoekopdracht te starten"
 
 #: bika/lims/content/instrumentmaintenancetask.py:163
 #: bika/lims/content/instrumentscheduledtask.py:120
 msgid "Preventive"
-msgstr ""
+msgstr "Preventief"
 
 #: bika/lims/content/instrument.py:212
 msgid "Preventive maintenance procedure"
-msgstr ""
+msgstr "Preventieve onderhoudsprocedure"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
-msgstr ""
+msgstr "Voorbeeld"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
-msgstr ""
+msgstr "Prijs"
 
 #: bika/lims/content/abstractbaseanalysis.py:551
 #: bika/lims/content/analysisprofile.py:112
 msgid "Price (excluding VAT)"
-msgstr ""
+msgstr "Prijs (exclusief btw)"
 
 #: bika/lims/content/labproduct.py:54
 msgid "Price excluding VAT"
-msgstr ""
+msgstr "Prijs exclusief btw"
 
 #: bika/lims/profiles/default/types/Pricelist.xml
 msgid "Pricelist"
-msgstr ""
+msgstr "Prijslijst"
 
 #: bika/lims/content/pricelist.py:51
 msgid "Pricelist for"
-msgstr ""
+msgstr "Prijslijst voor"
 
 #: bika/lims/browser/pricelist.py:51
 #: bika/lims/profiles/default/types/PricelistFolder.xml
 msgid "Pricelists"
-msgstr ""
+msgstr "Prijslijsten"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
-msgstr ""
+msgstr "Primair contact"
 
 #: bika/lims/browser/publish/reports_listing.py:73
 #: bika/lims/browser/templates/analysisreport_info.pt:60
 msgid "Primary Sample"
-msgstr ""
+msgstr "Primair monster"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
-msgstr ""
+msgstr "Afdrukken"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Print Invoice"
-msgstr ""
+msgstr "Factuur afdrukken"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:135
 msgid "Print Worksheet"
-msgstr ""
+msgstr "Werkblad afdrukken"
 
 #: bika/lims/browser/templates/batch_publish.pt:124
 msgid "Print date:"
-msgstr ""
+msgstr "Afdrukdatum:"
 
 #: bika/lims/profiles/default/types/Pricelist.xml
 msgid "Print pricelist"
-msgstr ""
+msgstr "Prijslijst afdrukken"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
-msgstr ""
+msgstr "Stickers afdrukken"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
-msgstr ""
+msgstr "Afgedrukt"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:53
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:53
 msgid "Printed on"
-msgstr ""
+msgstr "Afgedrukt op"
 
 #: bika/lims/content/analysisrequest.py:925
 msgid "Priority"
-msgstr ""
+msgstr "Prioriteit"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
-msgstr ""
+msgstr "Profiel"
 
 #: bika/lims/content/analysisprofile.py:64
 msgid "Profile Analyses"
-msgstr ""
+msgstr "Profielanalyses"
 
 #: bika/lims/content/analysisrequest.py:432
 msgid "Profile Key"
-msgstr ""
+msgstr "Profielsleutel"
 
 #: bika/lims/content/analysisprofile.py:51
 msgid "Profile Keyword"
-msgstr ""
+msgstr "Profielsleutelwoord"
 
 #: bika/lims/content/analysisrequest.py:431
 msgid "Profile Name"
-msgstr ""
+msgstr "Profielnaam"
 
 #: senaite/core/content/analysisprofile.py:216
 msgid "Profile keyword must be unique"
-msgstr ""
+msgstr "Profielsleutelwoord moet uniek zijn"
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
-msgstr ""
+msgstr "Voortgang"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:103
 #: senaite/core/registry/schema.py:198
 msgid "Prominent fields"
-msgstr ""
+msgstr "Prominente velden"
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
-msgstr ""
+msgstr "Protocol-ID"
 
 #: bika/lims/browser/clientfolder.py:75
 msgid "Province"
-msgstr ""
+msgstr "Provincie"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
-msgstr ""
+msgstr "Publicatiemodi"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Publish"
-msgstr ""
+msgstr "Publiceren"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr "Rapporten publiceren"
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
-msgstr ""
+msgstr "Gepubliceerd"
 
 #: bika/lims/browser/publish/reports_listing.py:86
 msgid "Published By"
-msgstr ""
+msgstr "Gepubliceerd door"
 
 #: bika/lims/browser/publish/reports_listing.py:84
 msgid "Published Date"
-msgstr ""
+msgstr "Publicatiedatum"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
-msgstr ""
+msgstr "Gepubliceerde resultaten"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr "Gepubliceerde monsters waarvan de rapporten nog niet zijn afgedrukt"
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
-msgstr ""
+msgstr "Gepubliceerd {}, "
 
 #: senaite/core/browser/viewlets/sampleanalyses.py:76
 msgid "QC Analyses"
-msgstr ""
+msgstr "QC-analyses"
 
 #: bika/lims/browser/referencesample.py:143
 msgid "QC Analysis ID"
-msgstr ""
+msgstr "QC-analyse-ID"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "QC Results"
-msgstr ""
+msgstr "QC-resultaten"
 
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
-msgstr ""
+msgstr "QC-monster-ID"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr "Per kwartaal"
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr "Snelle acties"
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
-msgstr ""
+msgstr "Bereik max"
 
 #: bika/lims/content/abstractbaseanalysis.py:620
 msgid "Range min"
-msgstr ""
+msgstr "Bereik min"
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:18
 msgid "Ranges for some analyses are different from the Specification"
-msgstr ""
+msgstr "Bereiken voor sommige analyses verschillen van de specificatie"
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:29
 msgid "Re-assign the Specification if you want to restore analysis ranges."
-msgstr ""
+msgstr "Wijs de specificatie opnieuw toe als u de analysebereiken wilt herstellen."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:256
 msgid "Re-enter the password. Make sure the passwords are identical."
-msgstr ""
+msgstr "Voer het wachtwoord opnieuw in. Zorg ervoor dat de wachtwoorden identiek zijn."
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:145
 msgid "Reasons for rejection"
-msgstr ""
+msgstr "Redenen voor afwijzing"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
-msgstr ""
+msgstr "Opnieuw toewijzen"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:445
 msgid "Reassignable Slot"
-msgstr ""
+msgstr "Opnieuw toewijsbaar slot"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr ""
+msgstr "Opnieuw koppelen"
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
-msgstr ""
+msgstr "Herberekenen"
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
-msgstr ""
+msgstr "Ontvangen"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
-msgstr ""
+msgstr "Ontvangen"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr "Ontvangen monsters met analyses die op resultaten wachten"
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
-msgstr ""
+msgstr "Ontvangst in behandeling"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
-msgstr ""
+msgstr "Ontvanger"
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
-msgstr ""
+msgstr "Ontvangers"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
 #: bika/lims/content/worksheettemplate.py:57
 msgid "Reference"
-msgstr ""
+msgstr "Referentie"
 
 #: bika/lims/browser/referencesample.py:83
 msgid "Reference Analyses"
-msgstr ""
+msgstr "Referentieanalyses"
 
 #: bika/lims/profiles/default/types/ReferenceAnalysis.xml
 msgid "Reference Analysis"
-msgstr ""
+msgstr "Referentieanalyse"
 
 #: bika/lims/browser/referencesample.py:353
 #: bika/lims/browser/templates/referencesample_view.pt:67
 #: bika/lims/profiles/default/types/ReferenceDefinition.xml
 msgid "Reference Definition"
-msgstr ""
+msgstr "Referentiedefinitie"
 
 #: bika/lims/controlpanel/bika_referencedefinitions.py:63
 #: bika/lims/profiles/default/types/ReferenceDefinitions.xml
 msgid "Reference Definitions"
-msgstr ""
+msgstr "Referentiedefinities"
 
 #: bika/lims/content/referencesample.py:64
 msgid "Reference ID"
-msgstr ""
+msgstr "Referentie-ID"
 
 #: bika/lims/browser/instrument.py:558
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:12
 #: bika/lims/browser/worksheet/views/referencesamples.py:72
 msgid "Reference Sample"
-msgstr ""
+msgstr "Referentiemonster"
 
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Reference Samples"
-msgstr ""
+msgstr "Referentiemonsters"
 
 #: bika/lims/browser/referencesample.py:202
 #: bika/lims/profiles/default/types/ReferenceSample.xml
 msgid "Reference Values"
-msgstr ""
+msgstr "Referentiewaarden"
 
 #: bika/lims/content/referencesample.py:98
 msgid "Reference sample values are zero or 'blank'"
-msgstr ""
+msgstr "Referentiemonsterwaarden zijn nul of 'blanco'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
-msgstr ""
+msgstr "Registreren"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr "Monsters registreren"
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
-msgstr ""
+msgstr "Geregistreerd"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_cancellable_type_workflow/definition.xml
 msgid "Reinstate"
-msgstr ""
+msgstr "Herstellen"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:149
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reject"
-msgstr ""
+msgstr "Afwijzen"
 
 #: bika/lims/profiles/default/types/RejectAnalysis.xml
 msgid "Reject Analysis"
-msgstr ""
+msgstr "Analyse afwijzen"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:17
 msgid "Reject samples"
-msgstr ""
+msgstr "Monsters afwijzen"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
-msgstr ""
+msgstr "Afgewezen"
 
 #: bika/lims/browser/workflow/analysisrequest.py:98
 msgid "Rejected items: {}"
-msgstr ""
+msgstr "Afgewezen items: {}"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:13
 msgid "Rejected sample"
-msgstr ""
+msgstr "Afgewezen monster"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:114
 msgid "Rejected {} samples: {}"
-msgstr ""
+msgstr "{} monsters afgewezen: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
-msgstr ""
+msgstr "Afwijzingsredenen"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:121
 msgid "Rejection cancelled"
-msgstr ""
+msgstr "Afwijzing geannuleerd"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:84
 msgid "Rejection reasons"
-msgstr ""
+msgstr "Afwijzingsredenen"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:70
 msgid "Rejection workflow is not enabled"
-msgstr ""
+msgstr "Afwijzingsworkflow is niet ingeschakeld"
 
 # senaite.app.listing: Reload
 msgid "Reload"
-msgstr ""
+msgstr "Opnieuw laden"
 
 #: senaite/core/browser/modals/analysis/schema.py:122
 #: senaite/core/browser/viewlets/remarks.py:31
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:242
 msgid "Remarks"
-msgstr ""
+msgstr "Opmerkingen"
 
 #: bika/lims/content/analysisrequest.py:1103
 msgid "Remarks and comments for this request"
-msgstr ""
+msgstr "Opmerkingen en commentaar voor deze aanvraag"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:672
 msgid "Remarks of {}"
-msgstr ""
+msgstr "Opmerkingen van {}"
 
 #: bika/lims/content/instrumentcalibration.py:108
 msgid "Remarks to take into account before calibration"
-msgstr ""
+msgstr "Opmerkingen om rekening mee te houden vóór kalibratie"
 
 #: bika/lims/content/instrumentscheduledtask.py:87
 msgid "Remarks to take into account before performing the task"
-msgstr ""
+msgstr "Opmerkingen om rekening mee te houden voordat de taak wordt uitgevoerd"
 
 #: bika/lims/content/instrumentvalidation.py:90
 msgid "Remarks to take into account before validation"
-msgstr ""
+msgstr "Opmerkingen om rekening mee te houden vóór validatie"
 
 #: bika/lims/content/instrumentmaintenancetask.py:94
 msgid "Remarks to take into account for maintenance process"
-msgstr ""
+msgstr "Opmerkingen om rekening mee te houden voor het onderhoudsproces"
 
 #: bika/lims/browser/auditlog.py:90
 #: bika/lims/controlpanel/auditlog.py:92
 msgid "Remote IP"
-msgstr ""
+msgstr "Extern IP"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:72
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Remove"
-msgstr ""
+msgstr "Verwijderen"
+
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr "Verwijder deze analyse uit de filter"
 
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
-msgstr ""
+msgstr "{} sleutel(s) verwijderd: {}"
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
+msgstr "Filter hernoemen"
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
-msgstr ""
+msgstr "Bijlage weergeven in rapport"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:68
 msgid "Render in Report"
-msgstr ""
+msgstr "Weergeven in rapport"
 
 #: bika/lims/content/instrumentmaintenancetask.py:164
 #: bika/lims/content/instrumentscheduledtask.py:121
 msgid "Repair"
-msgstr ""
+msgstr "Repareren"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:59
 #: bika/lims/content/analysisservice.py:226
 msgid "Report"
-msgstr ""
+msgstr "Rapport"
 
 #: bika/lims/content/instrumentcalibration.py:68
 #: bika/lims/content/instrumentvalidation.py:50
 msgid "Report Date"
-msgstr ""
+msgstr "Rapportdatum"
 
 #: bika/lims/content/instrumentcalibration.py:150
 #: bika/lims/content/instrumentvalidation.py:132
 msgid "Report ID"
-msgstr ""
+msgstr "Rapport-ID"
 
 #: bika/lims/content/instrumentcalibration.py:151
 #: bika/lims/content/instrumentvalidation.py:133
 msgid "Report identification number"
-msgstr ""
+msgstr "Rapportidentificatienummer"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
-msgstr ""
+msgstr "Rapportmetadata"
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
-msgstr ""
+msgstr "Rapportontvangers"
 
 #: bika/lims/content/instrumentcertification.py:194
 msgid "Report upload"
-msgstr ""
+msgstr "Rapport uploaden"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Republish"
-msgstr ""
+msgstr "Opnieuw publiceren"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
-msgstr ""
+msgstr "Opnieuw gepubliceerd na laatste afdruk"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:71
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:70
 msgid "Request ID"
-msgstr ""
+msgstr "Aanvraag-ID"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
-msgstr ""
+msgstr "Nieuwe analyses aanvragen"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:227
 msgid "Required"
-msgstr ""
+msgstr "Vereist"
 
 #: bika/lims/browser/fields/partitionsetupfield.py:118
 msgid "Required Volume"
-msgstr ""
+msgstr "Vereist volume"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:198
 msgid "Reset"
-msgstr ""
+msgstr "Resetten"
+
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr "Kolomzichtbaarheid en -volgorde terugzetten naar de standaardwaarden"
 
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
-msgstr ""
+msgstr "Kolommen resetten"
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr "Terugzetten naar standaardkolommen en -volgorde"
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr "Weergave resetten"
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
-msgstr ""
+msgstr "Verantwoordelijken"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
-msgstr ""
+msgstr "Herstellen"
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
-msgstr ""
+msgstr "Werkbladtoegang beperken tot toegewezen analisten"
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
-msgstr ""
+msgstr "Werkbladbeheer beperken tot labmanagers"
 
 #: senaite/core/browser/modals/analysis/schema.py:53
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:86
 msgid "Result"
-msgstr ""
+msgstr "Resultaat"
 
 #: senaite/core/browser/modals/analysis/schema.py:130
 msgid "Result Capture Date"
-msgstr ""
+msgstr "Datum resultaatvastlegging"
 
 #: bika/lims/content/abstractbaseanalysis.py:726
 msgid "Result Value"
-msgstr ""
+msgstr "Resultaatwaarde"
 
 #: bika/lims/validators.py:642
 msgid "Result Value must be a number"
-msgstr ""
+msgstr "Resultaatwaarde moet een getal zijn"
 
 #: bika/lims/validators.py:657
 msgid "Result Value must be unique"
-msgstr ""
+msgstr "Resultaatwaarde moet uniek zijn"
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
-msgstr ""
+msgstr "Resultaat in schouderbereik"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
-msgstr ""
+msgstr "Resultaat buiten bereik"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
-msgstr ""
+msgstr "Resultaatbereik verschilt van specificatie: {}"
 
 #: bika/lims/content/abstractbaseanalysis.py:711
 msgid "Result type"
-msgstr ""
+msgstr "Resultaattype"
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
-msgstr ""
+msgstr "Resultaatwaarden met ten minste dit aantal significante cijfers worden weergegeven in wetenschappelijke notatie met de letter 'e' om de exponent aan te geven.  De precisie kan worden geconfigureerd in individuele analysediensten."
 
 #: bika/lims/content/analysisservice.py:116
 msgid "Result variables"
-msgstr ""
+msgstr "Resultaatvariabelen"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:63
 msgid "Results"
-msgstr ""
+msgstr "Resultaten"
 
 #: bika/lims/content/analysisrequest.py:1369
 msgid "Results Interpretation"
-msgstr ""
+msgstr "Resultaatinterpretatie"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr "Resultaten in behandeling"
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
-msgstr ""
+msgstr "Resultaatrapport"
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
-msgstr ""
+msgstr "Resultaatrapporten"
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
-msgstr ""
+msgstr "Resultaten zijn ingetrokken"
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:39
 msgid "Results interpretation"
-msgstr ""
+msgstr "Resultaatinterpretatie"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
-msgstr ""
+msgstr "Resultaten in behandeling"
 
 #: bika/lims/content/analysisrequest.py:660
 #: bika/lims/content/preservation.py:52
 #: bika/lims/content/sampletype.py:116
 msgid "Retention Period"
-msgstr ""
+msgstr "Bewaartermijn"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Retest"
-msgstr ""
+msgstr "Hertest"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:96
 msgid "Retested"
-msgstr ""
+msgstr "Hertest"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Retract"
-msgstr ""
+msgstr "Intrekken"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
-msgstr ""
+msgstr "Ingetrokken"
 
 #: bika/lims/browser/templates/analyses_retractedlist.pt:11
 msgid "Retracted analyses"
-msgstr ""
+msgstr "Ingetrokken analyses"
 
 #: bika/lims/browser/instrument.py:561
 msgid "Retractions"
-msgstr ""
+msgstr "Intrekkingen"
 
 #: bika/lims/browser/publish/reports_listing.py:78
 msgid "Review State"
-msgstr ""
+msgstr "Beoordelingsstatus"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:171
 msgid "Reviewed by"
-msgstr ""
+msgstr "Beoordeeld door"
 
 #: bika/lims/browser/auditlog.py:88
 #: bika/lims/controlpanel/auditlog.py:88
 msgid "Roles"
-msgstr ""
+msgstr "Rollen"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Rollback"
-msgstr ""
+msgstr "Terugdraaien"
 
 #: bika/lims/browser/worksheet/views/folder.py:110
 msgid "Routine Analyses"
-msgstr ""
+msgstr "Routineanalyses"
+
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr "Rij ${num}"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
-msgstr ""
+msgstr "SENAITE CORE"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE Add-on"
-msgstr ""
+msgstr "SENAITE CORE-add-on"
 
 #: bika/lims/profiles.zcml:15
 msgid "SENAITE Core 1.x (do not install)"
-msgstr ""
+msgstr "SENAITE Core 1.x (niet installeren)"
 
 #: senaite/core/browser/frontpage/templates/frontpage.pt:6
 msgid "SENAITE LIMS"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE LIMS front-page"
-msgstr ""
+msgstr "SENAITE LIMS-voorpagina"
 
 #: senaite/core/profiles/default/controlpanel.xml
 #: senaite/core/registry/controlpanel.py:81
 msgid "SENAITE Registry"
-msgstr ""
+msgstr "SENAITE Registry"
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
-msgstr ""
+msgstr "SENAITE Instellingen"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE front-page"
-msgstr ""
+msgstr "SENAITE-voorpagina"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
-msgstr ""
+msgstr "SMTP-server verbroken. Aanmaken van gebruiker afgebroken."
 
 #: bika/lims/content/supplier.py:87
 msgid "SWIFT code"
-msgstr ""
+msgstr "SWIFT-code"
 
 #: bika/lims/content/person.py:42
 msgid "Salutation"
-msgstr ""
+msgstr "Aanhef"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
-msgstr ""
+msgstr "Monster"
 
 #: bika/lims/browser/analysisrequest/add2.py:2195
 msgid "Sample ${AR} was successfully created."
-msgstr ""
+msgstr "Monster ${AR} is succesvol aangemaakt."
 
 #: senaite/core/browser/samples/invalidate_samples.py:149
 msgid "Sample ${sample_id} has been successfully invalidated."
-msgstr ""
+msgstr "Monster ${sample_id} is succesvol ongeldig verklaard."
 
 #: senaite/core/browser/samples/invalidate_samples.py:139
 msgid "Sample ${sample_id} was successfully invalidated, and a notification email has been sent to the following recipients: ${recipients}."
-msgstr ""
+msgstr "Monster ${sample_id} is succesvol ongeldig verklaard en er is een meldingsmail verzonden naar de volgende ontvangers: ${recipients}."
 
 #: senaite/core/profiles/default/types/SampleCondition.xml
 msgid "Sample Condition"
-msgstr ""
+msgstr "Monsterconditie"
 
 #: senaite/core/profiles/default/types/SampleConditions.xml
 msgid "Sample Conditions"
-msgstr ""
+msgstr "Monstercondities"
 
 #: senaite/core/profiles/default/types/SampleContainer.xml
 msgid "Sample Container"
-msgstr ""
+msgstr "Monstercontainer"
 
 #: senaite/core/profiles/default/types/SampleContainers.xml
 msgid "Sample Containers"
-msgstr ""
+msgstr "Monstercontainers"
 
 #: senaite/core/registry/schema.py:160
 msgid "Sample Header"
-msgstr ""
+msgstr "Monsterkop"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
-msgstr ""
+msgstr "Monster-ID"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:17
 msgid "Sample Invalidation"
-msgstr ""
+msgstr "Ongeldigverklaring monster"
 
 #: senaite/core/profiles/default/types/SampleMatrices.xml
 msgid "Sample Matrices"
-msgstr ""
+msgstr "Monstermatrices"
 
 #: senaite/core/profiles/default/types/SampleMatrix.xml
 msgid "Sample Matrix"
-msgstr ""
+msgstr "Monstermatrix"
 
 #: bika/lims/content/artemplate.py:172
 msgid "Sample Partitions"
-msgstr ""
+msgstr "Monsterpartities"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
-msgstr ""
+msgstr "Monsterpunt"
 
 #: senaite/core/profiles/default/types/SamplePoints.xml
 msgid "Sample Points"
-msgstr ""
+msgstr "Monsterpunten"
 
 #: senaite/core/profiles/default/types/SamplePreservation.xml
 msgid "Sample Preservation"
-msgstr ""
+msgstr "Monsterconservering"
 
 #: senaite/core/profiles/default/types/SamplePreservations.xml
 msgid "Sample Preservations"
-msgstr ""
+msgstr "Monsterconserveringen"
 
 #: bika/lims/content/analysisrequest.py:671
 msgid "Sample Rejection"
-msgstr ""
+msgstr "Monsterafwijzing"
 
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Sample Templates"
-msgstr ""
+msgstr "Monstersjablonen"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
-msgstr ""
+msgstr "Monstertype"
 
 #: bika/lims/content/sampletype.py:156
 msgid "Sample Type Prefix"
-msgstr ""
+msgstr "Monstertypeprefix"
 
 #: senaite/core/registry/schema.py:124
 msgid "Sample View"
-msgstr ""
+msgstr "Monsterweergave"
 
 #: bika/lims/content/artemplate.py:118
 msgid "Sample collected by the laboratory"
-msgstr ""
+msgstr "Monster verzameld door het laboratorium"
 
 #: bika/lims/browser/analysisrequest/add2.py:1992
 msgid "Sample creation cancelled"
-msgstr ""
+msgstr "Aanmaken van monster geannuleerd"
 
 #: bika/lims/browser/workflow/analysisrequest.py:248
 msgid "Sample date required for sample %s"
-msgstr ""
+msgstr "Monsterdatum vereist voor monster %s"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Sample due"
-msgstr ""
+msgstr "Monster verwacht"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:111
 msgid "Sample type"
-msgstr ""
+msgstr "Monstertype"
 
 #: senaite/core/content/interpretationtemplate.py:71
 msgid "Sample types"
-msgstr ""
+msgstr "Monstertypes"
 
 #: senaite/core/registry/schema.py:125
 msgid "Sample view configuration"
-msgstr ""
+msgstr "Configuratie monsterweergave"
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:15
 msgid "Sample with partitions"
-msgstr ""
+msgstr "Monster met partities"
 
 #: senaite/core/profiles/default/types/SampleTemplate.xml
 msgid "SampleTemplate"
-msgstr ""
+msgstr "MonsterSjabloon"
 
 #: senaite/core/profiles/default/types/SampleTemplates.xml
 msgid "SampleTemplates"
-msgstr ""
+msgstr "MonsterSjablonen"
 
 #: senaite/core/profiles/default/types/SampleType.xml
 msgid "SampleType"
-msgstr ""
+msgstr "MonsterType"
 
 #: senaite/core/profiles/default/types/SampleTypes.xml
 msgid "SampleTypes"
-msgstr ""
+msgstr "MonsterTypes"
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
-msgstr ""
+msgstr "Monsternemer"
 
 #: bika/lims/content/analysisrequest.py:497
 msgid "Sampler for scheduled sampling"
-msgstr ""
+msgstr "Monsternemer voor geplande monstername"
 
 #: bika/lims/browser/workflow/analysisrequest.py:241
 msgid "Sampler required for sample %s"
-msgstr ""
+msgstr "Monsternemer vereist voor monster %s"
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
-msgstr ""
+msgstr "Monsters"
 
 #: bika/lims/browser/analysisrequest/add2.py:2192
 msgid "Samples ${ARs} were successfully created."
-msgstr ""
+msgstr "Monsters ${ARs} zijn succesvol aangemaakt."
 
 #: senaite/core/browser/samples/invalidate_samples.py:155
 msgid "Samples ${sample_ids} were successfully invalidated, with notification emails sent for the following: ${notified_ids}."
-msgstr ""
+msgstr "Monsters ${sample_ids} zijn succesvol ongeldig verklaard, met meldingsmails verzonden voor de volgende: ${notified_ids}."
 
 #: senaite/core/browser/samples/invalidate_samples.py:164
 msgid "Samples ${sample_ids} were successfully invalidated."
-msgstr ""
+msgstr "Monsters ${sample_ids} zijn succesvol ongeldig verklaard."
+
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr "Monsters die wachten op verzameling van het monster"
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr "Monsters die wachten op conservering"
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr "Monsters die wachten op ontvangst bij het laboratorium"
 
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
-msgstr ""
+msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:67
 msgid "Samples rejection reporting form"
-msgstr ""
+msgstr "Formulier voor rapportage van monsterafwijzing"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr "Te ontvangen monsters"
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr "Monsters waarvan de rapporten zijn gepubliceerd"
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr "Monsters waarvan de resultaten op verificatie wachten"
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr "Monsters met een geplande monsternamedatum"
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
-msgstr ""
+msgstr "Monstername"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:106
 msgid "Sampling Date"
-msgstr ""
+msgstr "Monsternamedatum"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
-msgstr ""
+msgstr "Monsternameafwijking"
 
 #: senaite/core/profiles/default/types/SamplingDeviations.xml
 msgid "Sampling Deviations"
-msgstr ""
+msgstr "Monsternameafwijkingen"
 
 #: bika/lims/content/samplepoint.py:83
 msgid "Sampling Frequency"
-msgstr ""
+msgstr "Monsternamefrequentie"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
-msgstr ""
+msgstr "Monstername gepland"
 
 #: senaite/core/vocabularies/setup.py:161
 msgid "Saturday"
-msgstr ""
+msgstr "Zaterdag"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
-msgstr ""
+msgstr "Opslaan"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
-msgstr ""
+msgstr "Opslaan en kopiëren"
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr "Huidige weergave opslaan"
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr "Opgeslagen filters"
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
-msgstr ""
+msgstr "Opgeslagen items: {}"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Schedule"
-msgstr ""
+msgstr "Plannen"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Schedule sampling"
-msgstr ""
+msgstr "Monstername plannen"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
-msgstr ""
+msgstr "Geplande monstername"
 
 #: bika/lims/browser/instrument.py:400
 msgid "Scheduled task"
-msgstr ""
+msgstr "Geplande taak"
 
 #: bika/lims/content/abstractbaseanalysis.py:95
 msgid "Scientific name"
-msgstr ""
+msgstr "Wetenschappelijke naam"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:154
 msgid "Search"
-msgstr ""
+msgstr "Zoeken"
+
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr "Kolommen zoeken…"
 
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
-msgstr ""
+msgstr "Zoeken..."
 
 #: bika/lims/browser/fields/coordinatefield.py:38
 msgid "Seconds"
-msgstr ""
+msgstr "Seconden"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
-msgstr ""
+msgstr "Beveiliging"
 
 #: bika/lims/content/container.py:118
 msgid "Security Seal Intact Y/N"
-msgstr ""
+msgstr "Verzegeling intact J/N"
 
 #: senaite/core/content/samplecontainer.py:122
 msgid "Security seal intact"
-msgstr ""
+msgstr "Verzegeling intact"
 
 #: bika/lims/content/analysisservice.py:261
 msgid "Select"
-msgstr ""
+msgstr "Selecteren"
 
 #: senaite/core/exportimport/import.pt:100
 msgid "Select Import Interface"
-msgstr ""
+msgstr "Import-interface selecteren"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:215
 msgid "Select Partition Analyses"
-msgstr ""
+msgstr "Partitie-analyses selecteren"
 
 #: bika/lims/content/analysisservice.py:146
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
-msgstr ""
+msgstr "Selecteer een standaardconservering voor deze analysedienst. Als de conservering afhangt van de combinatie met het monstertype, geef dan per monstertype een conservering op in de onderstaande tabel"
 
 # senaite.core.browser.modals.templates.create_worksheet.pt
 msgid "Select all"
-msgstr ""
+msgstr "Alles selecteren"
 
 #: bika/lims/browser/publish/templates/email.pt:168
 msgid "Select all:"
-msgstr ""
+msgstr "Alles selecteren:"
 
 #: bika/lims/content/instrument.py:223
 msgid "Select an Export interface for this instrument."
-msgstr ""
+msgstr "Selecteer een export-interface voor dit instrument."
 
 #: bika/lims/content/instrument.py:236
 msgid "Select an Import interface for this instrument."
-msgstr ""
+msgstr "Selecteer een import-interface voor dit instrument."
 
 #: bika/lims/content/artemplate.py:288
 msgid "Select analyses to include in this template"
-msgstr ""
+msgstr "Selecteer analyses om op te nemen in dit sjabloon"
 
 #: senaite/core/browser/worksheets/templates/view.pt:36
 msgid "Select analyst"
-msgstr ""
+msgstr "Analist selecteren"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:203
 msgid "Select any add-ons you want to activate immediately. You can also activate add-ons after the site has been created using the Add-ons control panel."
-msgstr ""
+msgstr "Selecteer de add-ons die u direct wilt activeren. U kunt add-ons ook activeren nadat de site is aangemaakt via het configuratiescherm voor add-ons."
 
 #: senaite/core/exportimport/import.pt:135
 msgid "Select existing file"
-msgstr ""
+msgstr "Bestaand bestand selecteren"
 
 #: bika/lims/content/instrumentcertification.py:85
 msgid "Select if is an in-house calibration certificate"
-msgstr ""
+msgstr "Selecteer of het een intern kalibratiecertificaat betreft"
 
 #: bika/lims/content/analysisservice.py:88
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
-msgstr ""
+msgstr "Selecteer of de te gebruiken berekening de standaardberekening van de standaardmethode is. Als deze niet is geselecteerd, kan de berekening handmatig worden gekozen"
 
 #: bika/lims/content/pricelist.py:76
 msgid "Select if the descriptions should be included"
-msgstr ""
+msgstr "Selecteer of de beschrijvingen moeten worden opgenomen"
 
 #: bika/lims/content/abstractbaseanalysis.py:393
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
-msgstr ""
+msgstr "Selecteer of de resultaten voor tests van dit type analyse met behulp van een instrument kunnen worden ingesteld. Indien uitgeschakeld, zullen er geen instrumenten beschikbaar zijn voor tests van dit type analyse in de weergave voor resultaatbeheer, ook al zijn er instrumenten toegewezen aan de voor de test geselecteerde methode."
 
 #: senaite/core/browser/worksheets/templates/view.pt:66
 msgid "Select instrument"
-msgstr ""
+msgstr "Instrument selecteren"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:50
 msgid "Select reasons"
-msgstr ""
+msgstr "Redenen selecteren"
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:76
 #: senaite/core/browser/worksheets/templates/view.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:33
 msgid "Select template"
-msgstr ""
+msgstr "Sjabloon selecteren"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
-msgstr ""
+msgstr "Selecteer het land dat de site standaard zal tonen"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
-msgstr ""
+msgstr "Selecteer de valuta die de site gebruikt om prijzen weer te geven."
 
 #: bika/lims/content/analysisservice.py:166
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
-msgstr ""
+msgstr "Selecteer de standaardcontainer voor deze analysedienst. Als de te gebruiken container afhangt van de combinatie van monstertype en conservering, geef de container dan op in de monstertypetabel hieronder"
 
 #: bika/lims/profiles/default/registry.xml
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
-msgstr ""
+msgstr "Selecteer de standaardstartpagina. Deze wordt gebruikt wanneer een klantgebruiker zich aanmeldt bij het systeem, of wanneer een klant wordt geselecteerd uit de lijst met klantmappen."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
-msgstr ""
+msgstr "Selecteer het standaardstickersjabloon voor automatisch afdrukken."
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
-msgstr ""
+msgstr "Selecteer het standaardstickersjabloon voor automatisch afdrukken.<br/>"
 
 #: bika/lims/content/identifiertype.py:40
 msgid "Select the types that this ID is used to identify."
-msgstr ""
+msgstr "Selecteer de typen die met deze ID worden geïdentificeerd."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
-msgstr ""
+msgstr "Selecteer dit om automatische e-mailmeldingen aan de klant te activeren wanneer een monster wordt afgewezen."
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
-msgstr ""
+msgstr "Selecteer dit om het dashboard te activeren als standaardvoorpagina."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
-msgstr ""
+msgstr "Selecteer dit om de workflowstappen voor monsterverzameling te activeren."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
-msgstr ""
+msgstr "Selecteer dit om een monsternamecoördinator toe te staan een monstername te plannen. Deze functionaliteit is alleen van kracht wanneer de 'Monstername-workflow' actief is"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr "Selecteer dit om het verzenden van monsters via de overgang 'verzenden' toe te staan en de aanvullende status 'verzonden' in te schakelen. De analyses van een verzonden monster worden alleen-lezen en worden teruggezet naar hun vorige status wanneer het monster wordt hersteld. Standaard uitgeschakeld."
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr "Selecteer dit om het afvoeren van monsters via de overgang 'afvoeren' toe te staan en de aanvullende status 'afgevoerd' in te schakelen. Standaard uitgeschakeld."
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
-msgstr ""
+msgstr "Selecteer dit om de gebruiker toe te staan een aanvullende status 'Afgedrukt' toe te kennen aan die analyseaanvragen die zijn gepubliceerd. Standaard uitgeschakeld."
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
-msgstr ""
+msgstr "Selecteer dit om monsters automatisch te ontvangen wanneer ze door laboratoriumpersoneel worden aangemaakt en de monstername-workflow is uitgeschakeld. Monsters die door contactpersonen van klanten worden aangemaakt, worden niet automatisch ontvangen"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-msgstr ""
+msgstr "Selecteer dit om monsterpartities te tonen aan contactpersonen van klanten. Indien gedeactiveerd, worden partities niet opgenomen in lijsten en wordt er geen infobericht met links naar het primaire monster getoond aan contactpersonen van klanten."
 
 #: bika/lims/content/worksheettemplate.py:82
 msgid "Select which Analyses should be included on the Worksheet"
-msgstr ""
+msgstr "Selecteer welke analyses op het werkblad moeten worden opgenomen"
 
 #: senaite/core/config/vocabularies.py:57
 msgid "Selection list"
-msgstr ""
+msgstr "Selectielijst"
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
-msgstr ""
+msgstr "Zelfverificatie van resultaten"
 
 #: bika/lims/browser/publish/templates/email.pt:208
 msgid "Send"
-msgstr ""
+msgstr "Verzenden"
 
 #: bika/lims/browser/publish/templates/email.pt:23
 msgid "Send Analysis Reports via Email"
-msgstr ""
+msgstr "Analyserapporten via e-mail verzenden"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
-msgstr ""
+msgstr "Verzendlogboek"
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
-msgstr ""
+msgstr "Verzendlogboekregel"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:132
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:135
 msgid "Send an email notification to ${recipients}"
-msgstr ""
+msgstr "Een e-mailmelding verzenden naar ${recipients}"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:132
 msgid "Sender"
-msgstr ""
+msgstr "Afzender"
 
 #: bika/lims/browser/publish/reports_listing.py:91
 msgid "Sent to"
-msgstr ""
+msgstr "Verzonden naar"
 
 #: bika/lims/browser/fields/partitionsetupfield.py:115
 #: bika/lims/content/analysisservice.py:129
 msgid "Separate Container"
-msgstr ""
+msgstr "Aparte container"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
-msgstr ""
+msgstr "Seq-type"
 
 #: bika/lims/content/instrument.py:145
 msgid "Serial No"
-msgstr ""
+msgstr "Serienr."
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:74
 #: bika/lims/browser/templates/analysisservice_info.pt:209
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:73
 msgid "Service"
-msgstr ""
+msgstr "Dienst"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
-msgstr ""
+msgstr "Dienst kan niet worden gedeselecteerd. Klik op de infoknop voor meer details"
 
 #: senaite/core/exportimport/instruments/importer.py:315
 msgid "Service keyword {analysis_keyword} not found"
-msgstr ""
+msgstr "Dienstsleutelwoord {analysis_keyword} niet gevonden"
 
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:119
 msgid "Set Conditions"
-msgstr ""
+msgstr "Voorwaarden instellen"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:167
 msgid "Set remarks"
-msgstr ""
+msgstr "Opmerkingen instellen"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:171
 msgid "Set remarks for selected analyses"
-msgstr ""
+msgstr "Opmerkingen instellen voor geselecteerde analyses"
 
 #: bika/lims/content/analysisrequest.py:672
 msgid "Set the Sample Rejection workflow and the reasons"
-msgstr ""
+msgstr "Stel de workflow voor monsterafwijzing en de redenen in"
 
 #: bika/lims/content/instrumentmaintenancetask.py:128
 msgid "Set the maintenance task as closed."
-msgstr ""
+msgstr "Stel de onderhoudstaak in als gesloten."
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
-msgstr ""
+msgstr "Stel de tekst in voor de hoofdtekst van de e-mail die naar de contactpersoon van de klant van het monster wordt verzonden als de optie 'E-mailmelding bij monsterafwijzing' is ingeschakeld. U kunt gereserveerde sleutelwoorden gebruiken: $sample_id, $sample_link, $reasons, $lab_address"
 
 #: senaite/core/registry/schema.py:40
 msgid "Settings for Clients"
-msgstr ""
+msgstr "Instellingen voor klanten"
 
 #: bika/lims/profiles/default/types/BikaSetup.xml
 msgid "Setup"
-msgstr ""
+msgstr "Instellingen"
 
 #: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
-msgstr ""
+msgstr "Legplankcode"
 
 #: bika/lims/content/storagelocation.py:83
 msgid "Shelf Description"
-msgstr ""
+msgstr "Legplankbeschrijving"
 
 #: bika/lims/content/storagelocation.py:73
 msgid "Shelf Title"
-msgstr ""
+msgstr "Legplanktitel"
 
 #: bika/lims/config.py:84
 msgid "Shipping address"
-msgstr ""
+msgstr "Verzendadres"
 
 #: bika/lims/content/client.py:61
 msgid "Short and unique identifier of this client. Besides fast searches by client in Samples listings, the purposes of this field depend on the laboratory needs. For instance, the Client ID can be included as part of the Sample identifier, so the lab can easily know the client a given sample belongs to by just looking to its ID."
-msgstr ""
+msgstr "Korte en unieke identificatie van deze klant. Naast snel zoeken op klant in monsterlijsten hangen de doeleinden van dit veld af van de behoeften van het laboratorium. De klant-ID kan bijvoorbeeld worden opgenomen als onderdeel van de monsteridentificatie, zodat het lab eenvoudig kan weten tot welke klant een bepaald monster behoort door alleen naar de ID te kijken."
 
 #: bika/lims/content/method.py:160
 msgid "Short method description"
-msgstr ""
+msgstr "Korte methodebeschrijving"
 
 #: bika/lims/content/abstractbaseanalysis.py:68
 msgid "Short title"
-msgstr ""
+msgstr "Korte titel"
 
 #: bika/lims/content/analysisrequest.py:974
 msgid "Should the analyses be excluded from the invoice?"
-msgstr ""
+msgstr "Moeten de analyses worden uitgesloten van de factuur?"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:127
 msgid "Should the default example content be added to the site?"
-msgstr ""
+msgstr "Moet de standaard voorbeeldinhoud aan de site worden toegevoegd?"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
-msgstr ""
+msgstr "Aanvullende velden tonen"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
-msgstr ""
+msgstr "Alles tonen"
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
+msgstr "Geschiedenis tonen"
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
-msgstr ""
+msgstr "Laatste logboeken voor automatische import tonen"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
-msgstr ""
+msgstr "Minder tonen"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
-msgstr ""
+msgstr "Meer tonen"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
-msgstr ""
+msgstr "Standaardvelden tonen"
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr "Deze kolom tonen"
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
+msgstr "Tijdlijn tonen/verbergen"
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
-msgstr ""
+msgstr "Handtekening"
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "Simple File"
-msgstr ""
+msgstr "Eenvoudig bestand"
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "Simple Image"
-msgstr ""
+msgstr "Eenvoudige afbeelding"
 
 #: bika/lims/content/storagelocation.py:43
 msgid "Site Code"
-msgstr ""
+msgstr "Sitecode"
 
 #: bika/lims/content/storagelocation.py:48
 msgid "Site Description"
-msgstr ""
+msgstr "Sitebeschrijving"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
-msgstr ""
+msgstr "Sitelogo"
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
-msgstr ""
+msgstr "Sitelogo-CSS"
 
 #: bika/lims/content/storagelocation.py:38
 msgid "Site Title"
-msgstr ""
+msgstr "Sitetitel"
 
 #: senaite/core/browser/clients/client/attachments/view.py:67
 #: senaite/core/browser/viewlets/templates/attachments.pt:65
 msgid "Size"
-msgstr ""
+msgstr "Grootte"
 
 #: senaite/core/exportimport/instruments/importer.py:648
 msgid "Skipping result for analysis '{keyword}' of sample '{sid}' with calculation '{calculation}'"
-msgstr ""
+msgstr "Resultaat voor analyse '{keyword}' van monster '{sid}' met berekening '{calculation}' wordt overgeslagen"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Small Sticker"
-msgstr ""
+msgstr "Kleine sticker"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
-msgstr ""
+msgstr "Klein stickersjabloon"
 
 #: bika/lims/browser/auditlog.py:98
 msgid "Snapshot"
-msgstr ""
+msgstr "Momentopname"
 
 #: bika/lims/browser/worksheet/views/results.py:190
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
-msgstr ""
+msgstr "Sommige analyses gebruiken verouderde of niet-gekalibreerde instrumenten. Bewerken van resultaten niet toegestaan"
 
 #: bika/lims/content/abstractbaseanalysis.py:82
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
-msgstr ""
+msgstr "Sorteersleutel"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr "Oplopend sorteren"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr "Aflopend sorteren"
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
-msgstr ""
+msgstr "Bron"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:93
 msgid "Specification"
-msgstr ""
+msgstr "Specificatie"
 
 #: senaite/core/content/dynamicanalysisspec.py:50
 msgid "Specification File"
-msgstr ""
+msgstr "Specificatiebestand"
 
 #: bika/lims/content/analysisrequest.py:707
 msgid "Specification Name"
-msgstr ""
+msgstr "Specificatienaam"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:18
 msgid "Specification ranges have changed since they were assigned"
-msgstr ""
+msgstr "De specificatiebereiken zijn gewijzigd sinds ze werden toegewezen"
 
 #: bika/lims/content/analysisspec.py:90
 msgid "Specifications"
-msgstr ""
+msgstr "Specificaties"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
-msgstr ""
+msgstr "Geef aan hoeveel exemplaren van elke sticker standaard moeten worden afgedrukt."
 
 #: bika/lims/content/worksheettemplate.py:63
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
-msgstr ""
+msgstr "Geef de grootte van het werkblad op, bijvoorbeeld overeenkomend met de trayafmeting van een specifiek instrument. Selecteer vervolgens een analyse-'type' per werkbladpositie. Waar QC-monsters worden geselecteerd, selecteer ook welk referentiemonster moet worden gebruikt. Als een duplicaatanalyse wordt geselecteerd, geef dan aan van welke monsterpositie het een duplicaat moet zijn"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
-msgstr ""
+msgstr "Splitslengte"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:149
 #: senaite/core/registry/schema.py:205
 msgid "Standard fields"
-msgstr ""
+msgstr "Standaardvelden"
 
 #: bika/lims/browser/pricelist.py:64
 msgid "Start Date"
-msgstr ""
+msgstr "Startdatum"
 
 #: bika/lims/validators.py:237
 msgid "Start date must be before End Date"
-msgstr ""
+msgstr "Startdatum moet vóór einddatum liggen"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
-msgstr ""
+msgstr "Status"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
-msgstr ""
+msgstr "Sticker"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Stickers preview"
-msgstr ""
+msgstr "Voorbeeld van stickers"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr "Automatisch toepassen stoppen"
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
-msgstr ""
+msgstr "Opslaglocatie"
 
 #: senaite/core/profiles/default/types/StorageLocations.xml
 msgid "Storage Locations"
-msgstr ""
+msgstr "Opslaglocaties"
 
 #: senaite/core/config/vocabularies.py:55
 msgid "String"
-msgstr ""
+msgstr "Tekenreeks"
 
 #: senaite/core/profiles/default/types/SubGroup.xml
 msgid "SubGroup"
-msgstr ""
+msgstr "Subgroep"
 
 #: senaite/core/profiles/default/types/SubGroups.xml
 msgid "SubGroups"
-msgstr ""
+msgstr "Subgroepen"
 
 #: bika/lims/content/subgroup.py:39
 msgid "Subgroups are sorted with this key in group views"
-msgstr ""
+msgstr "Subgroepen worden met deze sleutel gesorteerd in groepsweergaven"
 
 #: bika/lims/browser/publish/templates/email.pt:115
 #: bika/lims/browser/templates/analysisreport_info.pt:165
 msgid "Subject"
-msgstr ""
+msgstr "Onderwerp"
 
 #: senaite/core/exportimport/import.pt:124
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Submit"
-msgstr ""
+msgstr "Indienen"
 
 #: senaite/core/exportimport/import.pt:114
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
-msgstr ""
+msgstr "Dien een geldig Open XML-bestand (.XLSX) in met instellingsrecords om door te gaan."
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr "Ingediende analyses in afwachting van verificatie"
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
-msgstr ""
+msgstr "Ingediend en geverifieerd door dezelfde gebruiker: {}"
 
 #: bika/lims/browser/analyses/view.py:181
 msgid "Submitter"
-msgstr ""
+msgstr "Indiener"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
-msgstr ""
+msgstr "Subtotaal"
 
 #: senaite/core/vocabularies/setup.py:162
 msgid "Sunday"
-msgstr ""
+msgstr "Zondag"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:600
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Supplier"
-msgstr ""
+msgstr "Leverancier"
 
 #: senaite/core/profiles/default/types/Suppliers.xml
 msgid "Suppliers"
-msgstr ""
+msgstr "Leveranciers"
 
 #: bika/lims/browser/worksheet/views/referencesamples.py:75
 msgid "Supported Services"
-msgstr ""
+msgstr "Ondersteunde diensten"
 
 #: bika/lims/content/method.py:116
 msgid "Supported calculations of this method"
-msgstr ""
+msgstr "Ondersteunde berekeningen van deze methode"
 
 #: bika/lims/content/person.py:75
 msgid "Surname"
-msgstr ""
+msgstr "Achternaam"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:33
 msgid "Switch to classic view"
-msgstr ""
+msgstr "Overschakelen naar klassieke weergave"
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:6
 msgid "Switch to dashboard"
-msgstr ""
+msgstr "Overschakelen naar dashboard"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:25
 msgid "Switch to transposed view"
-msgstr ""
+msgstr "Overschakelen naar getransponeerde weergave"
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
-msgstr ""
+msgstr "Systeemstandaard"
 
 #: bika/lims/browser/instrument.py:84
 msgid "Task"
-msgstr ""
+msgstr "Taak"
 
 #: bika/lims/content/instrumentcertification.py:57
 msgid "Task ID"
-msgstr ""
+msgstr "Taak-ID"
 
 #. Default: "Type"
 #: bika/lims/browser/instrument.py:86
 #: bika/lims/content/instrumentscheduledtask.py:66
 msgid "Task type"
-msgstr ""
+msgstr "Type"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:217
 msgid "Taxes"
-msgstr ""
+msgstr "Belastingen"
 
 #: bika/lims/content/method.py:78
 msgid "Technical description and instructions intended for analysts"
-msgstr ""
+msgstr "Technische beschrijving en instructies bedoeld voor analisten"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
-msgstr ""
+msgstr "Sjabloon"
 
 #: bika/lims/content/calculation.py:156
 msgid "Test Parameters"
-msgstr ""
+msgstr "Testparameters"
 
 #: bika/lims/content/calculation.py:170
 msgid "Test Result"
-msgstr ""
+msgstr "Testresultaat"
 
 #: senaite/core/config/vocabularies.py:56
 msgid "Text"
-msgstr ""
+msgstr "Tekst"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:5
 msgid "Thank you for your analysis request."
-msgstr ""
+msgstr "Bedankt voor uw analyseaanvraag."
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:54
 msgid "The ID of the site. This ends up as part of the URL. No special characters or spaces are allowed."
-msgstr ""
+msgstr "De ID van de site. Deze wordt onderdeel van de URL. Speciale tekens of spaties zijn niet toegestaan."
 
 #: bika/lims/content/laboratory.py:65
 msgid "The Laboratory's web address"
-msgstr ""
+msgstr "Het webadres van het laboratorium"
 
 #: senaite/core/browser/form/adapters/referencesample.py:46
 msgid "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
-msgstr ""
+msgstr "De referentiemonster-ID kan niet worden gewijzigd omdat deze al is gekoppeld aan andere objecten, zoals QC-analyses."
 
 #: bika/lims/content/laboratory.py:142
 msgid "The accreditation standard that applies, e.g. ISO 17025"
-msgstr ""
+msgstr "De van toepassing zijnde accreditatienorm, bijv. ISO 17025"
 
 #: bika/lims/content/analysisprofile.py:65
 msgid "The analyses included in this profile, grouped per category"
-msgstr ""
+msgstr "De analyses die in dit profiel zijn opgenomen, gegroepeerd per categorie"
 
 #: bika/lims/content/instrumentcalibration.py:97
 msgid "The analyst or agent responsible of the calibration"
-msgstr ""
+msgstr "De analist of medewerker die verantwoordelijk is voor de kalibratie"
 
 #: bika/lims/content/instrumentmaintenancetask.py:84
 msgid "The analyst or agent responsible of the maintenance"
-msgstr ""
+msgstr "De analist of medewerker die verantwoordelijk is voor het onderhoud"
 
 #: bika/lims/content/instrumentvalidation.py:79
 msgid "The analyst responsible of the validation"
-msgstr ""
+msgstr "De analist die verantwoordelijk is voor de validatie"
 
 #: bika/lims/browser/batch/batchbook.py:38
 msgid "The batch book allows to introduce analysis results for all samples in this batch. Please note that submitting the results for verification is only possible within samples or worksheets, because additional information like e.g. the instrument or the method need to be set additionally."
-msgstr ""
+msgstr "Met het batchboek kunt u analyseresultaten invoeren voor alle monsters in deze batch. Houd er rekening mee dat het indienen van de resultaten voor verificatie alleen mogelijk is binnen monsters of werkbladen, omdat aanvullende informatie zoals bijvoorbeeld het instrument of de methode aanvullend moet worden ingesteld."
 
 #: bika/lims/content/analysisrequest.py:852
 msgid "The client side identifier of the sample"
-msgstr ""
+msgstr "De identificatie van het monster aan de klantzijde"
 
 #: bika/lims/content/analysisrequest.py:818
 msgid "The client side order number for this request"
-msgstr ""
+msgstr "Het ordernummer aan de klantzijde voor deze aanvraag"
 
 #: bika/lims/content/analysisrequest.py:835
 msgid "The client side reference for this request"
-msgstr ""
+msgstr "De referentie aan de klantzijde voor deze aanvraag"
 
 #: bika/lims/content/instrument.py:348
 msgid "The date the instrument was installed"
-msgstr ""
+msgstr "De datum waarop het instrument is geïnstalleerd"
 
 #: bika/lims/content/analysisrequest.py:623
 msgid "The date when the sample was preserved"
-msgstr ""
+msgstr "De datum waarop het monster is geconserveerd"
 
 #: bika/lims/content/analysisrequest.py:1077
 msgid "The date when the sample was received"
-msgstr ""
+msgstr "De datum waarop het monster is ontvangen"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
-msgstr ""
+msgstr "Het decimaalteken dat is geselecteerd in Bika Setup wordt gebruikt."
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:113
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
-msgstr ""
+msgstr "De standaardinstelling voor de tijdzone van het portaal. Gebruikers kunnen hun eigen tijdzone instellen, mits er beschikbare tijdzones zijn gedefinieerd in de datum- en tijdinstellingen."
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-msgstr ""
+msgstr "Het hier ingevoerde kortingspercentage wordt toegepast op de prijzen voor klanten die zijn gemarkeerd als 'leden', doorgaans coöperatieve leden of partners die deze korting verdienen"
 
 #: bika/lims/browser/publish/emailview.py:179
 msgid "The email 'From' address is invalid. Please verify the \"Publication 'From' address\" in Setup > Notifications and/or the \"Site 'From' address\" in Site Setup > Mail."
-msgstr ""
+msgstr "Het 'Van'-e-mailadres is ongeldig. Controleer het \"Publicatie-'Van'-adres\" in Instellingen > Meldingen en/of het \"Site-'Van'-adres\" in Site-instellingen > E-mail."
 
 #: bika/lims/content/analysisrequest.py:940
 msgid "The environmental condition during sampling"
-msgstr ""
+msgstr "De omgevingsconditie tijdens de monstername"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:104
 msgid "The fields are always listed on top and can not be faded out. You can drag and drop any fields to the lower list to change thier visibility."
-msgstr ""
+msgstr "De velden worden altijd bovenaan weergegeven en kunnen niet worden verborgen. U kunt velden naar de onderste lijst slepen om hun zichtbaarheid te wijzigen."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:150
 msgid "The fields are listed below the promient fields and can be faded out. You can drag and drop any fields to the upper list to change their visibility."
-msgstr ""
+msgstr "De velden worden onder de prominente velden weergegeven en kunnen worden verborgen. U kunt velden naar de bovenste lijst slepen om hun zichtbaarheid te wijzigen."
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:20
 msgid "The following partitions have been created from this Sample:"
-msgstr ""
+msgstr "De volgende partities zijn aangemaakt op basis van dit monster:"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:47
 msgid "The following sample(s) will be dispatched"
-msgstr ""
+msgstr "De volgende monster(s) worden verzonden"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr "De volgende monster(s) worden afgevoerd"
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
-msgstr ""
+msgstr "Het globale auditlogboek toont alle wijzigingen van het systeem. Indien ingeschakeld, worden alle entiteiten geïndexeerd in een aparte catalogus. Dit verlengt de tijd bij het aanmaken of wijzigen van objecten."
 
 #: bika/lims/content/samplepoint.py:75
 msgid "The height or depth at which the sample has to be taken"
-msgstr ""
+msgstr "De hoogte of diepte waarop het monster moet worden genomen"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
-msgstr ""
+msgstr "De houdbaarheidstijd voor dit monster en deze analyse is verstreken. Doorgaan met de analyse kan de betrouwbaarheid van de resultaten in gevaar brengen."
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
-msgstr ""
+msgstr "De houdbaarheidstijd voor dit monster en deze analyse verloopt binnenkort. Voltooi de analyse zo snel mogelijk om de nauwkeurigheid en betrouwbaarheid van de gegevens te waarborgen."
 
 #: bika/lims/content/instrument.py:309
 #: bika/lims/content/instrumentcertification.py:58
 msgid "The instrument's ID in the lab's asset register"
-msgstr ""
+msgstr "De ID van het instrument in het inventarisregister van het lab"
 
 #: bika/lims/content/instrument.py:138
 msgid "The instrument's model number"
-msgstr ""
+msgstr "Het modelnummer van het instrument"
 
 #: bika/lims/content/instrumentcertification.py:111
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
-msgstr ""
+msgstr "Het interval wordt berekend vanaf het veld 'Van' en bepaalt na hoeveel dagen het certificaat verloopt. Het instellen van dit interval overschrijft het veld 'Tot' bij opslaan."
 
 #: senaite/core/browser/samples/invalidate_samples.py:121
 msgid "The invalidation process has been successfully cancelled."
-msgstr ""
+msgstr "Het ongeldigverklaringsproces is met succes geannuleerd."
 
 #: bika/lims/browser/accreditation.py:71
 msgid "The lab is not accredited, or accreditation has not been configured. "
-msgstr ""
+msgstr "Het lab is niet geaccrediteerd, of de accreditatie is niet geconfigureerd. "
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:90
 msgid "The main language of the site."
-msgstr ""
+msgstr "De hoofdtaal van de site."
 
 #: bika/lims/content/sampletype.py:166
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
-msgstr ""
+msgstr "Het minimale monstervolume dat nodig is voor analyse, bijv. '10 ml' of '1 kg'."
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:40
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
-msgstr ""
+msgstr "De opslag van de nummergenerator is leeg. Tellers worden geïnitialiseerd bij de eerste ID-generatie voor elk voorvoegsel."
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
-msgstr ""
+msgstr "Het aantal dagen voordat een monster verloopt en niet meer kan worden geanalyseerd. Deze instelling kan per afzonderlijk monstertype worden overschreven in de instellingen voor monstertypen"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-msgstr ""
+msgstr "Het aantal minuten voordat een gebruiker automatisch wordt afgemeld. 0 schakelt automatisch afmelden uit"
 
 #: bika/lims/content/sampletype.py:117
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
-msgstr ""
+msgstr "De periode gedurende welke niet-geconserveerde monsters van dit type kunnen worden bewaard voordat ze verlopen en niet verder kunnen worden geanalyseerd"
 
 #: bika/lims/content/analysisrequest.py:644
 msgid "The person who preserved the sample"
-msgstr ""
+msgstr "De persoon die het monster heeft geconserveerd"
 
 #: bika/lims/content/analysisrequest.py:477
 msgid "The person who took the sample"
-msgstr ""
+msgstr "De persoon die het monster heeft genomen"
 
 #: bika/lims/content/abstractbaseanalysis.py:562
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
-msgstr ""
+msgstr "De prijs die per analyse in rekening wordt gebracht voor klanten die in aanmerking komen voor volumekortingen"
 
 #: bika/lims/content/analysisprofile.py:92
 msgid "The profile's commercial ID for accounting purposes."
-msgstr ""
+msgstr "De commerciële ID van het profiel voor boekhoudkundige doeleinden."
 
 #: bika/lims/content/analysisprofile.py:52
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
-msgstr ""
+msgstr "Het sleutelwoord van het profiel wordt gebruikt om het uniek te identificeren in importbestanden. Het moet uniek zijn en mag niet hetzelfde zijn als een ID van een tussentijds berekeningsveld."
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:23
 msgid "The ranges for the following analyses have been manually changed and they are no longer compliant with the ranges of the Specification:"
-msgstr ""
+msgstr "De bereiken voor de volgende analyses zijn handmatig gewijzigd en voldoen niet langer aan de bereiken van de specificatie:"
 
 #: bika/lims/content/laboratory.py:153
 msgid "The reference code issued to the lab by the accreditation body"
-msgstr ""
+msgstr "De referentiecode die door de accreditatie-instantie aan het lab is toegekend"
 
 #: bika/lims/content/calculation.py:171
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
-msgstr ""
+msgstr "Het resultaat nadat de berekening met testwaarden heeft plaatsgevonden. U moet de berekening opslaan voordat deze waarde wordt berekend."
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
-msgstr ""
+msgstr "Het resultaat is vastgelegd na de houdbaarheidstijdlimiet."
 
 #: bika/lims/content/method.py:149
 msgid "The results for the Analysis Services that use this method can be set manually"
-msgstr ""
+msgstr "De resultaten voor de analysediensten die deze methode gebruiken, kunnen handmatig worden ingesteld"
 
 #: bika/lims/content/abstractbaseanalysis.py:514
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
-msgstr ""
+msgstr "De resultaten van veldanalyses worden vastgelegd tijdens de monstername op het monsterpunt, bijv. de temperatuur van een watermonster in de rivier waar het wordt genomen. Labanalyses worden in het laboratorium uitgevoerd"
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:8
 msgid "The sample cannot be received"
-msgstr ""
+msgstr "Het monster kan niet worden ontvangen"
 
 #: bika/lims/content/artemplate.py:110
 msgid "The sample is a mix of sub samples"
-msgstr ""
+msgstr "Het monster is een mengsel van submonsters"
 
 #: bika/lims/content/instrument.py:146
 msgid "The serial number that uniquely identifies the instrument"
-msgstr ""
+msgstr "Het serienummer dat het instrument uniek identificeert"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
-msgstr ""
+msgstr "De ID van het analytische protocol van de dienst"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
-msgstr ""
+msgstr "De commerciële ID van de dienst voor boekhoudkundige doeleinden"
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:14
 msgid "The specification has a Dynamic Specification assigned"
-msgstr ""
+msgstr "Aan de specificatie is een dynamische specificatie toegewezen"
 
 #: senaite/core/schema/emailfield.py:12
 msgid "The specified email is not valid."
-msgstr ""
+msgstr "Het opgegeven e-mailadres is niet geldig."
 
 #: bika/lims/content/referencesample.py:65
 msgid "The unique identifier for this reference sample. If specified, the system will use this value as the sample's ID instead of automatically generating one based on the formatting rules defined in the setup's ID server."
-msgstr ""
+msgstr "De unieke identificatie voor dit referentiemonster. Indien opgegeven, gebruikt het systeem deze waarde als de ID van het monster in plaats van er automatisch een te genereren op basis van de opmaakregels die zijn gedefinieerd in de ID-server van de instellingen."
 
 #: bika/lims/content/abstractbaseanalysis.py:363
 msgid "The unique keyword used to identify the analysis service in import files of bulk Sample requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
-msgstr ""
+msgstr "Het unieke sleutelwoord dat wordt gebruikt om de analysedienst te identificeren in importbestanden van bulk-monsteraanvragen en resultaatimports van instrumenten. Het wordt ook gebruikt om afhankelijke analysediensten te identificeren in door de gebruiker gedefinieerde resultaatberekeningen"
 
 #: bika/lims/browser/analysisrequest/add2.py:1461
 msgid "The value of field '%s' was emptied. Please select a new value."
-msgstr ""
+msgstr "De waarde van veld '%s' is leeggemaakt. Selecteer een nieuwe waarde."
 
 #: bika/lims/browser/publish/templates/email.pt:126
 msgid "The variable ${recipients} will be automatically replaced with the names and emails of the final selected recipients."
-msgstr ""
+msgstr "De variabele ${recipients} wordt automatisch vervangen door de namen en e-mailadressen van de uiteindelijk geselecteerde ontvangers."
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:93
 msgid "There are no pre-defined conditions set"
-msgstr ""
+msgstr "Er zijn geen vooraf gedefinieerde voorwaarden ingesteld"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:14
 msgid "This Analysis Specification has a Dynamic Specification assigned"
-msgstr ""
+msgstr "Aan deze analysespecificatie is een dynamische specificatie toegewezen"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:15
 msgid "This Sample has been rejected due to the following reasons:"
-msgstr ""
+msgstr "Dit monster is afgewezen om de volgende redenen:"
 
 #: bika/lims/browser/viewlets/templates/partition_ar_viewlet.pt:14
 msgid "This is a Partition from Sample"
-msgstr ""
+msgstr "Dit is een partitie van monster"
 
 #: bika/lims/browser/viewlets/templates/secondary_ar_viewlet.pt:15
 msgid "This is a Secondary Sample of"
-msgstr ""
+msgstr "Dit is een secundair monster van"
 
 #: bika/lims/browser/viewlets/templates/detached_partition_viewlet.pt:15
 msgid "This is a detached partition from Sample"
-msgstr ""
+msgstr "Dit is een losgekoppelde partitie van monster"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
-msgstr ""
+msgstr "Dit is de standaard maximale tijd die is toegestaan voor het uitvoeren van analyses. Deze wordt alleen gebruikt voor analyses waarbij de analysedienst geen doorlooptijd opgeeft. Alleen laboratoriumwerkdagen worden in aanmerking genomen."
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
-msgstr ""
+msgstr "Dit is de standaard maximale tijd die is toegestaan voor het uitvoeren van analyses. Deze wordt alleen gebruikt voor analyses waarbij de analysedienst geen doorlooptijd opgeeft. Alleen laboratoriumwerkdagen worden in aanmerking genomen."
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:134
 msgid "This operation can not be undone. Are you sure you want to reject the selected analyses?"
-msgstr ""
+msgstr "Deze bewerking kan niet ongedaan worden gemaakt. Weet u zeker dat u de geselecteerde analyses wilt afwijzen?"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:14
 msgid "This report was sent to the following contacts:"
-msgstr ""
+msgstr "Dit rapport is verzonden naar de volgende contactpersonen:"
 
 #: bika/lims/browser/viewlets/templates/retest_ar_viewlet.pt:19
 msgid "This sample is a retest, automatically generated following the invalidation of sample ${invalidated_id}."
-msgstr ""
+msgstr "Dit monster is een hertest, automatisch gegenereerd na de ongeldigverklaring van monster ${invalidated_id}."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:28
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date} for the following reason(s): ${reason}."
-msgstr ""
+msgstr "Dit monster is ongeldig verklaard door ${actor_fullname} (${actor_id}) op ${date} om de volgende reden(en): ${reason}."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:38
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
-msgstr ""
+msgstr "Dit monster is ongeldig verklaard door ${actor_fullname} (${actor_id}) op ${date}."
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
-msgstr ""
+msgstr "Deze dienst kan niet worden geselecteerd om te voorkomen dat de analyse wordt uitgevoerd na de analytische houdbaarheidstijd."
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
-msgstr ""
+msgstr "Dit toont een aangepast logo op uw SENAITE-site."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:57
 msgid "This site configuration is outdated and needs to be upgraded:"
-msgstr ""
+msgstr "Deze siteconfiguratie is verouderd en moet worden bijgewerkt:"
 
 #: bika/lims/content/laboratory.py:100
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
+msgstr "Deze waarde wordt onderaan alle gepubliceerde resultaten vermeld"
 
 #: bika/lims/browser/worksheet/tools.py:84
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
-msgstr ""
+msgstr "Dit werkblad is aangemaakt ter vervanging van het afgewezen werkblad bij ${ws_id}"
 
 #: bika/lims/browser/worksheet/tools.py:77
 msgid "This worksheet has been rejected.  The replacement worksheet is ${ws_id}"
-msgstr ""
+msgstr "Dit werkblad is afgewezen. Het vervangende werkblad is ${ws_id}"
 
 #: senaite/core/vocabularies/setup.py:159
 msgid "Thursday"
-msgstr ""
+msgstr "Donderdag"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:47
 msgid "Time"
-msgstr ""
+msgstr "Tijd"
 
 #: senaite/core/exportimport/import.pt:129
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
-msgstr ""
+msgstr "Tip. Bijgevoegde documenten worden niet geladen tenzij ze aanwezig zijn in de instantie."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
-msgstr ""
+msgstr "Titel"
 
 #: bika/lims/content/storagelocation.py:54
 msgid "Title of location"
-msgstr ""
+msgstr "Titel van locatie"
 
 #: bika/lims/controlpanel/dynamic_analysisspecs.py:35
 msgid "Title of the Folder"
-msgstr ""
+msgstr "Titel van de map"
 
 #: bika/lims/content/storagelocation.py:74
 msgid "Title of the shelf"
-msgstr ""
+msgstr "Titel van de legplank"
 
 #: bika/lims/content/storagelocation.py:39
 msgid "Title of the site"
-msgstr ""
+msgstr "Titel van de site"
 
 #: bika/lims/content/instrumentcalibration.py:88
 #: bika/lims/content/instrumentmaintenancetask.py:75
 #: bika/lims/content/instrumentvalidation.py:70
 msgid "To"
-msgstr ""
+msgstr "Tot"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
-msgstr ""
+msgstr "Te conserveren"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
-msgstr ""
+msgstr "Te bemonsteren"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr "Te publiceren"
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr "Te verifiëren"
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
-msgstr ""
+msgstr "Om onder elke analysecategoriesectie op resultaatrapporten te worden weergegeven."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
-msgstr ""
+msgstr "Te conserveren"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
-msgstr ""
+msgstr "Af te drukken"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
-msgstr ""
+msgstr "Te bemonsteren"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
-msgstr ""
+msgstr "Te verifiëren"
 
 #: bika/lims/content/calculation.py:157
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
-msgstr ""
+msgstr "Voer hier waarden in voor alle berekeningsparameters om de berekening te testen. Dit omvat hierboven gedefinieerde tussentijdse velden, evenals eventuele diensten waarvan deze berekening afhankelijk is om resultaten te berekenen."
 
 #: senaite/core/registry/schema.py:174
 msgid "Toggle visibility of standard sample header fields"
-msgstr ""
+msgstr "Zichtbaarheid van standaard monsterkopvelden in-/uitschakelen"
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
-msgstr ""
+msgstr "Totaal"
 
 #: bika/lims/content/analysisprofile.py:142
 #: bika/lims/content/labproduct.py:67
 msgid "Total price"
-msgstr ""
+msgstr "Totaalprijs"
 
 #: bika/lims/browser/publish/emailview.py:202
 msgid "Total size of email exceeded {:.1f} MB ({:.2f} MB)"
-msgstr ""
+msgstr "Totale grootte van de e-mail overschreed {:.1f} MB ({:.2f} MB)"
 
 #: bika/lims/config.py:126
 msgid "Transposed"
-msgstr ""
+msgstr "Getransponeerd"
 
 #: senaite/core/vocabularies/setup.py:157
 msgid "Tuesday"
-msgstr ""
+msgstr "Dinsdag"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:64
 msgid "Type of control to be displayed on value entry when choices are set"
-msgstr ""
+msgstr "Type besturingselement dat bij waarde-invoer wordt weergegeven wanneer keuzes zijn ingesteld"
 
 #: bika/lims/content/multifile.py:74
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
-msgstr ""
+msgstr "Type document (bijv. gebruikershandleiding, instrumentspecificaties, afbeelding, ...)"
 
 #: bika/lims/content/storagelocation.py:69
 msgid "Type of location"
-msgstr ""
+msgstr "Type locatie"
 
 #: senaite/core/content/samplecontainer.py:73
 msgid "Type of the container"
-msgstr ""
+msgstr "Type van de container"
 
 #: senaite/core/browser/controlpanel/templates/setupview.pt:27
 msgid "Type to filter ..."
-msgstr ""
+msgstr "Typ om te filteren ..."
+
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr "Typ om te filteren..."
 
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
-msgstr ""
+msgstr "Typen die labels rechtstreeks ondersteunen.<br/>OPMERKING: In clusteropstellingen moeten andere instanties handmatig opnieuw worden gestart om de wijzigingen door te voeren!"
 
 #: senaite/core/registry/schema.py:77
 msgid "Types with labels"
-msgstr ""
+msgstr "Typen met labels"
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
-msgstr ""
+msgstr "UID"
 
 #: bika/lims/browser/worksheet/views/printview.py:151
 msgid "Unable to load the template"
-msgstr ""
+msgstr "Kan het sjabloon niet laden"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassign"
-msgstr ""
+msgstr "Toewijzing opheffen"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
-msgstr ""
+msgstr "Niet toegewezen"
 
 #: senaite/core/browser/modals/analysis/schema.py:61
 msgid "Uncertainty"
-msgstr ""
+msgstr "Onzekerheid"
 
 #: bika/lims/content/abstractbaseanalysis.py:622
 msgid "Uncertainty value"
-msgstr ""
+msgstr "Onzekerheidswaarde"
 
 #: bika/lims/content/department.py:45
 msgid "Unique Department ID that identifies the department"
-msgstr ""
+msgstr "Unieke afdelings-ID die de afdeling identificeert"
 
 #: senaite/core/browser/modals/analysis/schema.py:96
 msgid "Unit"
-msgstr ""
+msgstr "Eenheid"
 
 #: senaite/core/browser/clients/client/attachments/view.py:125
 msgid "Unknown"
-msgstr ""
+msgstr "Onbekend"
 
 #: senaite/core/content/supplier.py:156
 msgid "Unknown IBAN country %s"
-msgstr ""
+msgstr "Onbekend IBAN-land %s"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:108
 msgid "Unlink User"
-msgstr ""
+msgstr "Gebruiker ontkoppelen"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
-msgstr ""
+msgstr "Ontkoppelde gebruiker"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr "Ontgrendelen"
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
-msgstr ""
+msgstr "Niet-herkend bestandsformaat ${file_format}"
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:51
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:63
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:51
 msgid "Unrecognized file format ${fileformat}"
-msgstr ""
+msgstr "Niet-herkend bestandsformaat ${fileformat}"
 
 #: senaite/core/exportimport/instruments/horiba/jobinyvon/icp.py:57
 msgid "Unrecognized file format ${format}"
-msgstr ""
+msgstr "Niet-herkend bestandsformaat ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
-msgstr ""
+msgstr "Niet toegewezen"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
-msgstr ""
+msgstr "Bijlagen bijwerken"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr "Voorinstelling bijwerken met huidige weergave"
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
-msgstr ""
+msgstr "{} sleutel(s) bijgewerkt: {}"
 
 #: bika/lims/content/labcontact.py:47
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
-msgstr ""
+msgstr "Upload een gescande handtekening voor gebruik op afgedrukte analyseresultaatrapporten. De ideale grootte is 250 pixels breed bij 150 pixels hoog"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
-msgstr ""
+msgstr "Upload bestanden en afbeeldingen voor deze klant. Bestanden worden opgeslagen in de klantmap en kunnen later worden gedownload."
 
 #: bika/lims/content/analysisprofile.py:101
 msgid "Use Analysis Profile Price"
-msgstr ""
+msgstr "Analyseprofielprijs gebruiken"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
-msgstr ""
+msgstr "Dashboard als standaard startpagina gebruiken"
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:84
 msgid "Use Template"
-msgstr ""
+msgstr "Sjabloon gebruiken"
 
 #: bika/lims/content/analysisservice.py:87
 msgid "Use the Default Calculation of Method"
-msgstr ""
+msgstr "De standaardberekening van de methode gebruiken"
 
 #: bika/lims/content/instrument.py:292
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
-msgstr ""
+msgstr "Gebruik dit veld om willekeurige parameters door te geven aan de export-/importmodules."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:71
 #: senaite/core/browser/clients/client/contacts/view.py:74
 #: senaite/core/browser/controlpanel/contacts/view.py:62
 msgid "User Name"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:101
 msgid "User groups"
-msgstr ""
+msgstr "Gebruikersgroepen"
 
 #: senaite/core/browser/user/userdatapanel.py:181
 msgid "User is linked to lab contact '${fullname}'"
-msgstr ""
+msgstr "Gebruiker is gekoppeld aan labcontactpersoon '${fullname}'"
 
 #: senaite/core/browser/user/userdatapanel.py:192
 msgid "User is linked to the contact '${fullname}'"
-msgstr ""
+msgstr "Gebruiker is gekoppeld aan contactpersoon '${fullname}'"
 
 #: senaite/core/browser/user/userdatapanel.py:189
 msgid "User is linked to the global contact '${fullname}'"
-msgstr ""
+msgstr "Gebruiker is gekoppeld aan de globale contactpersoon '${fullname}'"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
-msgstr ""
+msgstr "Gebruiker gekoppeld aan deze contactpersoon"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:98
 msgid "User name"
-msgstr ""
+msgstr "Gebruikersnaam"
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
-msgstr ""
+msgstr "Gebruikersnaam"
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-msgstr ""
+msgstr "Te weinig datapunten gebruiken is statistisch niet zinvol. Stel een aanvaardbaar minimumaantal resultaten in voordat QC-statistieken worden berekend en uitgezet"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
-msgstr ""
+msgstr "Btw"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
-msgstr ""
+msgstr "Btw %"
 
 #: bika/lims/content/organisation.py:52
 msgid "VAT number"
-msgstr ""
+msgstr "Btw-nummer"
 
 #: bika/lims/browser/analyses/view.py:223
 msgid "Valid"
-msgstr ""
+msgstr "Geldig"
 
 #: bika/lims/browser/instrument.py:662
 #: bika/lims/content/instrumentcertification.py:126
 msgid "Valid from"
-msgstr ""
+msgstr "Geldig vanaf"
 
 #: bika/lims/browser/instrument.py:663
 #: bika/lims/content/instrumentcertification.py:136
 msgid "Valid to"
-msgstr ""
+msgstr "Geldig tot"
 
 #: bika/lims/content/instrumentscheduledtask.py:122
 msgid "Validation"
-msgstr ""
+msgstr "Validatie"
 
 #: senaite/core/z3cform/error.py:32
 msgid "Validation failed."
-msgstr ""
+msgstr "Validatie mislukt."
 
 #: bika/lims/validators.py:346
 msgid "Validation failed: '${keyword}': duplicate keyword"
-msgstr ""
+msgstr "Validatie mislukt: '${keyword}': dubbel sleutelwoord"
 
 #: bika/lims/validators.py:365
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
-msgstr ""
+msgstr "Validatie mislukt: '${title}': Dit sleutelwoord is al in gebruik door dienst '${used_by}'"
 
 #: bika/lims/validators.py:354
 msgid "Validation failed: '${title}': duplicate title"
-msgstr ""
+msgstr "Validatie mislukt: '${title}': dubbele titel"
 
 #: bika/lims/validators.py:206
 msgid "Validation failed: '${value}' is not unique"
-msgstr ""
+msgstr "Validatie mislukt: '${value}' is niet uniek"
 
 #: bika/lims/validators.py:1465
 msgid "Validation failed: '{}' is not numeric"
-msgstr ""
+msgstr "Validatie mislukt: '{}' is niet numeriek"
 
 #: bika/lims/validators.py:624
 msgid "Validation failed: Bearing must be E/W"
-msgstr ""
+msgstr "Validatie mislukt: Peiling moet O/W zijn"
 
 #: bika/lims/validators.py:605
 msgid "Validation failed: Bearing must be N/S"
-msgstr ""
+msgstr "Validatie mislukt: Peiling moet N/Z zijn"
 
 #: bika/lims/validators.py:1350
 msgid "Validation failed: Could not import module '%s'"
-msgstr ""
+msgstr "Validatie mislukt: Kon module '%s' niet importeren"
 
 #: bika/lims/validators.py:966
 msgid "Validation failed: Error percentage must be between 0 and 100"
-msgstr ""
+msgstr "Validatie mislukt: Foutpercentage moet tussen 0 en 100 liggen"
 
 #: bika/lims/validators.py:982
 msgid "Validation failed: Error value must be 0 or greater"
-msgstr ""
+msgstr "Validatie mislukt: Foutwaarde moet 0 of groter zijn"
 
 #: bika/lims/validators.py:959
 msgid "Validation failed: Error values must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: Foutwaarden moeten numeriek zijn"
 
 #: bika/lims/validators.py:499
 msgid "Validation failed: Keyword '${keyword}' is invalid"
-msgstr ""
+msgstr "Validatie mislukt: Sleutelwoord '${keyword}' is ongeldig"
 
 #: bika/lims/validators.py:974
 msgid "Validation failed: Max values must be greater than Min values"
-msgstr ""
+msgstr "Validatie mislukt: Max-waarden moeten groter zijn dan Min-waarden"
 
 #: bika/lims/validators.py:944
 msgid "Validation failed: Max values must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: Max-waarden moeten numeriek zijn"
 
 #: bika/lims/validators.py:937
 msgid "Validation failed: Min values must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: Min-waarden moeten numeriek zijn"
 
 #: bika/lims/validators.py:1451
 msgid "Validation failed: Please set a default value when defining a required checkbox condition."
-msgstr ""
+msgstr "Validatie mislukt: Stel een standaardwaarde in bij het definiëren van een verplichte selectievakjevoorwaarde."
 
 #: bika/lims/validators.py:1445
 msgid "Validation failed: Please use the character '|' to separate the available options in 'Choices' subfield"
-msgstr ""
+msgstr "Validatie mislukt: Gebruik het teken '|' om de beschikbare opties in het subveld 'Keuzes' te scheiden"
 
 #: bika/lims/validators.py:770
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
-msgstr ""
+msgstr "Validatie mislukt: Voorgeconserveerde containers moeten een conservering geselecteerd hebben."
 
 #: bika/lims/validators.py:728
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
-msgstr ""
+msgstr "Validatie mislukt: De selectie vereist dat de volgende categorieën worden geselecteerd: ${categories}"
 
 #: bika/lims/validators.py:1014
 msgid "Validation failed: Values must be numbers"
-msgstr ""
+msgstr "Validatie mislukt: Waarden moeten getallen zijn"
 
 #: bika/lims/validators.py:393
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
-msgstr ""
+msgstr "Validatie mislukt: kolomtitel '${title}' moet sleutelwoord '${keyword}' hebben"
 
 #: bika/lims/validators.py:615
 msgid "Validation failed: degrees is 180; minutes must be zero"
-msgstr ""
+msgstr "Validatie mislukt: graden is 180; minuten moeten nul zijn"
 
 #: bika/lims/validators.py:620
 msgid "Validation failed: degrees is 180; seconds must be zero"
-msgstr ""
+msgstr "Validatie mislukt: graden is 180; seconden moeten nul zijn"
 
 #: bika/lims/validators.py:596
 msgid "Validation failed: degrees is 90; minutes must be zero"
-msgstr ""
+msgstr "Validatie mislukt: graden is 90; minuten moeten nul zijn"
 
 #: bika/lims/validators.py:601
 msgid "Validation failed: degrees is 90; seconds must be zero"
-msgstr ""
+msgstr "Validatie mislukt: graden is 90; seconden moeten nul zijn"
 
 #: bika/lims/validators.py:610
 msgid "Validation failed: degrees must be 0 - 180"
-msgstr ""
+msgstr "Validatie mislukt: graden moeten 0 - 180 zijn"
 
 #: bika/lims/validators.py:591
 msgid "Validation failed: degrees must be 0 - 90"
-msgstr ""
+msgstr "Validatie mislukt: graden moeten 0 - 90 zijn"
 
 #: bika/lims/validators.py:564
 msgid "Validation failed: degrees must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: graden moeten numeriek zijn"
 
 #: bika/lims/validators.py:405
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord '${keyword}' moet kolomtitel '${title}' hebben"
 
 #: senaite/core/api/analysisservice.py:172
 msgid "Validation failed: keyword contains invalid characters"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord bevat ongeldige tekens"
 
 #: senaite/core/api/analysisservice.py:177
 msgid "Validation failed: keyword is already in use"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord is al in gebruik"
 
 #: senaite/core/api/analysisservice.py:187
 msgid "Validation failed: keyword is already in use by calculation '{}'"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord is al in gebruik door berekening '{}'"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:95
 #: bika/lims/validators.py:324
 msgid "Validation failed: keyword is required"
-msgstr ""
+msgstr "Validatie mislukt: sleutelwoord is verplicht"
 
 #: bika/lims/validators.py:580
 msgid "Validation failed: minutes must be 0 - 59"
-msgstr ""
+msgstr "Validatie mislukt: minuten moeten 0 - 59 zijn"
 
 #: bika/lims/validators.py:570
 msgid "Validation failed: minutes must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: minuten moeten numeriek zijn"
 
 #: bika/lims/validators.py:1042
 msgid "Validation failed: percent values must be between 0 and 100"
-msgstr ""
+msgstr "Validatie mislukt: procentwaarden moeten tussen 0 en 100 liggen"
 
 #: bika/lims/validators.py:1038
 msgid "Validation failed: percent values must be numbers"
-msgstr ""
+msgstr "Validatie mislukt: procentwaarden moeten getallen zijn"
 
 #: bika/lims/validators.py:584
 msgid "Validation failed: seconds must be 0 - 59"
-msgstr ""
+msgstr "Validatie mislukt: seconden moeten 0 - 59 zijn"
 
 #: bika/lims/validators.py:576
 msgid "Validation failed: seconds must be numeric"
-msgstr ""
+msgstr "Validatie mislukt: seconden moeten numeriek zijn"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:88
 #: bika/lims/validators.py:320
 msgid "Validation failed: title is required"
-msgstr ""
+msgstr "Validatie mislukt: titel is verplicht"
 
 #: bika/lims/validators.py:1456
 msgid "Validation failed: value for Choices subfield is only required for when the control type of choice is 'Select'"
-msgstr ""
+msgstr "Validatie mislukt: waarde voor subveld Keuzes is alleen vereist wanneer het besturingstype van de keuze 'Select' is"
 
 #: bika/lims/validators.py:1438
 msgid "Validation failed: value for Choices subfield is required when the control type of choice is 'Select'"
-msgstr ""
+msgstr "Validatie mislukt: waarde voor subveld Keuzes is vereist wanneer het besturingstype van de keuze 'Select' is"
 
 #: senaite/core/content/analysiscategory.py:122
 #: senaite/core/content/subgroup.py:82
 msgid "Validation failed: value must be between 0 and 1000"
-msgstr ""
+msgstr "Validatie mislukt: waarde moet tussen 0 en 1000 liggen"
 
 #: senaite/core/content/analysiscategory.py:118
 #: senaite/core/content/subgroup.py:78
 msgid "Validation failed: value must be float"
-msgstr ""
+msgstr "Validatie mislukt: waarde moet een decimaal getal zijn"
 
 #: bika/lims/content/instrumentvalidation.py:51
 msgid "Validation report date"
-msgstr ""
+msgstr "Datum validatierapport"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Validations"
-msgstr ""
+msgstr "Validaties"
 
 #: bika/lims/browser/instrument.py:318
 #: bika/lims/content/instrumentvalidation.py:78
 msgid "Validator"
-msgstr ""
+msgstr "Validator"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:206
 msgid "Value"
-msgstr ""
+msgstr "Waarde"
 
 #: senaite/core/schema/coordinatefield.py:109
 msgid "Value for degrees must be within 0 and 180"
-msgstr ""
+msgstr "Waarde voor graden moet tussen 0 en 180 liggen"
 
 #: senaite/core/schema/coordinatefield.py:93
 msgid "Value for degrees must be within 0 and 90"
-msgstr ""
+msgstr "Waarde voor graden moet tussen 0 en 90 liggen"
 
 #: senaite/core/schema/coordinatefield.py:68
 msgid "Value for minutes must be within 0 and 59"
-msgstr ""
+msgstr "Waarde voor minuten moet tussen 0 en 59 liggen"
 
 #: senaite/core/schema/coordinatefield.py:77
 msgid "Value for seconds must be within 0 and 59.9999"
-msgstr ""
+msgstr "Waarde voor seconden moet tussen 0 en 59.9999 liggen"
 
 #: bika/lims/content/abstractanalysis.py:183
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
-msgstr ""
+msgstr "Hier kunnen waarden worden ingevoerd die de standaardwaarden overschrijven die zijn opgegeven in de tussenvelden van de berekening."
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
-msgstr ""
+msgstr "Geverifieerd"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:133
 msgid "Verified By"
-msgstr ""
+msgstr "Geverifieerd door"
+
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr "Geverifieerde monsters klaar om te publiceren"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
-msgstr ""
+msgstr "Verifiëren"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr "Resultaten verifiëren"
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
 #: bika/lims/controlpanel/auditlog.py:72
 msgid "Version"
-msgstr ""
+msgstr "Versie"
 
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "View"
-msgstr ""
+msgstr "Weergeven"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
-msgstr ""
+msgstr "Bekijk uw SENAITE-site"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr "Zichtbaar"
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr "Zichtbare / totale kolommen"
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
-msgstr ""
+msgstr "Zichtbare velden"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:24
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:24
 msgid "Visit the Dynamic Specification for additional information:"
-msgstr ""
+msgstr "Bezoek de dynamische specificatie voor aanvullende informatie:"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:28
 msgid "Visit the Specification's changes history for additional information:"
-msgstr ""
+msgstr "Bezoek de wijzigingsgeschiedenis van de specificatie voor aanvullende informatie:"
 
 #: bika/lims/content/labproduct.py:36
 msgid "Volume"
-msgstr ""
+msgstr "Volume"
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:17
 msgid "Warning"
-msgstr ""
+msgstr "Waarschuwing"
 
 #: bika/lims/content/laboratory.py:132
 msgid "Web address for the accreditation body"
-msgstr ""
+msgstr "Webadres van de accreditatie-instantie"
 
 #: bika/lims/content/supplier.py:52
 msgid "Website"
-msgstr ""
+msgstr "Website"
 
 #: senaite/core/vocabularies/setup.py:158
 msgid "Wednesday"
-msgstr ""
+msgstr "Woensdag"
+
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr "Wekelijks"
 
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
-msgstr ""
+msgstr "Weken tot vervaldatum"
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:7
 msgid "Welcome"
-msgstr ""
+msgstr "Welkom"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:14
 msgid "Welcome to SENAITE"
-msgstr ""
+msgstr "Welkom bij SENAITE"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-msgstr ""
+msgstr "Indien ingeschakeld hebben analisten alleen toegang tot werkbladen waaraan ze zijn toegewezen. Indien uitgeschakeld hebben analisten toegang tot alle werkbladen."
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-msgstr ""
+msgstr "Indien ingeschakeld kunnen alleen labmanagers werkbladen aanmaken en beheren. Indien uitgeschakeld kunnen ook analisten en labmedewerkers werkbladen beheren. Let op: Deze instelling wordt automatisch ingeschakeld en vergrendeld wanneer de toegang tot werkbladen is beperkt tot toegewezen analisten."
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-msgstr ""
+msgstr "Indien ingeschakeld wordt het monster automatisch geverifieerd zodra alle resultaten zijn geverifieerd. Anders moeten gebruikers met voldoende rechten het monster daarna handmatig verifiëren. Standaard: ingeschakeld"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-msgstr ""
+msgstr "Indien ingeschakeld kunnen gebruikers resultaten indienen voor analyses die niet aan hen zijn toegewezen of voor niet-toegewezen analyses. Indien uitgeschakeld kunnen gebruikers alleen resultaten indienen voor analyses die aan henzelf zijn toegewezen. Deze instelling geldt niet voor gebruikers met de rol Labmanager."
 
 #: bika/lims/content/analysisprofile.py:102
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
-msgstr ""
+msgstr "Wanneer dit is ingesteld, gebruikt het systeem de prijs van het analyseprofiel voor de offerte en wordt de btw van het systeem overschreven door de specifieke btw van het analyseprofiel"
 
 #: bika/lims/content/abstractbaseanalysis.py:480
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
-msgstr ""
+msgstr "Wanneer de resultaten van duplicaatanalyses op werkbladen, uitgevoerd op hetzelfde monster, meer dan dit percentage verschillen, wordt een waarschuwing gegeven"
 
 #: bika/lims/validators.py:518
 msgid "Wildcards for interims are not allowed: ${wildcards}"
-msgstr ""
+msgstr "Jokertekens voor tussenvelden zijn niet toegestaan: ${wildcards}"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:20
 msgid "With best regards"
-msgstr ""
+msgstr "Met vriendelijke groet"
 
 #: bika/lims/content/instrumentcalibration.py:118
 #: bika/lims/content/instrumentmaintenancetask.py:103
 #: bika/lims/content/instrumentvalidation.py:100
 msgid "Work Performed"
-msgstr ""
+msgstr "Uitgevoerd werk"
 
 #: bika/lims/browser/auditlog.py:94
 #: bika/lims/controlpanel/auditlog.py:99
 msgid "Workflow State"
-msgstr ""
+msgstr "Workflowstatus"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Worksheet"
-msgstr ""
+msgstr "Werkblad"
 
 #: bika/lims/content/worksheettemplate.py:62
 msgid "Worksheet Layout"
-msgstr ""
+msgstr "Werkbladindeling"
 
 #: senaite/core/profiles/default/types/WorksheetTemplate.xml
 msgid "Worksheet Template"
-msgstr ""
+msgstr "Werkbladsjabloon"
 
 #: senaite/core/profiles/default/types/WorksheetTemplates.xml
 msgid "Worksheet Templates"
-msgstr ""
+msgstr "Werkbladsjablonen"
 
 #: senaite/core/registry/schema.py:109
 msgid "Worksheet printing templates order"
-msgstr ""
+msgstr "Volgorde van werkbladafdruksjablonen"
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
-msgstr ""
+msgstr "Werkbladen"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr "Werkbladen die zijn geverifieerd"
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr "Werkbladen waarvan de resultaten op verificatie wachten"
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
-msgstr ""
+msgstr "Verkeerde IBAN-lengte met %s: %s"
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
-msgstr ""
+msgstr "Verkeerde IBAN-lengte met %s: %ste kort met %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr "Jaarlijks"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
 msgid "Yes"
-msgstr ""
+msgstr "Ja"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:124
 msgid "You can add another SENAITE site:"
-msgstr ""
+msgstr "U kunt nog een SENAITE-site toevoegen:"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:109
 msgid "You can change the visibility of a field by selecting or unselecting the checkbox."
-msgstr ""
+msgstr "U kunt de zichtbaarheid van een veld wijzigen door het selectievakje aan of uit te vinken."
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:17
 msgid "You can enable the global Audit Log again in the <a href=\"${DYNAMIC_CONTENT}\">Setup</a>"
-msgstr ""
+msgstr "U kunt het globale auditlogboek opnieuw inschakelen in de <a href=\"${DYNAMIC_CONTENT}\">Instellingen</a>"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:294
 msgid "You can use the browse button to select and upload a new attachment."
-msgstr ""
+msgstr "U kunt de bladerknop gebruiken om een nieuwe bijlage te selecteren en te uploaden."
 
 #: bika/lims/browser/worksheet/tools.py:42
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
-msgstr ""
+msgstr "U hebt onvoldoende rechten om het werkblad ${worksheet_title} te bekijken."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:78
 msgid "You have multiple SENAITE sites:"
-msgstr ""
+msgstr "U hebt meerdere SENAITE-sites:"
 
 #: bika/lims/browser/worksheet/views/export.py:33
 msgid "You must select an instrument"
-msgstr ""
+msgstr "U moet een instrument selecteren"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:159
 msgid "You normally don't need to change anything here unless you have specific reasons and know what you are doing."
-msgstr ""
+msgstr "Normaal gesproken hoeft u hier niets te wijzigen, tenzij u specifieke redenen hebt en weet wat u doet."
 
 #: senaite/core/exportimport/instruments/sysmex/xs/i500.py:77
 msgid "You should introduce a default result key."
-msgstr ""
+msgstr "U moet een standaard resultaatsleutel invoeren."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:121
 msgid "Your SENAITE site has not been added yet:"
-msgstr ""
+msgstr "Uw SENAITE-site is nog niet toegevoegd:"
 
 #: bika/lims/browser/templates/referencesample_view.pt:134
 msgid "activate"
-msgstr ""
+msgstr "activeren"
 
 #. Default: "Classic"
 #: senaite/core/config/worksheet.py:25
 msgid "analyses_classic_view_name"
-msgstr ""
+msgstr "Klassiek"
 
 #. Default: "Transposed"
 #: senaite/core/config/worksheet.py:29
 msgid "analyses_transposed_view_name"
-msgstr ""
+msgstr "Getransponeerd"
 
 #. Default: "Analysis"
 #: senaite/core/config/vocabularies.py:35
 msgid "analysis_type_analysis"
-msgstr ""
+msgstr "Analyse"
 
 #. Default: "Blank"
 #: senaite/core/config/vocabularies.py:39
 msgid "analysis_type_blank"
-msgstr ""
+msgstr "Blanco"
 
 #. Default: "Control"
 #: senaite/core/config/vocabularies.py:43
 msgid "analysis_type_control"
-msgstr ""
+msgstr "Controle"
 
 #. Default: "Duplicate"
 #: senaite/core/config/vocabularies.py:47
 msgid "analysis_type_duplicate"
-msgstr ""
+msgstr "Duplicaat"
 
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
-msgstr ""
+msgstr "Analist moet worden opgegeven."
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
+msgstr "auto"
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
-msgstr ""
+msgstr "halfjaarlijks"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:48
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:48
 msgid "by"
-msgstr ""
+msgstr "door"
 
 #. in '${calc}')"
 #. Default: "keyword '${keyword}' must have column title '${title}' (defined in '${calc}')"
 #: senaite/core/validators/interimfields.py:151
+#, fuzzy
 msgid "calcs_interims_validator_dup_keyword_error"
-msgstr ""
+msgstr "sleutelwoord '${keyword}' moet kolomtitel '${title}' hebben (gedefinieerd in '${calc}')"
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:57
 msgid "change_worksheet_result_layout_message"
-msgstr ""
+msgstr "Wijzigingen opgeslagen."
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:168
 msgid "changes_saved"
-msgstr ""
+msgstr "Wijzigingen opgeslagen."
 
 #. Results edition not allowed: ${inv}"
 #. Default: "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed: ${inv}"
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:214
+#, fuzzy
 msgid "check_instrument_validity_message"
-msgstr ""
+msgstr "Sommige analyses gebruiken verouderde of niet-gekalibreerde instrumenten. Bewerken van resultaten niet toegestaan: ${inv}"
 
 #. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #. Default: "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #: senaite/core/validators/interimfields.py:211
+#, fuzzy
 msgid "choice_syntax_validation_error"
-msgstr ""
+msgstr "Geen geldig formaat in het keuzeveld. Ondersteund formaat is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #. Default: "Control type is not supported for empty choices"
 #: senaite/core/validators/interimfields.py:111
 msgid "choices_and_restype_validator_no_choices_error"
-msgstr ""
+msgstr "Besturingstype wordt niet ondersteund voor lege keuzes"
 
 #. Default: "Chosen control type not supporting choices"
 #: senaite/core/validators/interimfields.py:117
 msgid "choices_and_restype_validator_not_supported_choices_error"
-msgstr ""
+msgstr "Gekozen besturingstype ondersteunt geen keuzes"
 
 #. Default: "Empty keys are not supported"
 #: senaite/core/validators/interimfields.py:169
 msgid "choices_empty_keys_validator_error"
-msgstr ""
+msgstr "Lege sleutels worden niet ondersteund"
 
 #. Default: "At least, two options for choices field are required"
 #: senaite/core/validators/interimfields.py:195
 msgid "choices_min_items_validator_error"
-msgstr ""
+msgstr "Ten minste twee opties voor het keuzeveld zijn vereist"
 
 #. Default: "Duplicate keys in choices field"
 #: senaite/core/validators/interimfields.py:183
 msgid "choices_unique_keys_validator_error"
-msgstr ""
+msgstr "Dubbele sleutels in het keuzeveld"
 
 #: bika/lims/content/instrumentcertification.py:250
 msgid "daily"
-msgstr ""
+msgstr "dagelijks"
 
 #. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -6876,7 +7279,7 @@ msgstr ""
 #. ${b} ${d}, ${Y} ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "date_format_long"
-msgstr ""
+msgstr "${d}-${m}-${Y} ${H}:${M}"
 
 #. Default: "${Y}-${m}-${d}"
 #. The variables used here are the same as used in the strftime formating.
@@ -6887,71 +7290,83 @@ msgstr ""
 #. ${b} ${d}, ${Y}
 #: ./TranslationServiceTool.py
 msgid "date_format_short"
-msgstr ""
+msgstr "${d}-${m}-${Y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
+#. Default: "yy-mm-dd"
+#, fuzzy
 msgid "date_format_short_datepicker"
-msgstr ""
+msgstr "dd-mm-jj"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "days"
-msgstr ""
+msgstr "dagen"
 
 #: bika/lims/browser/templates/referencesample_view.pt:127
 msgid "deactivate"
-msgstr ""
+msgstr "deactiveren"
+
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr "Monster afgevoerd na de bewaartermijn."
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr "verwijderd door {user} op {time}"
 
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
-msgstr ""
+msgstr "Toegevoegde labels"
 
 #. Default: "The accreditation standard that applies, e.g. ISO 17025"
 #: senaite/core/content/laboratory.py:174
 msgid "description_accreditation"
-msgstr ""
+msgstr "De van toepassing zijnde accreditatienorm, bijv. ISO 17025"
 
 #. Default: "E.g. SANAS, APLAC, etc."
 #: senaite/core/content/laboratory.py:153
 msgid "description_accreditation_body"
-msgstr ""
+msgstr "Bijv. SANAS, APLAC, enz."
 
 #. and results reports by your accreditation body. Maximum size is 175 x 175
 #. pixels."
 #. Default: "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 #: senaite/core/content/laboratory.py:198
+#, fuzzy
 msgid "description_accreditation_body_logo"
-msgstr ""
+msgstr "Upload het logo dat u door uw accreditatie-instantie gemachtigd bent te gebruiken op uw website en resultaatrapporten. Maximale grootte is 175 x 175 pixels."
 
 #. Default: "Web address for the accreditation body"
 #: senaite/core/content/laboratory.py:163
 msgid "description_accreditation_body_url"
-msgstr ""
+msgstr "Webadres van de accreditatie-instantie"
 
 #. following fields are available: lab_is_accredited, lab_name, lab_country,
 #. confidence, accreditation_body_name, accreditation_standard,
 #. accreditation_reference"
 #. Default: "Enter the details of your lab's service accreditations here. The following fields are available: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 #: senaite/core/content/laboratory.py:220
+#, fuzzy
 msgid "description_accreditation_page_header"
-msgstr ""
+msgstr "Voer hier de gegevens van de dienstaccreditaties van uw lab in. De volgende velden zijn beschikbaar: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 
 #. Default: "The reference code issued to the lab by the accreditation body"
 #: senaite/core/content/laboratory.py:186
 msgid "description_accreditation_reference"
-msgstr ""
+msgstr "De referentiecode die door de accreditatie-instantie aan het lab is toegekend"
 
 #. Default: "The category the analysis service belongs to"
 #: bika/lims/content/abstractbaseanalysis.py:533
 msgid "description_analysis_category"
-msgstr ""
+msgstr "De categorie waartoe de analysedienst behoort"
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/abstractbaseanalysis.py:591
 msgid "description_analysis_department"
-msgstr ""
+msgstr "Selecteer de verantwoordelijke afdeling"
 
 #. registration form if the elapsed time since sample collection exceeds the
 #. holding time limit. Exceeding this time limit may result in unreliable or
@@ -6962,16 +7377,18 @@ msgstr ""
 #. view."
 #. Default: "This service will not appear for selection on the sample registration form if the elapsed time since sample collection exceeds the holding time limit. Exceeding this time limit may result in unreliable or compromised data, as the integrity of the sample can degrade over time. Consequently, any results obtained after this period may not accurately reflect the sample's true composition, impacting data validity. Note: This setting does not affect the test's availability in the 'Manage Analyses' view."
 #: bika/lims/content/abstractbaseanalysis.py:457
+#, fuzzy
 msgid "description_analysis_maxholdingtime"
-msgstr ""
+msgstr "Deze dienst verschijnt niet ter selectie op het monsterregistratieformulier als de verstreken tijd sinds de monstername de bewaartijdlimiet overschrijdt. Overschrijding van deze tijdslimiet kan leiden tot onbetrouwbare of gecompromitteerde gegevens, aangezien de integriteit van het monster in de loop van de tijd kan afnemen. Bijgevolg weerspiegelen resultaten die na deze periode worden verkregen mogelijk niet de werkelijke samenstelling van het monster, wat de geldigheid van de gegevens beïnvloedt. Let op: Deze instelling heeft geen invloed op de beschikbaarheid van de test in de weergave 'Analyses beheren'."
 
 #. in results entry listings. Note this only applies to the options displayed
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
+#, fuzzy
 msgid "description_analysis_results_options_sorting"
-msgstr ""
+msgstr "Criteria die worden gebruikt wanneer resultaatopties ter selectie worden weergegeven in lijsten voor resultaatinvoer. Let op: dit geldt alleen voor de opties die in de selectielijst worden weergegeven. Het heeft geen effect op de volgorde waarin resultaten worden weergegeven nadat ze zijn ingediend"
 
 #. in a range with minimum of 0 and maximum of 10, where the uncertainty value
 #. is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also
@@ -6985,58 +7402,64 @@ msgstr ""
 #. 20.00, 20.01 - 30.00 etc."
 #. Default: "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2%, a result of 100 will be reported as 100 ± 2.<br/>If you don't want uncertainty to be displayed for a given range, set 0 (or a value below 0) as the Uncertainty value.<br/>Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30.00 etc."
 #: bika/lims/content/abstractbaseanalysis.py:630
+#, fuzzy
 msgid "description_analysis_uncertainty"
-msgstr ""
+msgstr "Geef de onzekerheidswaarde op voor een bepaald bereik, bijv. voor resultaten in een bereik met een minimum van 0 en een maximum van 10, waar de onzekerheidswaarde 0,5 is - een resultaat van 6,67 wordt gerapporteerd als 6,67 ± 0,5.<br/>U kunt de onzekerheidswaarde ook opgeven als een percentage van de resultaatwaarde, door een '%' toe te voegen aan de waarde die is ingevoerd in de kolom 'Onzekerheidswaarde', bijv. voor resultaten in een bereik met een minimum van 10,01 en een maximum van 100, waar de onzekerheidswaarde 2% is, wordt een resultaat van 100 gerapporteerd als 100 ± 2.<br/>Als u niet wilt dat de onzekerheid voor een bepaald bereik wordt weergegeven, stel dan 0 (of een waarde onder 0) in als onzekerheidswaarde.<br/>Zorg ervoor dat opeenvolgende bereiken continu zijn, bijv. 0,00 - 10,00 wordt gevolgd door 10,01 - 20,00, 20,01 - 30,00 enz."
 
 #. mg/l, ppm, dB, mV, etc."
 #. Default: "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 #: bika/lims/content/abstractbaseanalysis.py:112
+#, fuzzy
 msgid "description_analysis_unit"
-msgstr ""
+msgstr "De meeteenheden voor de resultaten van deze analysedienst, bijv. mg/l, ppm, dB, mV, enz."
 
 #. Ensure to include the default unit in this list"
 #. Default: "Provide a list of units that are suitable for the analysis. Ensure to include the default unit in this list"
 #: bika/lims/content/abstractbaseanalysis.py:162
+#, fuzzy
 msgid "description_analysis_unitchoices"
-msgstr ""
+msgstr "Geef een lijst met eenheden op die geschikt zijn voor de analyse. Zorg ervoor dat u de standaardeenheid in deze lijst opneemt"
 
 #. reports."
 #. Default: "To be displayed below each Analysis Category section on results reports."
 #: senaite/core/content/analysiscategory.py:64
+#, fuzzy
 msgid "description_analysiscategory_comments"
-msgstr ""
+msgstr "Weer te geven onder elke sectie Analysecategorie op resultaatrapporten."
 
 #. Default: "Select the responsible department"
 #: senaite/core/content/analysiscategory.py:85
 msgid "description_analysiscategory_department"
-msgstr ""
+msgstr "Selecteer de verantwoordelijke afdeling"
 
 #. Duplicate values are ordered alphabetically."
 #. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 #: senaite/core/content/analysiscategory.py:99
+#, fuzzy
 msgid "description_analysiscategory_sort_key"
-msgstr ""
+msgstr "Decimale waarde van 0,0 - 1000,0 die de sorteervolgorde aangeeft. Dubbele waarden worden alfabetisch geordend."
 
 #. Default: "Commercial ID used for accounting"
 #: senaite/core/content/analysisprofile.py:125
 msgid "description_analysisprofile_commercial_id"
-msgstr ""
+msgstr "Commerciële ID gebruikt voor boekhouding"
 
 #. Default: "Please provide a unique profile keyword"
 #: senaite/core/content/analysisprofile.py:94
 msgid "description_analysisprofile_profile_key"
-msgstr ""
+msgstr "Geef een uniek profielsleutelwoord op"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/analysisprofile.py:149
 msgid "description_analysisprofile_profile_price"
-msgstr ""
+msgstr "Geef de prijs exclusief btw op"
 
 #. price"
 #. Default: "Please provide the VAT in percent that is added to the profile price"
 #: senaite/core/content/analysisprofile.py:161
+#, fuzzy
 msgid "description_analysisprofile_profile_vat"
-msgstr ""
+msgstr "Geef de btw in procenten op die aan de profielprijs wordt toegevoegd"
 
 #. profile won't be available for selection in sample creation and edit forms
 #. unless the selected sample type is one of these. If no sample type is set
@@ -7044,28 +7467,29 @@ msgstr ""
 #. the sample type of the sample."
 #. Default: "Sample types for which this analysis profile is supported. This profile won't be available for selection in sample creation and edit forms unless the selected sample type is one of these. If no sample type is set here, this profile will always be available for selection, regardless of the sample type of the sample."
 #: senaite/core/content/analysisprofile.py:184
+#, fuzzy
 msgid "description_analysisprofile_sampletypes"
-msgstr ""
+msgstr "Monstertypes waarvoor dit analyseprofiel wordt ondersteund. Dit profiel is niet beschikbaar ter selectie in formulieren voor het aanmaken en bewerken van monsters tenzij het geselecteerde monstertype een van deze is. Als hier geen monstertype is ingesteld, is dit profiel altijd beschikbaar ter selectie, ongeacht het monstertype van het monster."
 
 #. Default: "Select the included analyses for this profile"
 #: senaite/core/content/analysisprofile.py:110
 msgid "description_analysisprofile_services"
-msgstr ""
+msgstr "Selecteer de opgenomen analyses voor dit profiel"
 
 #. Default: "Use profile price instead of single analyses prices"
 #: senaite/core/content/analysisprofile.py:137
 msgid "description_analysisprofile_use_profile_price"
-msgstr ""
+msgstr "Profielprijs gebruiken in plaats van prijzen van afzonderlijke analyses"
 
 #. Default: "Number of samples to create with the information provided"
 #: bika/lims/content/analysisrequest.py:1441
 msgid "description_analysisrequest_numsamples"
-msgstr ""
+msgstr "Aantal aan te maken monsters met de opgegeven informatie"
 
 #. Default: "Link dynamic analysis specification"
 #: bika/lims/content/analysisspec.py:72
 msgid "description_analysisspec_dynamicspec"
-msgstr ""
+msgstr "Koppel dynamische analysespecificatie"
 
 #. outside this results range will raise an alert.<br/>'Min warn' and 'Max
 #. warn' values indicate a shoulder range. Any result outside the results
@@ -7076,108 +7500,115 @@ msgstr ""
 #. results report as well"
 #. Default: "'Min' and 'Max' values indicate a valid results range. Any result outside this results range will raise an alert.<br/>'Min warn' and 'Max warn' values indicate a shoulder range. Any result outside the results range but within the shoulder range will raise a less severe alert.<br/>If the result is out of range, the value set for '&lt; Min' or '&gt; Max' will be displayed in lists and results reports instead of the real result. In such case, the value set for 'Out of range comment' will be displayed in results report as well"
 #: bika/lims/content/analysisspec.py:91
+#, fuzzy
 msgid "description_analysisspec_resultsrange"
-msgstr ""
+msgstr "'Min'- en 'Max'-waarden geven een geldig resultaatbereik aan. Elk resultaat buiten dit resultaatbereik geeft een waarschuwing.<br/>'Min waarsch'- en 'Max waarsch'-waarden geven een schouderbereik aan. Elk resultaat buiten het resultaatbereik maar binnen het schouderbereik geeft een minder ernstige waarschuwing.<br/>Als het resultaat buiten het bereik ligt, wordt de waarde die is ingesteld voor '&lt; Min' of '&gt; Max' weergegeven in lijsten en resultaatrapporten in plaats van het werkelijke resultaat. In dat geval wordt de waarde die is ingesteld voor 'Opmerking buiten bereik' ook weergegeven in het resultaatrapport"
 
 #. Default: "Select the sample type for this specification"
 #: bika/lims/content/analysisspec.py:52
 msgid "description_analysisspec_sampletype"
-msgstr ""
+msgstr "Selecteer het monstertype voor deze specificatie"
 
 #. Default: "Contained samples in the PDF"
 #: bika/lims/content/arreport.py:82
 msgid "description_arreport_contained_samples"
-msgstr ""
+msgstr "Opgenomen monsters in de PDF"
 
 #. Default: "The primary sample of the PDF"
 #: bika/lims/content/arreport.py:52
 msgid "description_arreport_sample"
-msgstr ""
+msgstr "Het primaire monster van de PDF"
 
 #. Default: "Select the analysis profile for this template"
 #: bika/lims/content/artemplate.py:257
 msgid "description_artemplate_profile"
-msgstr ""
+msgstr "Selecteer het analyseprofiel voor dit sjabloon"
 
 #. Default: "Select the sample point for this template"
 #: bika/lims/content/artemplate.py:58
 msgid "description_artemplate_samplepoint"
-msgstr ""
+msgstr "Selecteer het monsterpunt voor dit sjabloon"
 
 #. Default: "Select the sample type for this template"
 #: bika/lims/content/artemplate.py:89
 msgid "description_artemplate_sampletype"
-msgstr ""
+msgstr "Selecteer het monstertype voor dit sjabloon"
 
 #. Default: "Select the type of the attachment"
 #: bika/lims/content/attachment.py:64
 msgid "description_attachment_type"
-msgstr ""
+msgstr "Selecteer het type van de bijlage"
 
 #. Default: "Assign the instrument for this log"
 #: bika/lims/content/autoimportlog.py:53
 msgid "description_autoimportlog_instrument"
-msgstr ""
+msgstr "Wijs het instrument toe voor dit logboek"
 
 #. Default: "The date and time when the log was created"
 #: bika/lims/content/autoimportlog.py:90
 msgid "description_autoimportlog_logtime"
-msgstr ""
+msgstr "De datum en tijd waarop het logboek is aangemaakt"
 
 #. Default: "The logged results"
 #: bika/lims/content/autoimportlog.py:77
 msgid "description_autoimportlog_results"
-msgstr ""
+msgstr "De gelogde resultaten"
 
 #. Default: "Select the client of this batch"
 #: bika/lims/content/batch.py:81
 msgid "description_batch_client"
-msgstr ""
+msgstr "Selecteer de klant van deze batch"
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
+#, fuzzy
 msgid "description_bikasetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Als deze optie is geactiveerd, kan de vastlegdatum van het resultaat handmatig worden ingevoerd voor analyses"
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
+#, fuzzy
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Indien geselecteerd ontvangen de verantwoordelijke personen van alle betrokken labafdelingen publicatie-e-mails."
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Analyses groeperen per categorie voor monsters"
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
+#, fuzzy
 msgid "description_bikasetup_date_sampled_required"
-msgstr ""
+msgstr "Selecteer dit om het veld Datum bemonsterd verplicht te maken bij het aanmaken van monsters. Deze functionaliteit is alleen van kracht wanneer 'Monsternameworkflow' niet actief is"
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
+#, fuzzy
 msgid "description_bikasetup_email_body_sample_publication"
-msgstr ""
+msgstr "Stel de standaard e-mailtekst in die wordt gebruikt bij het verzenden van resultaatrapporten naar de geselecteerde ontvangers. U kunt gereserveerde sleutelwoorden gebruiken: $client_name, $recipients, $lab_name, $lab_address"
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
+#, fuzzy
 msgid "description_bikasetup_email_from_sample_publication"
-msgstr ""
+msgstr "E-mail die als 'Van'-adres wordt gebruikt voor uitgaande e-mails bij het publiceren van resultaatrapporten. Dit adres overschrijft de waarde die is ingesteld bij de 'Mailinstellingen' van het portaal."
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
+#, fuzzy
 msgid "description_bikasetup_immediateresultsentry"
-msgstr ""
+msgstr "Sta de gebruiker toe om direct resultaten in te voeren na het aanmaken van monsters, bijv. om veldresultaten onmiddellijk in te voeren, of labresultaten, wanneer de automatische monsterontvangst is geactiveerd."
 
 #. sent to primary contacts and laboratory managers when a sample is
 #. invalidated. The following placeholders are supported: <code title='The ID
@@ -7187,26 +7618,28 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
+#, fuzzy
 msgid "description_bikasetup_invalidation_email_body"
-msgstr ""
+msgstr "Definieer het sjabloon voor de e-mailtekst die automatisch wordt verzonden naar primaire contactpersonen en laboratoriummanagers wanneer een monster ongeldig wordt verklaard. De volgende plaatshouders worden ondersteund: <code title='De ID van het monster'>$sample_id</code>, <code title='De ID van de hertest van het monster'>$retest_id</code>, <code title='De link naar de hertest'>$retest_link</code>, <code title='De reden(en) voor ongeldigverklaring'>$reason</code>, <code title='Het adres van het lab'>$lab_address</code>."
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
+#, fuzzy
 msgid "description_bikasetup_invalidation_reason_required"
-msgstr ""
+msgstr "Geef aan of het opgeven van een reden verplicht is bij het ongeldig verklaren van een monster. Indien ingeschakeld wordt de plaatshouder '$reason' in de e-mailtekst van de meldingsmail voor ongeldigverklaring vervangen door de ingevoerde reden."
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Analyses zijn vereist voor monsterregistratie"
 
 #. Default: "Dependent services of this calculation"
 #: bika/lims/content/calculation.py:84
 msgid "description_calculation_dependentservices"
-msgstr ""
+msgstr "Afhankelijke diensten van deze berekening"
 
 #. dynamically calculated when an analysis using this calculation is
 #. displayed.</p><p>To enter a Calculation, use standard maths operators, + -
@@ -7217,114 +7650,126 @@ msgstr ""
 #. where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #. Default: "<p>The formula you type here will be dynamically calculated be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators, + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #: senaite/core/content/calculation.py:291
+#, fuzzy
 msgid "description_calculation_formula"
-msgstr ""
+msgstr "<p>De formule die u hier typt, wordt dynamisch berekend wanneer een analyse die deze berekening gebruikt wordt weergegeven.</p><p>Om een berekening in te voeren, gebruikt u standaard wiskundige operatoren, + - * / ( ), en alle beschikbare sleutelwoorden, zowel van andere analysediensten als de hier opgegeven tussenvelden, als variabelen. Zet ze tussen vierkante haken [ ].</p><p>Bijv. de berekening voor Totale hardheid, het totaal van calcium- (ppm) en magnesiumionen (ppm) in water, wordt ingevoerd als [Ca] + [Mg], waarbij Ca en Mg de sleutelwoorden zijn voor die twee analysediensten.</p>"
+
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
+#. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
+#: senaite/core/content/calculation.py:268
+#, fuzzy
+msgid "description_calculation_imports"
+msgstr "Als uw formule een speciale functie uit een externe Python-bibliotheek nodig heeft, kunt u deze hier importeren. Bijv. als u de functie 'floor' uit de Python-module 'math' wilt gebruiken, voegt u 'math' toe aan het veld Module en 'floor' aan het veld functie. Het equivalent in Python zou 'from math import floor' zijn. In uw berekening zou u dan 'floor([Ca] + [Mg])' kunnen gebruiken."
 
 #. should your calculation require them. The field title specified here will
 #. be used as column headers and field descriptors where the interim fields
 #. are displayed. If 'Apply wide' is enabled the field will be shown in a
 #. selection box on the top of the worksheet, allowing to apply a specific
 #. value to all the corresponding fields on the sheet."
-#. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
-#: senaite/core/content/calculation.py:268
-msgid "description_calculation_imports"
-msgstr ""
-
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
+#, fuzzy
 msgid "description_calculation_interims"
-msgstr ""
+msgstr "Definieer tussenvelden zoals vatmassa, verdunningsfactoren, mocht uw berekening deze nodig hebben. De hier opgegeven veldtitel wordt gebruikt als kolomkoppen en veldbeschrijvingen waar de tussenvelden worden weergegeven. Als 'Breed toepassen' is ingeschakeld, wordt het veld weergegeven in een selectievak bovenaan het werkblad, waardoor een specifieke waarde op alle bijbehorende velden op het blad kan worden toegepast."
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
 #. Default: "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 #: senaite/core/content/calculation.py:321
+#, fuzzy
 msgid "description_calculation_test_params"
-msgstr ""
+msgstr "Om de berekening te testen, voert u hier waarden in voor alle berekeningsparameters. Dit omvat de hierboven gedefinieerde tussenvelden, evenals alle diensten waarvan deze berekening afhankelijk is om resultaten te berekenen."
 
 #. values."
 #. Default: "The result after the calculation has taken place with test values."
 #: senaite/core/content/calculation.py:345
+#, fuzzy
 msgid "description_calculation_test_result"
-msgstr ""
+msgstr "Het resultaat nadat de berekening met testwaarden heeft plaatsgevonden."
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/analysiscategory.py:62
 msgid "description_category_department"
-msgstr ""
+msgstr "Selecteer de verantwoordelijke afdeling"
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
-msgstr ""
+msgstr "De geselecteerde categorieën altijd uitvouwen"
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
-msgstr ""
+msgstr "Alleen geselecteerde categorieën tonen"
 
 #. Default: "This value is reported at the bottom of all published results"
 #: senaite/core/content/laboratory.py:127
 msgid "description_confidence_level"
-msgstr ""
+msgstr "Deze waarde wordt gerapporteerd onderaan alle gepubliceerde resultaten"
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
-msgstr ""
+msgstr "Contactpersonen in CC voor nieuwe monsters"
 
 #. could be selected here."
 #. Default: "If this container is pre-preserved, then the preservation method could be selected here."
 #: bika/lims/content/container.py:100
+#, fuzzy
 msgid "description_container_preservation"
-msgstr ""
+msgstr "Als deze container voorgeconserveerd is, kan hier de conserveringsmethode worden geselecteerd."
 
 #. Default: "Select the type of this container"
 #: bika/lims/content/container.py:57
 msgid "description_container_type"
-msgstr ""
+msgstr "Selecteer het type van deze container"
 
 #. Default: "${copyright} 2017-${current_year} ${senaitelims}"
 #: senaite/core/browser/viewlets/templates/footer.pt:13
 msgid "description_copyright"
-msgstr ""
+msgstr "${copyright} 2017-${current_year} ${senaitelims}"
 
 #. Default: "Please provide a unique department identifier"
 #: senaite/core/content/department.py:80
 msgid "description_department_id"
-msgstr ""
+msgstr "Geef een unieke afdelingsidentificatie op"
 
 #. the 'lab contacts' setup item. Departmental managers are referenced on
 #. analysis results reports containing analyses by their department."
 #. Default: "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 #: senaite/core/content/department.py:106
+#, fuzzy
 msgid "description_department_manager"
-msgstr ""
+msgstr "Selecteer een manager uit het beschikbare personeel dat is geconfigureerd onder het instellingenitem 'labcontactpersonen'. Afdelingsmanagers worden vermeld op analyseresultaatrapporten die analyses van hun afdeling bevatten."
 
 #. Default: "Name of the department"
 #: senaite/core/content/department.py:52
 msgid "description_department_title"
-msgstr ""
+msgstr "Naam van de afdeling"
 
 #. Default: "Location where the instrument is installed"
 #: bika/lims/content/instrument.py:322
 msgid "description_instrument_instrumentlocation"
-msgstr ""
+msgstr "Locatie waar het instrument is geïnstalleerd"
 
 #. Default: "Select the type of this instrument"
 #: bika/lims/content/instrument.py:82
 msgid "description_instrument_instrumenttype"
-msgstr ""
+msgstr "Selecteer het type van dit instrument"
 
 #. Default: "Select the manufacturer of this instrument"
 #: bika/lims/content/instrument.py:102
 msgid "description_instrument_manufacturer"
-msgstr ""
+msgstr "Selecteer de fabrikant van dit instrument"
 
 #. Default: "Methods that are supported by this analytical instrument"
 #: bika/lims/content/instrument.py:174
 msgid "description_instrument_methods"
-msgstr ""
+msgstr "Methoden die door dit analytische instrument worden ondersteund"
 
 #. where the system should look for the results files while automatically
 #. importing results. Having a folder for each Instrument and inside that
@@ -7333,112 +7778,140 @@ msgstr ""
 #. unique."
 #. Default: "For each interface of this instrument, you can define a folder where the system should look for the results files while automatically importing results. Having a folder for each Instrument and inside that folder creating different folders for each of its Interfaces can be a good approach. You can use Interface codes to be sure that folder names are unique."
 #: bika/lims/content/instrument.py:267
+#, fuzzy
 msgid "description_instrument_result_file_folder"
-msgstr ""
+msgstr "Voor elke interface van dit instrument kunt u een map definiëren waar het systeem naar de resultaatbestanden moet zoeken tijdens het automatisch importeren van resultaten. Een map voor elk instrument hebben en binnen die map verschillende mappen aanmaken voor elk van de interfaces kan een goede aanpak zijn. U kunt interfacecodes gebruiken om ervoor te zorgen dat mapnamen uniek zijn."
 
 #. Default: "Select the supplier of this instrument"
 #: bika/lims/content/instrument.py:122
 msgid "description_instrument_supplier"
-msgstr ""
+msgstr "Selecteer de leverancier van dit instrument"
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentcalibration.py:130
 msgid "description_instrumentcalibration_worker"
-msgstr ""
+msgstr "De persoon die de taak heeft uitgevoerd"
 
 #. Default: "The person at the supplier who prepared the certificat"
 #: bika/lims/content/instrumentcertification.py:149
 msgid "description_instrumentcertification_preparator"
-msgstr ""
+msgstr "De persoon bij de leverancier die het certificaat heeft opgesteld"
 
 #. Default: "The person at the supplier who approved the certificate"
 #: bika/lims/content/instrumentcertification.py:173
 msgid "description_instrumentcertification_validator"
-msgstr ""
+msgstr "De persoon bij de leverancier die het certificaat heeft goedgekeurd"
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentvalidation.py:112
 msgid "description_instrumentvalidation_worker"
-msgstr ""
+msgstr "De persoon die de taak heeft uitgevoerd"
 
 #. selected departments."
 #. Default: "Select a default department for this contact from one of the selected departments."
 #: bika/lims/content/labcontact.py:89
+#, fuzzy
 msgid "description_labcontact_default_department"
-msgstr ""
+msgstr "Selecteer een standaardafdeling voor deze contactpersoon uit een van de geselecteerde afdelingen."
 
 #. Default: "Assigned laboratory departments"
 #: bika/lims/content/labcontact.py:62
 msgid "description_labcontact_departments"
-msgstr ""
+msgstr "Toegewezen laboratoriumafdelingen"
+
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+#, fuzzy
+msgid "description_label_color"
+msgstr "Hexkleurcode gebruikt voor de chip (bijv. #0d6efd). Laat leeg voor de standaardstijl."
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+#, fuzzy
+msgid "description_label_title"
+msgstr "Het hernoemen van dit label herschrijft de opgeslagen naam op elke inhoud die momenteel is gelabeld. De cascade wordt uitgevoerd in dezelfde transactie als het opslaan en kan bij grote datasets even duren."
 
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
-msgstr ""
+msgstr "Vink dit vakje aan als uw laboratorium geaccrediteerd is"
 
 #. Default: "The Laboratory's web address"
 #: senaite/core/content/laboratory.py:101
 msgid "description_laboratory_lab_url"
-msgstr ""
+msgstr "Het webadres van het laboratorium"
 
 #. Default: "Supervisor of the Lab"
 #: bika/lims/content/laboratory.py:78
 msgid "description_laboratory_suervisor"
-msgstr ""
+msgstr "Supervisor van het lab"
 
 #. Default: "Supervisor of the Lab"
 #: senaite/core/content/laboratory.py:77
 msgid "description_laboratory_supervisor"
-msgstr ""
+msgstr "Supervisor van het lab"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/labproduct.py:89
 msgid "description_labproduct_price"
-msgstr ""
+msgstr "Geef de prijs exclusief btw op"
 
 #. price"
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
+#, fuzzy
 msgid "description_labproduct_vat"
-msgstr ""
+msgstr "Geef de btw in procenten op die aan de labproductprijs wordt toegevoegd"
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+#, fuzzy
+msgid "description_manage_viewlets"
+msgstr "De viewletmanagers en hun viewlets worden ter plaatse getoond, genest en gepositioneerd zoals ze op de site verschijnen. Gebruik de bediening om elke viewlet te verbergen, tonen of herordenen."
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
 msgid "description_multifile_document_location"
-msgstr ""
+msgstr "Locatie waar de documentenset is opgeborgen"
 
 #. image, ...)"
 #. Default: "Type of document (e.g. user manual, instrument specifications, image, ...)"
 #: senaite/core/content/multifile.py:83
+#, fuzzy
 msgid "description_multifile_document_type"
-msgstr ""
+msgstr "Type document (bijv. gebruikershandleiding, instrumentspecificaties, afbeelding, ...)"
 
 #. Default: "File upload"
 #: senaite/core/content/multifile.py:51
 msgid "description_multifile_file"
-msgstr ""
+msgstr "Bestand uploaden"
 
 #. Default: "Greeting title eg. Mr, Mrs, Dr"
 #: senaite/core/content/person.py:71
 msgid "description_person_salutation"
-msgstr ""
+msgstr "Aanhef bijv. Dhr., Mevr., Dr."
 
 #. Default: "Reference sample values are zero or 'blank'"
 #: bika/lims/content/referencedefinition.py:77
 msgid "description_referencedefinition_blank"
-msgstr ""
+msgstr "Referentiemonsterwaarden zijn nul of 'blanco'"
 
 #. definition."
 #. Default: "Hazard categories that apply to samples of this reference definition."
 #: bika/lims/content/referencedefinition.py:106
+#, fuzzy
 msgid "description_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën die van toepassing zijn op monsters van deze referentiedefinitie."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: bika/lims/content/referencedefinition.py:91
 msgid "description_referencedefinition_hazardous"
-msgstr ""
+msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
 
 #. category. Enter minimum and maximum values to indicate a valid results
 #. range. Any result outside this range will raise an alert. The % Error field
@@ -7448,61 +7921,67 @@ msgstr ""
 #. alert."
 #. Default: "Click on Analysis Categories to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 #: bika/lims/content/referencedefinition.py:55
+#, fuzzy
 msgid "description_referencedefinition_referencevalues"
-msgstr ""
+msgstr "Klik op Analysecategorieën om analysediensten in elke categorie te zien. Voer minimum- en maximumwaarden in om een geldig resultaatbereik aan te geven. Elk resultaat buiten dit bereik geeft een waarschuwing. Het veld % Fout maakt het mogelijk om een % onzekerheid in aanmerking te nemen bij het evalueren van resultaten ten opzichte van minimum- en maximumwaarden. Een resultaat buiten het bereik maar toch binnen het bereik als de % fout in aanmerking wordt genomen, geeft een minder ernstige waarschuwing."
 
 #. inherit from the reference definition."
 #. Default: "Hazard categories for this reference sample. Leave empty to inherit from the reference definition."
 #: bika/lims/content/referencesample.py:118
+#, fuzzy
 msgid "description_referencesample_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën voor dit referentiemonster. Laat leeg om over te nemen van de referentiedefinitie."
 
 #. Default: "Select the manufacturer for this sample"
 #: bika/lims/content/referencesample.py:136
 msgid "description_referencesample_manufacturer"
-msgstr ""
+msgstr "Selecteer de fabrikant voor dit monster"
 
 #. Default: "Select the reference definition for this sample"
 #: bika/lims/content/referencesample.py:82
 msgid "description_referencesample_referencedefinition"
-msgstr ""
+msgstr "Selecteer de referentiedefinitie voor dit monster"
 
 #. the paste popup in the sample add form. Please note that the paste button
 #. will only show for the fields listed here."
 #. Default: "Add all field names that support to enter multiple values using the paste popup in the sample add form. Please note that the paste button will only show for the fields listed here."
 #: senaite/core/registry/schema.py:375
+#, fuzzy
 msgid "description_registry_allow_multi_paste"
-msgstr ""
+msgstr "Voeg alle veldnamen toe die het invoeren van meerdere waarden ondersteunen via de plakpop-up in het formulier voor het toevoegen van monsters. Let op: de plakknop wordt alleen weergegeven voor de hier vermelde velden."
 
 #. catalogs in which these portal types should be indexed, beyond the default
 #. catalogs. A restart is required for these changes to take effect."
 #. Default: "Define the relationship between portal types and the additional catalogs in which these portal types should be indexed, beyond the default catalogs. A restart is required for these changes to take effect."
 #: senaite/core/registry/schema.py:278
+#, fuzzy
 msgid "description_registry_catalog_mappings"
-msgstr ""
+msgstr "Definieer de relatie tussen portaaltypes en de aanvullende catalogi waarin deze portaaltypes moeten worden geïndexeerd, naast de standaardcatalogi. Een herstart is vereist om deze wijzigingen van kracht te laten worden."
 
 #. logs into the system, or when a client is selected from the client folder
 #. listing"
 #. Default: "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing"
 #: senaite/core/registry/schema.py:51
+#, fuzzy
 msgid "description_registry_client_landing_page"
-msgstr ""
+msgstr "Selecteer de standaard bestemmingspagina. Deze wordt gebruikt wanneer een klantgebruiker inlogt op het systeem, of wanneer een klant wordt geselecteerd uit de klantmaplijst"
 
 #. structure of the site via Generic Setup"
 #. Default: "List of portal types to be skipped when exporting the content structure of the site via Generic Setup"
 #: senaite/core/registry/schema.py:238
+#, fuzzy
 msgid "description_registry_generic_setup_skip_export_types"
-msgstr ""
+msgstr "Lijst van portaaltypes die moeten worden overgeslagen bij het exporteren van de inhoudsstructuur van de site via Generic Setup"
 
 #. Default: "Attach import file to all Worksheet assigned analyses"
 #: senaite/core/registry/schema.py:443
 msgid "description_registry_import_analysis_attach_attachment"
-msgstr ""
+msgstr "Importbestand koppelen aan alle aan het werkblad toegewezen analyses"
 
 #. Default: "Automatically submit analyses upon import"
 #: senaite/core/registry/schema.py:456
 msgid "description_registry_import_analysis_submit"
-msgstr ""
+msgstr "Analyses automatisch indienen bij import"
 
 #. in its own ZODB transaction with a per-sample retry on conflict. This
 #. reduces the chance that ID-counter or container contention aborts the whole
@@ -7510,192 +7989,200 @@ msgstr ""
 #. batch is created in a single transaction (legacy behaviour)."
 #. Default: "When enabled, each sample created from the add form is committed in its own ZODB transaction with a per-sample retry on conflict. This reduces the chance that ID-counter or container contention aborts the whole batch on instances with many concurrent users. When disabled, the whole batch is created in a single transaction (legacy behaviour)."
 #: senaite/core/registry/schema.py:391
+#, fuzzy
 msgid "description_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Indien ingeschakeld wordt elk monster dat via het toevoegformulier wordt aangemaakt vastgelegd in zijn eigen ZODB-transactie met een nieuwe poging per monster bij een conflict. Dit vermindert de kans dat conflicten om de ID-teller of container de hele batch afbreken op instanties met veel gelijktijdige gebruikers. Indien uitgeschakeld wordt de hele batch in één transactie aangemaakt (verouderd gedrag)."
 
 #. matching the source sample structure. Each partition will be created with
 #. the same configuration (sample type, container, preservation) and analyses
 #. as the source partition."
 #. Default: "When enabled, copying a sample will also create partitions matching the source sample structure. Each partition will be created with the same configuration (sample type, container, preservation) and analyses as the source partition."
 #: senaite/core/registry/schema.py:328
+#, fuzzy
 msgid "description_registry_sample_add_copy_partitions"
-msgstr ""
+msgstr "Indien ingeschakeld worden bij het kopiëren van een monster ook partities aangemaakt die overeenkomen met de structuur van het bronmonster. Elke partitie wordt aangemaakt met dezelfde configuratie (monstertype, container, conservering) en analyses als de bronpartitie."
 
 #. copying analyses to a new sample in the sample add form."
 #. Default: "Add all analyses workflow states that should be skipped when copying analyses to a new sample in the sample add form."
 #: senaite/core/registry/schema.py:359
+#, fuzzy
 msgid "description_registry_sample_add_skip_analyses_in_states"
-msgstr ""
+msgstr "Voeg alle analyseworkflowstatussen toe die moeten worden overgeslagen bij het kopiëren van analyses naar een nieuw monster in het formulier voor het toevoegen van monsters."
 
 #. copying a sample. Only analyses that directly belong to the source sample
 #. will be copied to the new sample."
 #. Default: "When enabled, analyses from partitions will be excluded when copying a sample. Only analyses that directly belong to the source sample will be copied to the new sample."
 #: senaite/core/registry/schema.py:344
+#, fuzzy
 msgid "description_registry_sample_add_skip_partition_analyses"
-msgstr ""
+msgstr "Indien ingeschakeld worden analyses van partities uitgesloten bij het kopiëren van een monster. Alleen analyses die rechtstreeks tot het bronmonster behoren, worden naar het nieuwe monster gekopieerd."
 
 #. upon sample creation. This option is disabled by default, but certain add-
 #. ons may depend on it to operate correctly."
 #. Default: "When enabled, triggers “before” and “after” transition events upon sample creation. This option is disabled by default, but certain add-ons may depend on it to operate correctly."
 #: senaite/core/registry/schema.py:410
+#, fuzzy
 msgid "description_registry_trigger_events_on_sample_creation"
-msgstr ""
+msgstr "Indien ingeschakeld activeert dit “voor”- en “na”-overgangsgebeurtenissen bij het aanmaken van monsters. Deze optie is standaard uitgeschakeld, maar bepaalde add-ons kunnen ervan afhankelijk zijn om correct te werken."
 
 #. Default: "Worksheet view configuration"
 #: senaite/core/registry/schema.py:99
 msgid "description_registry_worksheet_settings"
-msgstr ""
+msgstr "Configuratie van werkbladweergave"
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
-msgstr ""
+msgstr "Opgenomen monsters in de PDF"
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
-msgstr ""
+msgstr "Het primaire monster van de PDF"
 
 #. Default: "Assign sample to a batch"
 #: bika/lims/content/analysisrequest.py:331
 msgid "description_sample_batch"
-msgstr ""
+msgstr "Monster toewijzen aan een batch"
 
 #. Default: "The contacts used in CC for email notifications"
 #: bika/lims/content/analysisrequest.py:200
 msgid "description_sample_cccontact"
-msgstr ""
+msgstr "De contactpersonen die in CC worden gebruikt voor e-mailmeldingen"
 
 #. Default: "Select the client for this sample"
 #: bika/lims/content/analysisrequest.py:258
 msgid "description_sample_client"
-msgstr ""
+msgstr "Selecteer de klant voor dit monster"
 
 #. Default: "Select the primary contact for this sample"
 #: bika/lims/content/analysisrequest.py:159
 msgid "description_sample_contact"
-msgstr ""
+msgstr "Selecteer de primaire contactpersoon voor dit monster"
 
 #. Default: "Select a container for this sample"
 #: bika/lims/content/analysisrequest.py:569
 msgid "description_sample_container"
-msgstr ""
+msgstr "Selecteer een container voor dit monster"
 
 #. Default: "The date when the sample was taken"
 #: bika/lims/content/analysisrequest.py:453
 msgid "description_sample_datesampled"
-msgstr ""
+msgstr "De datum waarop het monster is genomen"
 
 #. Default: "Reference to detached sample"
 #: bika/lims/content/analysisrequest.py:1311
 msgid "description_sample_detached_from"
-msgstr ""
+msgstr "Verwijzing naar losgekoppeld monster"
 
 #. Default: "Reference to the source sample this sample was duplicated from"
 #: bika/lims/content/analysisrequest.py:1283
 msgid "description_sample_duplicated_from"
-msgstr ""
+msgstr "Verwijzing naar het bronmonster waarvan dit monster is gedupliceerd"
 
 #. Default: "Generated invoice for this sample"
 #: bika/lims/content/analysisrequest.py:1049
 msgid "description_sample_invoice"
-msgstr ""
+msgstr "Gegenereerde factuur voor dit monster"
 
 #. Default: "Reference to parent sample"
 #: bika/lims/content/analysisrequest.py:1255
 msgid "description_sample_parent_sample"
-msgstr ""
+msgstr "Verwijzing naar bovenliggend monster"
 
 #. Default: "Select the needed preservation for this sample"
 #: bika/lims/content/analysisrequest.py:600
 msgid "description_sample_preservation"
-msgstr ""
+msgstr "Selecteer de benodigde conservering voor dit monster"
 
 #. Default: "Select a sample to create a secondary Sample"
 #: bika/lims/content/analysisrequest.py:295
 msgid "description_sample_primary"
-msgstr ""
+msgstr "Selecteer een monster om een secundair monster aan te maken"
 
 #. Default: "Select an analysis profile for this sample"
 #: bika/lims/content/analysisrequest.py:421
 msgid "description_sample_profiles"
-msgstr ""
+msgstr "Selecteer een analyseprofiel voor dit monster"
 
 #. sample publication report"
 #. Default: "Select an analysis specification that should be used in the sample publication report"
 #: bika/lims/content/analysisrequest.py:737
+#, fuzzy
 msgid "description_sample_publicationspecification"
-msgstr ""
+msgstr "Selecteer een analysespecificatie die moet worden gebruikt in het publicatierapport van het monster"
 
 #. Default: "Reference to retracted sample"
 #: bika/lims/content/analysisrequest.py:1339
 msgid "description_sample_retracted"
-msgstr ""
+msgstr "Verwijzing naar ingetrokken monster"
 
 #. Default: "The condition of the sample"
 #: bika/lims/content/analysisrequest.py:900
 msgid "description_sample_samplecondition"
-msgstr ""
+msgstr "De conditie van het monster"
 
 #. Default: "Location where the sample was taken"
 #: bika/lims/content/analysisrequest.py:770
 msgid "description_sample_samplepoint"
-msgstr ""
+msgstr "Locatie waar het monster is genomen"
 
 #. Default: "Select the sample type of this sample"
 #: bika/lims/content/analysisrequest.py:541
 msgid "description_sample_sampletype"
-msgstr ""
+msgstr "Selecteer het monstertype van dit monster"
 
 #. Default: "The date when the sample will be taken"
 #: bika/lims/content/analysisrequest.py:516
 msgid "description_sample_samplingdate"
-msgstr ""
+msgstr "De datum waarop het monster zal worden genomen"
 
 #. Default: "Deviation between the sample and how it was sampled"
 #: bika/lims/content/analysisrequest.py:872
 msgid "description_sample_samplingdeviation"
-msgstr ""
+msgstr "Afwijking tussen het monster en hoe het is bemonsterd"
 
 #. Default: "Select an analysis specification for this sample"
 #: bika/lims/content/analysisrequest.py:693
 msgid "description_sample_specification"
-msgstr ""
+msgstr "Selecteer een analysespecificatie voor dit monster"
 
 #. Default: "Location where the sample is kept"
 #: bika/lims/content/analysisrequest.py:794
 msgid "description_sample_storagelocation"
-msgstr ""
+msgstr "Locatie waar het monster wordt bewaard"
 
 #. Default: "The assigned batch sub group of this request"
 #: bika/lims/content/analysisrequest.py:366
 msgid "description_sample_subgroup"
-msgstr ""
+msgstr "De toegewezen batchsubgroep van deze aanvraag"
 
 #. Default: "Select an analysis template for this sample"
 #: bika/lims/content/analysisrequest.py:393
 msgid "description_sample_template"
-msgstr ""
+msgstr "Selecteer een analysesjabloon voor dit monster"
 
 #. and put together from more than one sub sample, e.g. several surface
 #. samples from a dam mixed together to be a representative sample for the
 #. dam. The default, unchecked, indicates 'grab' samples"
 #. Default: "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 #: senaite/core/content/samplepoint.py:147
+#, fuzzy
 msgid "description_samplepoint_composite"
-msgstr ""
+msgstr "Vink dit vakje aan als de monsters die op dit punt worden genomen 'samengesteld' zijn en zijn samengevoegd uit meer dan één submonster, bijv. verschillende oppervlaktemonsters uit een dam die samen zijn gemengd tot een representatief monster voor de dam. De standaardinstelling, niet aangevinkt, geeft 'grab'-monsters aan"
 
 #. Default: "The height or depth at which the sample has to be taken"
 #: senaite/core/content/samplepoint.py:91
 msgid "description_samplepoint_elevation"
-msgstr ""
+msgstr "De hoogte of diepte waarop het monster moet worden genomen"
 
 #. further analysis. It plays a pivotal role in research as it can
 #. significantly influence the results and conclusions drawn from the study."
 #. Default: "The geographical point or area from which samples are taken for further analysis. It plays a pivotal role in research as it can significantly influence the results and conclusions drawn from the study."
 #: senaite/core/content/samplepoint.py:76
+#, fuzzy
 msgid "description_samplepoint_location"
-msgstr ""
+msgstr "Het geografische punt of gebied waaruit monsters worden genomen voor verdere analyse. Het speelt een cruciale rol in het onderzoek, aangezien het de resultaten en conclusies van de studie aanzienlijk kan beïnvloeden."
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
@@ -7703,14 +8190,16 @@ msgstr ""
 #. regardless of the type."
 #. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
 #: bika/lims/content/samplepoint.py:98
+#, fuzzy
 msgid "description_samplepoint_sampletypes"
-msgstr ""
+msgstr "De lijst met monstertypes die op dit monsterpunt kunnen worden verzameld. Het veld voor de selectie van een monsterpunt in de aanmaak- en bewerkingsformulieren voor monsters wordt dienovereenkomstig gefilterd. Monsterpunten waaraan geen monstertype is toegewezen, blijven echter altijd beschikbaar voor selectie, ongeacht het type."
 
 #. frequency here, e.g. weekly"
 #. Default: "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 #: senaite/core/content/samplepoint.py:103
+#, fuzzy
 msgid "description_samplepoint_sampling_frequency"
-msgstr ""
+msgstr "Als op dit monsterpunt periodiek een monster wordt genomen, voer hier dan de frequentie in, bijv. wekelijks"
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
@@ -7718,474 +8207,520 @@ msgstr ""
 #. regardless of the type."
 #. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
 #: senaite/core/content/samplepoint.py:126
+#, fuzzy
 msgid "description_samplepoint_sampling_sample_types"
-msgstr ""
+msgstr "De lijst met monstertypes die op dit monsterpunt kunnen worden verzameld. Het veld voor de selectie van een monsterpunt in de aanmaak- en bewerkingsformulieren voor monsters wordt dienovereenkomstig gefilterd. Monsterpunten waaraan geen monstertype is toegewezen, blijven echter altijd beschikbaar voor selectie, ongeacht het type."
 
 #. sample is received"
 #. Default: "Automatically redirect the user to the partitions view when the sample is received"
 #: senaite/core/content/sampletemplate.py:258
+#, fuzzy
 msgid "description_sampletemplate_auto_partition"
-msgstr ""
+msgstr "De gebruiker automatisch doorverwijzen naar de partitieweergave wanneer het monster wordt ontvangen"
 
 #. Default: "Select if the sample is a mix of sub samples"
 #: senaite/core/content/sampletemplate.py:219
 msgid "description_sampletemplate_composite"
-msgstr ""
+msgstr "Selecteer of het monster een mengsel van deelmonsters is"
 
 #. ID'"
 #. Default: "Each line defines a new partition identified by the 'Partition ID'"
 #: senaite/core/content/sampletemplate.py:245
+#, fuzzy
 msgid "description_sampletemplate_partitions"
-msgstr ""
+msgstr "Elke regel definieert een nieuwe partitie die wordt geïdentificeerd door de 'Partitie-ID'"
 
 #. Default: "Select the sample point for this template"
 #: senaite/core/content/sampletemplate.py:187
 msgid "description_sampletemplate_samplepoint"
-msgstr ""
+msgstr "Selecteer het monsterpunt voor dit sjabloon"
 
 #. Default: "Select the sample type for this template"
 #: senaite/core/content/sampletemplate.py:209
 msgid "description_sampletemplate_sampletype"
-msgstr ""
+msgstr "Selecteer het monstertype voor dit sjabloon"
 
 #. Default: "Enable sampling workflow for the created samples"
 #: senaite/core/content/sampletemplate.py:228
 msgid "description_sampletemplate_sampling_required"
-msgstr ""
+msgstr "Monstername-workflow inschakelen voor de aangemaakte monsters"
 
 #. Default: "Select the services for this template"
 #: senaite/core/content/sampletemplate.py:273
 msgid "description_sampletemplate_services"
-msgstr ""
+msgstr "Selecteer de diensten voor dit sjabloon"
 
 #. Default: "Defines the stickers to use for this sample type."
 #: senaite/core/content/sampletype.py:281
 msgid "description_sampletype_admitted_stickers_templates"
-msgstr ""
+msgstr "Definieert de stickers die voor dit monstertype worden gebruikt."
 
 #. automatically assigned a container of this type, unless it has been
 #. specified in more details per analysis service"
 #. Default: "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 #: senaite/core/content/sampletype.py:258
+#, fuzzy
 msgid "description_sampletype_containertype"
-msgstr ""
+msgstr "Het standaardcontainertype. Nieuwe monsterpartities krijgen automatisch een container van dit type toegewezen, tenzij dit gedetailleerder is opgegeven per analysedienst"
 
 #. before they expire and cannot be analysed any further"
 #. Default: "The period for which unpreserved samples of this type can be kept before they expire and cannot be analysed any further"
 #: senaite/core/content/sampletype.py:155
+#, fuzzy
 msgid "description_sampletype_duration_period"
-msgstr ""
+msgstr "De periode waarin ongeconserveerde monsters van dit type kunnen worden bewaard voordat ze vervallen en niet verder kunnen worden geanalyseerd"
 
 #. display the appropriate pictograms in reports and lists."
 #. Default: "Hazard categories that apply to samples of this type. Used to display the appropriate pictograms in reports and lists."
 #: senaite/core/content/sampletype.py:180
+#, fuzzy
 msgid "description_sampletype_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën die van toepassing zijn op monsters van dit type. Worden gebruikt om de juiste pictogrammen weer te geven in rapporten en lijsten."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: senaite/core/content/sampletype.py:168
 msgid "description_sampletype_hazardous"
-msgstr ""
+msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
 
 #. kg'."
 #. Default: "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 #: senaite/core/content/sampletype.py:235
+#, fuzzy
 msgid "description_sampletype_min_volume"
-msgstr ""
+msgstr "Het minimale monstervolume dat vereist is voor analyse, bijv. '10 ml' of '1 kg'."
 
 #. Default: "Only ASCII characters without whitespaces are allowed."
 #: senaite/core/content/sampletype.py:222
 msgid "description_sampletype_prefix"
-msgstr ""
+msgstr "Alleen ASCII-tekens zonder spaties zijn toegestaan."
 
 #. Default: "Select the sample matrix for this sample type"
 #: senaite/core/content/sampletype.py:208
 msgid "description_sampletype_samplematrix"
-msgstr ""
+msgstr "Selecteer de monstermatrix voor dit monstertype"
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
+#, fuzzy
 msgid "description_senaitesetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Als deze optie is geactiveerd, kan de vastlegdatum van het resultaat handmatig worden ingevoerd voor analyses"
 
 #. to them or for unassigned analyses. When disabled, users can only submit
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
+#, fuzzy
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
-msgstr ""
+msgstr "Indien ingeschakeld kunnen gebruikers resultaten indienen voor analyses die niet aan hen zijn toegewezen of voor niet-toegewezen analyses. Indien uitgeschakeld kunnen gebruikers alleen resultaten indienen voor analyses die aan henzelf zijn toegewezen. Deze instelling is niet van toepassing op gebruikers met de rol Labmanager."
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
+#, fuzzy
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Indien geselecteerd ontvangen de verantwoordelijken van alle betrokken labafdelingen publicatie-e-mails."
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
+#, fuzzy
 msgid "description_senaitesetup_auto_log_off"
-msgstr ""
+msgstr "Het aantal minuten voordat een gebruiker automatisch wordt afgemeld. 0 schakelt automatisch afmelden uit"
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
+#, fuzzy
 msgid "description_senaitesetup_auto_verify_samples"
-msgstr ""
+msgstr "Indien ingeschakeld wordt het monster automatisch geverifieerd zodra alle resultaten zijn geverifieerd. Anders moeten gebruikers met voldoende rechten het monster achteraf handmatig verifiëren. Standaard: ingeschakeld"
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
+#, fuzzy
 msgid "description_senaitesetup_categorise_analysis_services"
-msgstr ""
+msgstr "Analysediensten per categorie groeperen in de LIMS-tabellen, handig wanneer de lijst lang is"
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Analyses per categorie groeperen voor monsters"
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
-msgstr ""
+msgstr "Selecteer de valuta die de site gebruikt om prijzen weer te geven."
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
-msgstr ""
+msgstr "Selecteer dit om het dashboard te activeren als standaard startpagina."
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
+#, fuzzy
 msgid "description_senaitesetup_date_sampled_required"
-msgstr ""
+msgstr "Selecteer dit om het veld Bemonsteringsdatum verplicht te maken bij het aanmaken van een monster. Deze functionaliteit werkt alleen wanneer de 'Monstername-workflow' niet actief is"
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
-msgstr ""
+msgstr "Voorkeursdecimaalteken voor rapporten."
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
-msgstr ""
+msgstr "Selecteer het land dat de site standaard toont"
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
+#, fuzzy
 msgid "description_senaitesetup_default_number_of_ars_to_add"
-msgstr ""
+msgstr "Standaardwaarde van het 'Aantal monsters' wanneer gebruikers op de knop 'TOEVOEGEN' klikken om nieuwe monsters aan te maken"
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
+#, fuzzy
 msgid "description_senaitesetup_email_from_sample_publication"
-msgstr ""
+msgstr "E-mailadres dat als 'Van'-adres wordt gebruikt voor uitgaande e-mails bij het publiceren van resultaatrapporten. Dit adres overschrijft de waarde die is ingesteld bij de 'Mailinstellingen' van het portaal."
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
+#, fuzzy
 msgid "description_senaitesetup_enable_analysis_remarks"
-msgstr ""
+msgstr "Indien ingeschakeld wordt bij elke analyse in de weergave voor resultaatinvoer een vrij tekstveld weergegeven"
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
-msgstr ""
+msgstr "Analysespecificaties die rechtstreeks op het monster worden bewerkt."
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
+#, fuzzy
 msgid "description_senaitesetup_enable_rejection_workflow"
-msgstr ""
+msgstr "Selecteer dit om de afwijzingsworkflow voor monsters te activeren. In het actiemenu wordt een optie 'Afwijzen' weergegeven."
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
+#, fuzzy
 msgid "description_senaitesetup_exponential_format_threshold"
-msgstr ""
+msgstr "Resultaatwaarden met ten minste dit aantal significante cijfers worden weergegeven in wetenschappelijke notatie met de letter 'e' om de exponent aan te geven. De precisie kan in afzonderlijke analysediensten worden geconfigureerd."
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
+#, fuzzy
 msgid "description_senaitesetup_immediateresultsentry"
-msgstr ""
+msgstr "Sta de gebruiker toe om resultaten direct na het aanmaken van het monster in te voeren, bijv. om veldresultaten direct in te voeren, of labresultaten wanneer de automatische monsterontvangst is geactiveerd."
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
+#, fuzzy
 msgid "description_senaitesetup_invalidation_reason_required"
-msgstr ""
+msgstr "Geef aan of het opgeven van een reden verplicht is bij het ongeldig maken van een monster. Indien ingeschakeld wordt de tijdelijke aanduiding '$reason' in de tekst van de meldingsmail voor het ongeldig maken van het monster vervangen door de ingevoerde reden."
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
+#, fuzzy
 msgid "description_senaitesetup_landing_page"
-msgstr ""
+msgstr "De landingspagina wordt getoond aan niet-geauthenticeerde gebruikers als het dashboard niet is geselecteerd als standaard startpagina. Als er geen landingspagina is geselecteerd, wordt de standaard startpagina weergegeven."
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
+#, fuzzy
 msgid "description_senaitesetup_maxnumberofsamplesadd"
-msgstr ""
+msgstr "Maximum aantal monsters dat kan worden aangemaakt overeenkomstig de waarde die is ingesteld voor het veld 'Aantal monsters' op het monsterregistratieformulier"
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
+#, fuzzy
 msgid "description_senaitesetup_member_discount"
-msgstr ""
+msgstr "Het hier ingevoerde kortingspercentage wordt toegepast op de prijzen voor klanten die zijn gemarkeerd als 'leden', doorgaans coöperatieleden of geassocieerden die deze korting verdienen"
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
+#, fuzzy
 msgid "description_senaitesetup_minimum_results"
-msgstr ""
+msgstr "Te weinig gegevenspunten gebruiken is statistisch niet zinvol. Stel een acceptabel minimumaantal resultaten in voordat QC-statistieken worden berekend en uitgezet"
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
+#, fuzzy
 msgid "description_senaitesetup_number_of_required_verifications"
-msgstr ""
+msgstr "Aantal vereiste verificaties voordat een bepaald resultaat als 'geverifieerd' wordt beschouwd. Deze instelling kan voor elke analyse worden overschreven in de bewerkingsweergave van de analysedienst. Standaard 1"
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
+#, fuzzy
 msgid "description_senaitesetup_publication_email_text"
-msgstr ""
+msgstr "Stel de standaard te gebruiken e-mailtekst in bij het verzenden van resultaatrapporten naar de geselecteerde ontvangers. Je kunt gereserveerde sleutelwoorden gebruiken: $client_name, $recipients, $lab_name, $lab_address"
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
+#, fuzzy
 msgid "description_senaitesetup_rejection_reasons"
-msgstr ""
+msgstr "Voer de vooraf gedefinieerde afwijzingsredenen in die gebruikers kunnen selecteren bij het afwijzen van een monster."
 
 #. When disabled, analysts and lab clerks can also manage worksheets. Note:
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
+#, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_management"
-msgstr ""
+msgstr "Indien ingeschakeld kunnen alleen labmanagers werkbladen aanmaken en beheren. Indien uitgeschakeld kunnen ook analisten en labmedewerkers werkbladen beheren. Let op: deze instelling wordt automatisch ingeschakeld en vergrendeld wanneer de toegang tot werkbladen is beperkt tot toegewezen analisten."
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
+#, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_users_access"
-msgstr ""
+msgstr "Indien ingeschakeld hebben analisten alleen toegang tot werkbladen waaraan zij zijn toegewezen. Indien uitgeschakeld hebben analisten toegang tot alle werkbladen."
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
-msgstr ""
+msgstr "Voorkeursdecimaalteken voor resultaten"
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
+#, fuzzy
 msgid "description_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Indien ingeschakeld kunnen gebruikers met voldoende rechten rechtstreeks vanuit een bestaand monster een broer-monster aanmaken via de actie 'Dupliceren' in de monsterlijst. Standaard ingeschakeld."
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Analyses zijn vereist voor monsterregistratie"
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
+#, fuzzy
 msgid "description_senaitesetup_sampleview_columns_order"
-msgstr ""
+msgstr "Selecteer welke kolommen worden weergegeven in de monsteranalyselijsten. De volgorde van selectie bepaalt de weergavevolgorde. Niet-geselecteerde kolommen worden verborgen. Laat leeg om alle kolommen in de standaardvolgorde weer te geven."
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
-msgstr ""
+msgstr "Voorkeursnotatie voor wetenschappelijke notatie voor rapporten"
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
-msgstr ""
+msgstr "Voorkeursnotatie voor wetenschappelijke notatie voor resultaten"
 
 #. verify it. This setting only take effect for those users with a role
 #. assigned that allows them to verify results (by default, managers,
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
+#, fuzzy
 msgid "description_senaitesetup_self_verification_enabled"
-msgstr ""
+msgstr "Indien ingeschakeld kan een gebruiker die een resultaat heeft ingediend, dit ook verifiëren. Deze instelling werkt alleen voor gebruikers met een toegewezen rol die hen toestaat resultaten te verifiëren (standaard managers, labmanagers en verifieerders). Deze instelling kan voor een bepaalde analyse worden overschreven in de bewerkingsweergave van de analysedienst. Standaard uitgeschakeld."
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
+#, fuzzy
 msgid "description_senaitesetup_show_lab_name_in_login"
-msgstr ""
+msgstr "Indien geselecteerd wordt de naam van het laboratorium weergegeven op de aanmeldpagina, boven de toegangsgegevens."
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
+#, fuzzy
 msgid "description_senaitesetup_show_partitions"
-msgstr ""
+msgstr "Selecteer dit om monsterpartities te tonen aan klantcontactpersonen. Indien gedeactiveerd worden partities niet opgenomen in lijsten en wordt er geen infobericht met links naar het primaire monster weergegeven aan klantcontactpersonen."
 
 #. navigation. The order of selection determines the display order in the
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
+#, fuzzy
 msgid "description_senaitesetup_sidebar_folders"
-msgstr ""
+msgstr "Selecteer welke mappen op het hoogste niveau in de zijbalknavigatie moeten worden weergegeven. De volgorde van selectie bepaalt de weergavevolgorde in de zijbalk. Als er geen zijn geselecteerd, worden alle mappen in de standaardvolgorde weergegeven."
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
+#, fuzzy
 msgid "description_senaitesetup_sidebar_navigation_depth"
-msgstr ""
+msgstr "Maximale diepte van de zijbalknavigatieboom. Niveau 1 toont alleen mappen op het hoogste niveau, niveau 2 bevat de onderliggende mappen, enzovoort."
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
+#, fuzzy
 msgid "description_senaitesetup_sidebar_skip_types"
-msgstr ""
+msgstr "Selecteer welke inhoudstypes moeten worden uitgesloten van de zijbalknavigatie. Als er geen zijn geselecteerd, worden alle inhoudstypes weergegeven."
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
+#, fuzzy
 msgid "description_senaitesetup_type_of_multi_verification"
-msgstr ""
+msgstr "Kies het type meervoudige verificatie voor dezelfde gebruiker. Deze instelling kan het meer dan één keer verifiëren/opeenvolgend verifiëren voor dezelfde gebruiker in-/uitschakelen."
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
+#, fuzzy
 msgid "description_senaitesetup_vat"
-msgstr ""
+msgstr "Voer een percentagewaarde in, bijv. 14.0. Dit percentage wordt systeembreed toegepast, maar kan op afzonderlijke items worden overschreven"
 
 #. view. Classic layout displays the Samples in rows and the analyses in
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
+#, fuzzy
 msgid "description_senaitesetup_worksheet_layout"
-msgstr ""
+msgstr "Voorkeursindeling van de resultaatinvoertabel in de werkbladweergave. De klassieke indeling geeft de monsters in rijen en de analyses in kolommen weer. De getransponeerde indeling geeft de monsters in kolommen en de analyses in rijen weer."
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
+#, fuzzy
 msgid "description_senaitesetup_wsview_columns_order"
-msgstr ""
+msgstr "Selecteer welke kolommen worden weergegeven in de werkbladanalyselijsten. De volgorde van selectie bepaalt de weergavevolgorde. Niet-geselecteerde kolommen worden verborgen. Laat leeg om alle kolommen in de standaardvolgorde weer te geven."
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
+#, fuzzy
 msgid "description_setup_landingpage"
-msgstr ""
+msgstr "De landingspagina wordt getoond aan niet-geauthenticeerde gebruikers als het dashboard niet is geselecteerd als standaard startpagina. Als er geen landingspagina is geselecteerd, wordt de standaard startpagina weergegeven."
 
 #. Default: "Code for the location"
 #: senaite/core/content/storagelocation.py:106
 msgid "description_storagelocation_location_code"
-msgstr ""
+msgstr "Code voor de locatie"
 
 #. Default: "Description of the location"
 #: senaite/core/content/storagelocation.py:118
 msgid "description_storagelocation_location_description"
-msgstr ""
+msgstr "Beschrijving van de locatie"
 
 #. Default: "Title of location"
 #: senaite/core/content/storagelocation.py:94
 msgid "description_storagelocation_location_title"
-msgstr ""
+msgstr "Titel van locatie"
 
 #. Default: "Type of location"
 #: senaite/core/content/storagelocation.py:130
 msgid "description_storagelocation_location_type"
-msgstr ""
+msgstr "Type locatie"
 
 #. Default: "Code the the shelf"
 #: senaite/core/content/storagelocation.py:154
 msgid "description_storagelocation_shelf_code"
-msgstr ""
+msgstr "Code voor de plank"
 
 #. Default: "Description of the shelf"
 #: senaite/core/content/storagelocation.py:166
 msgid "description_storagelocation_shelf_description"
-msgstr ""
+msgstr "Beschrijving van de plank"
 
 #. Default: "Title of the shelf"
 #: senaite/core/content/storagelocation.py:142
 msgid "description_storagelocation_shelf_title"
-msgstr ""
+msgstr "Titel van de plank"
 
 #. Default: "Code for the site"
 #: senaite/core/content/storagelocation.py:70
 msgid "description_storagelocation_site_code"
-msgstr ""
+msgstr "Code voor de vestiging"
 
 #. Default: "Description of the site"
 #: senaite/core/content/storagelocation.py:82
 msgid "description_storagelocation_site_description"
-msgstr ""
+msgstr "Beschrijving van de vestiging"
 
 #. Default: "Title of the site"
 #: senaite/core/content/storagelocation.py:58
 msgid "description_storagelocation_site_title"
-msgstr ""
+msgstr "Titel van de vestiging"
 
 #. Duplicate values are ordered alphabetically."
 #. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 #: senaite/core/content/subgroup.py:60
+#, fuzzy
 msgid "description_subgroup_sort_key"
-msgstr ""
+msgstr "Float-waarde van 0.0 - 1000.0 die de sorteervolgorde aangeeft. Dubbele waarden worden alfabetisch geordend."
 
 #. Default: "International Bank Account Number"
 #: senaite/core/content/supplier.py:100
 msgid "description_supplier_iban"
-msgstr ""
+msgstr "Internationaal bankrekeningnummer"
 
 #. Default: "National Identification Bank Account Number"
 #: senaite/core/content/supplier.py:88
 msgid "description_supplier_nib"
-msgstr ""
+msgstr "Nationaal identificatiebankrekeningnummer"
 
 #. contact profile."
 #. Default: "User is linked to a contact. Please change your settings in the contact profile."
 #: senaite/core/browser/user/userdatapanel.py:82
+#, fuzzy
 msgid "description_user_contact"
-msgstr ""
+msgstr "De gebruiker is gekoppeld aan een contactpersoon. Wijzig je instellingen in het contactprofiel."
 
 #. Default: "Select the preferred instrument"
 #: senaite/core/content/worksheettemplate.py:266
 msgid "description_worksheettemplate_instrument"
-msgstr ""
+msgstr "Selecteer het gewenste instrument"
 
 #. with the selected method.<br/>In order to apply this change to the services
 #. list, you should save the change first."
 #. Default: "Restrict the available analysis services and instruments to those with the selected method.<br/>In order to apply this change to the services list, you should save the change first."
 #: senaite/core/content/worksheettemplate.py:240
+#, fuzzy
 msgid "description_worksheettemplate_restrict_to_method"
-msgstr ""
+msgstr "Beperk de beschikbare analysediensten en instrumenten tot die met de geselecteerde methode.<br/>Om deze wijziging op de dienstenlijst toe te passen, moet je de wijziging eerst opslaan."
 
 #. Default: "Select which Analyses should be included on the Worksheet"
 #: senaite/core/content/worksheettemplate.py:350
 msgid "description_worksheettemplate_services"
-msgstr ""
+msgstr "Selecteer welke analyses op het werkblad moeten worden opgenomen"
 
 #. specific instrument's tray size. Then select an Analysis 'type' per
 #. Worksheet position. Where QC samples are selected, also select which
@@ -8193,398 +8728,405 @@ msgstr ""
 #. indicate which sample position it should be a duplicate of"
 #. Default: "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 #: senaite/core/content/worksheettemplate.py:315
+#, fuzzy
 msgid "description_worksheettemplate_template_layout"
-msgstr ""
+msgstr "Geef de grootte van het werkblad op, bijv. overeenkomend met de traygrootte van een specifiek instrument. Selecteer vervolgens per werkbladpositie een analyse'type'. Waar QC-monsters worden geselecteerd, selecteer ook welk referentiemonster moet worden gebruikt. Als een duplicaatanalyse is geselecteerd, geef dan aan van welke monsterpositie het een duplicaat moet zijn"
 
 #. Default: "Not found Analysis position for duplicate."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:114
 msgid "duplicate_reference_not_found"
-msgstr ""
+msgstr "Analysepositie voor duplicaat niet gevonden."
 
 #. routine analysis."
 #. Default: "Duplicate in position ${dup} references this, so it must be a routine analysis."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:164
+#, fuzzy
 msgid "duplicate_reference_this_position"
-msgstr ""
+msgstr "Duplicaat op positie ${dup} verwijst hiernaar, dus het moet een routineanalyse zijn."
 
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr ""
+msgstr "${days} dagen"
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr ""
+msgstr "${hours} uur"
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr ""
+msgstr "Dagen"
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr ""
+msgstr "Uren"
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr ""
+msgstr "Minuten"
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr ""
+msgstr "Seconden"
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr ""
+msgstr "${minutes} minuten"
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr ""
+msgstr "${seconds} seconden"
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
-msgstr ""
+msgstr "Inhoud van het bestand"
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
+msgstr "bewerkt"
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #: bika/lims/browser/analysisrequest/add2.py:2081
+#, fuzzy
 msgid "error_analyssirequest_numsamples_above_max"
-msgstr ""
+msgstr "Het aantal aan te maken monsters voor record 'Monster ${record_index}' (${num_samples}) ligt boven ${max_num_samples}"
 
 #. Default: "${name} is after ${max_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:120
 msgid "error_datetime_after_max"
-msgstr ""
+msgstr "${name} ligt na ${max_date}, corrigeer dit."
 
 #. Default: "${name} is before ${min_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:94
 msgid "error_datetime_before_min"
-msgstr ""
+msgstr "${name} ligt voor ${min_date}, corrigeer dit."
 
 #. Default: "Unable to load the template"
 #: senaite/core/browser/worksheets/worksheet/printview.py:155
 msgid "error_load_template_worksheet"
-msgstr ""
+msgstr "Kan het sjabloon niet laden"
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:48
 msgid "fieldset_samplepoint_location"
-msgstr ""
+msgstr "Locatie"
 
 #. Default: "Analyses"
 #: senaite/core/content/sampletemplate.py:152
 msgid "fieldset_sampletemplate_analyses"
-msgstr ""
+msgstr "Analyses"
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:141
 msgid "fieldset_sampletemplate_partitions"
-msgstr ""
+msgstr "Partities"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/formula.py:121
 msgid "formula_validation_chain_error"
-msgstr ""
+msgstr "Interne fout in validatieketen: ${error}"
 
 #. Default: "cryogenic / inert gas"
 #: senaite/core/vocabularies/hazard_categories.py:167
 msgid "hazard_ASPH01_common"
-msgstr ""
+msgstr "cryogeen / inert gas"
 
 #. Default: "Asphyxiating atmosphere"
 #: senaite/core/vocabularies/hazard_categories.py:165
 msgid "hazard_ASPH01_name"
-msgstr ""
+msgstr "Verstikkende atmosfeer"
 
 #. Default: "infectious / biological"
 #: senaite/core/vocabularies/hazard_categories.py:104
 msgid "hazard_BIO01_common"
-msgstr ""
+msgstr "infectieus / biologisch"
 
 #. Default: "Biohazard"
 #: senaite/core/vocabularies/hazard_categories.py:103
 msgid "hazard_BIO01_name"
-msgstr ""
+msgstr "Biologisch gevaar"
 
 #. Default: "freezing / cold storage"
 #: senaite/core/vocabularies/hazard_categories.py:158
 msgid "hazard_COLD01_common"
-msgstr ""
+msgstr "vriezen / koude opslag"
 
 #. Default: "Low temperature"
 #: senaite/core/vocabularies/hazard_categories.py:157
 msgid "hazard_COLD01_name"
-msgstr ""
+msgstr "Lage temperatuur"
 
 #. Default: "electric shock"
 #: senaite/core/vocabularies/hazard_categories.py:132
 msgid "hazard_ELEC01_common"
-msgstr ""
+msgstr "elektrische schok"
 
 #. Default: "Electricity"
 #: senaite/core/vocabularies/hazard_categories.py:131
 msgid "hazard_ELEC01_name"
-msgstr ""
+msgstr "Elektriciteit"
 
 #. Default: "explosive"
 #: senaite/core/vocabularies/hazard_categories.py:48
 msgid "hazard_GHS01_common"
-msgstr ""
+msgstr "explosief"
 
 #. Default: "Explosive"
 #: senaite/core/vocabularies/hazard_categories.py:47
 msgid "hazard_GHS01_name"
-msgstr ""
+msgstr "Explosief"
 
 #. Default: "flammable"
 #: senaite/core/vocabularies/hazard_categories.py:54
 msgid "hazard_GHS02_common"
-msgstr ""
+msgstr "ontvlambaar"
 
 #. Default: "Flammable"
 #: senaite/core/vocabularies/hazard_categories.py:53
 msgid "hazard_GHS02_name"
-msgstr ""
+msgstr "Ontvlambaar"
 
 #. Default: "oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:60
 msgid "hazard_GHS03_common"
-msgstr ""
+msgstr "oxiderend"
 
 #. Default: "Oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:59
 msgid "hazard_GHS03_name"
-msgstr ""
+msgstr "Oxiderend"
 
 #. Default: "pressurised gas"
 #: senaite/core/vocabularies/hazard_categories.py:66
 msgid "hazard_GHS04_common"
-msgstr ""
+msgstr "gas onder druk"
 
 #. Default: "Compressed gas"
 #: senaite/core/vocabularies/hazard_categories.py:65
 msgid "hazard_GHS04_name"
-msgstr ""
+msgstr "Samengeperst gas"
 
 #. Default: "acid / caustic"
 #: senaite/core/vocabularies/hazard_categories.py:72
 msgid "hazard_GHS05_common"
-msgstr ""
+msgstr "zuur / bijtend"
 
 #. Default: "Corrosive"
 #: senaite/core/vocabularies/hazard_categories.py:71
 msgid "hazard_GHS05_name"
-msgstr ""
+msgstr "Corrosief"
 
 #. Default: "poisonous"
 #: senaite/core/vocabularies/hazard_categories.py:78
 msgid "hazard_GHS06_common"
-msgstr ""
+msgstr "giftig"
 
 #. Default: "Acute toxicity"
 #: senaite/core/vocabularies/hazard_categories.py:77
 msgid "hazard_GHS06_name"
-msgstr ""
+msgstr "Acute toxiciteit"
 
 #. Default: "harmful / irritant"
 #: senaite/core/vocabularies/hazard_categories.py:84
 msgid "hazard_GHS07_common"
-msgstr ""
+msgstr "schadelijk / irriterend"
 
 #. Default: "Health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:83
 msgid "hazard_GHS07_name"
-msgstr ""
+msgstr "Gezondheidsgevaar"
 
 #. Default: "carcinogenic / mutagenic"
 #: senaite/core/vocabularies/hazard_categories.py:90
 msgid "hazard_GHS08_common"
-msgstr ""
+msgstr "kankerverwekkend / mutageen"
 
 #. Default: "Serious health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:89
 msgid "hazard_GHS08_name"
-msgstr ""
+msgstr "Ernstig gezondheidsgevaar"
 
 #. Default: "environmentally hazardous"
 #: senaite/core/vocabularies/hazard_categories.py:97
 msgid "hazard_GHS09_common"
-msgstr ""
+msgstr "milieugevaarlijk"
 
 #. Default: "Environmental hazard"
 #: senaite/core/vocabularies/hazard_categories.py:96
 msgid "hazard_GHS09_name"
-msgstr ""
+msgstr "Milieugevaar"
 
 #. Default: "heated material"
 #: senaite/core/vocabularies/hazard_categories.py:145
 msgid "hazard_HOT01_common"
-msgstr ""
+msgstr "verhit materiaal"
 
 #. Default: "Hot content"
 #: senaite/core/vocabularies/hazard_categories.py:144
 msgid "hazard_HOT01_name"
-msgstr ""
+msgstr "Hete inhoud"
 
 #. Default: "hot to touch"
 #: senaite/core/vocabularies/hazard_categories.py:139
 msgid "hazard_HSURF01_common"
-msgstr ""
+msgstr "heet bij aanraking"
 
 #. Default: "Hot surface"
 #: senaite/core/vocabularies/hazard_categories.py:138
 msgid "hazard_HSURF01_name"
-msgstr ""
+msgstr "Heet oppervlak"
 
 #. Default: "NMR / MRI"
 #: senaite/core/vocabularies/hazard_categories.py:125
 msgid "hazard_MAG01_common"
-msgstr ""
+msgstr "NMR / MRI"
 
 #. Default: "Magnetic field"
 #: senaite/core/vocabularies/hazard_categories.py:124
 msgid "hazard_MAG01_name"
-msgstr ""
+msgstr "Magnetisch veld"
 
 #. Default: "UV / laser / RF"
 #: senaite/core/vocabularies/hazard_categories.py:118
 msgid "hazard_NIR01_common"
-msgstr ""
+msgstr "UV / laser / RF"
 
 #. Default: "Non-ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:117
 msgid "hazard_NIR01_name"
-msgstr ""
+msgstr "Niet-ioniserende straling"
 
 #. Default: "ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:112
 msgid "hazard_RAD01_common"
-msgstr ""
+msgstr "ioniserende straling"
 
 #. Default: "Radioactive"
 #: senaite/core/vocabularies/hazard_categories.py:111
 msgid "hazard_RAD01_name"
-msgstr ""
+msgstr "Radioactief"
 
 #. Default: "autoclave / sterilisation"
 #: senaite/core/vocabularies/hazard_categories.py:151
 msgid "hazard_STEAM01_common"
-msgstr ""
+msgstr "autoclaaf / sterilisatie"
 
 #. Default: "Hot steam"
 #: senaite/core/vocabularies/hazard_categories.py:150
 msgid "hazard_STEAM01_name"
-msgstr ""
+msgstr "Hete stoom"
 
 #. Default: "Hazardous"
 #: senaite/core/api/hazard.py:37
 msgid "hazard_warning_label"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #. Default: "Legacy Setup"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:16
 msgid "heading_legacy_setup"
-msgstr ""
+msgstr "Verouderde instellingen"
 
 #. Default: "Re-enter the password. Make sure the passwords are identical."
 #: senaite/core/browser/user/passwordpanel.py:44
 msgid "help_confirm_password"
-msgstr ""
+msgstr "Voer het wachtwoord opnieuw in. Zorg ervoor dat de wachtwoorden identiek zijn."
 
 #. Default: "Enter full name, e.g. John Smith."
 #: senaite/core/browser/user/userdatapanel.py:65
 msgid "help_full_name_creation"
-msgstr ""
+msgstr "Voer de volledige naam in, bijv. Jan Jansen."
 
 #. Default: "Enter your new password."
 #: senaite/core/browser/user/passwordpanel.py:37
 msgid "help_new_password"
-msgstr ""
+msgstr "Voer je nieuwe wachtwoord in."
 
 #. Default: "Your time zone"
 #: senaite/core/browser/user/personalpreferences.py:39
 msgid "help_timezone"
-msgstr ""
+msgstr "Je tijdzone"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "hours"
-msgstr ""
+msgstr "uur"
 
 #. Default: "'${function}' not found in module '${module}'"
 #: senaite/core/validators/imports.py:66
 msgid "importable_function_error"
-msgstr ""
+msgstr "'${function}' niet gevonden in module '${module}'"
 
 #. Default: "Could not import module '${module}'"
 #: senaite/core/validators/imports.py:49
 msgid "importable_module_error"
-msgstr ""
+msgstr "Kan module '${module}' niet importeren"
 
 #: bika/lims/browser/publish/templates/email.pt:189
 msgid "in"
-msgstr ""
+msgstr "in"
 
 #. Default: "Instrument exporter not found"
 #: senaite/core/browser/worksheets/worksheet/export.py:66
 msgid "instrument_exporter_not_found_message"
-msgstr ""
+msgstr "Instrumentexporteur niet gevonden"
 
 #. Default: "Interim field ${row_num}: ${message}"
 #: senaite/core/validators/interimfields.py:299
 msgid "interim_field_error"
-msgstr ""
+msgstr "Tussenveld ${row_num}: ${message}"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/interimfields.py:278
 msgid "interims_validation_chain_error"
-msgstr ""
+msgstr "Interne fout in validatieketen: ${error}"
 
 #. Default: "'${field_name}' contains invalid characters"
 #: senaite/core/validators/interimfields.py:68
 msgid "invalid_characters_validator_error"
-msgstr ""
+msgstr "'${field_name}' bevat ongeldige tekens"
 
 #. Default: "AnalysesServices not found for keywords: ${keywords}"
 #: senaite/core/validators/formula.py:92
 msgid "invalid_keyword_error"
-msgstr ""
+msgstr "Geen analysediensten gevonden voor sleutelwoorden: ${keywords}"
 
 #. Default: "Invalid wildcards found: ${wildcards}"
 #: senaite/core/validators/formula.py:71
 msgid "invalid_wildcards_check_error"
-msgstr ""
+msgstr "Ongeldige jokertekens gevonden: ${wildcards}"
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
-msgstr ""
+msgstr "Labels"
 
 #. Default: "Add to the following groups:"
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:276
 msgid "label_add_to_groups"
-msgstr ""
+msgstr "Toevoegen aan de volgende groepen:"
 
 #. Default: "Address"
 #: senaite/core/content/person.py:197
 msgid "label_address"
-msgstr ""
+msgstr "Adres"
 
 #. Default: "Analysis Category"
 #: bika/lims/content/abstractbaseanalysis.py:530
 msgid "label_analysis_category"
-msgstr ""
+msgstr "Analysecategorie"
 
 #. Default: "Department"
 #: bika/lims/content/abstractbaseanalysis.py:588
 msgid "label_analysis_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. of a parameter that can be reliably detected by a specified testing
 #. methodology with a defined level of confidence. Results below this
@@ -8593,13 +9135,14 @@ msgstr ""
 #. detection capability of the method at a reliable level."
 #. Default: "The Lower Limit of Detection (LLOD) is the lowest concentration of a parameter that can be reliably detected by a specified testing methodology with a defined level of confidence. Results below this threshold are typically reported as '< LLOD' (or 'Not Detected'), indicating that the parameter's concentration, if present, is below the detection capability of the method at a reliable level."
 #: bika/lims/content/abstractbaseanalysis.py:207
+#, fuzzy
 msgid "label_analysis_lower_limit_of_detection_description"
-msgstr ""
+msgstr "De ondergrens van detectie (LLOD) is de laagste concentratie van een parameter die betrouwbaar kan worden gedetecteerd met een bepaalde testmethode en een gedefinieerd betrouwbaarheidsniveau. Resultaten onder deze drempel worden doorgaans gerapporteerd als '< LLOD' (of 'Niet gedetecteerd'), wat aangeeft dat de concentratie van de parameter, indien aanwezig, onder de detectiecapaciteit van de methode ligt op een betrouwbaar niveau."
 
 #. Default: "Lower Limit of Detection (LLOD)"
 #: bika/lims/content/abstractbaseanalysis.py:203
 msgid "label_analysis_lower_limit_of_detection_title"
-msgstr ""
+msgstr "Ondergrens van detectie (LLOD)"
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
@@ -8609,33 +9152,34 @@ msgstr ""
 #. cannot be determined reliably."
 #. Default: "The Lower Limit of Quantification (LLOQ) is the lowest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results below this value cannot be quantified with confidence and are typically reported as '< LOQ' (or 'Detected but < LOQ'), indicating that while the parameter may be present, its exact concentration cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:231
+#, fuzzy
 msgid "label_analysis_lower_limit_of_quantification_description"
-msgstr ""
+msgstr "De ondergrens van kwantificering (LLOQ) is de laagste concentratie van een parameter die betrouwbaar en nauwkeurig kan worden gemeten met de bepaalde testmethode, met acceptabele niveaus van precisie en nauwkeurigheid. Resultaten onder deze waarde kunnen niet met vertrouwen worden gekwantificeerd en worden doorgaans gerapporteerd als '< LOQ' (of 'Gedetecteerd maar < LOQ'), wat aangeeft dat de parameter weliswaar aanwezig kan zijn, maar dat de exacte concentratie niet betrouwbaar kan worden bepaald."
 
 #. Default: "Lower Limit Of Quantification (LLOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:227
 msgid "label_analysis_lower_limit_of_quantification_title"
-msgstr ""
+msgstr "Ondergrens van kwantificering (LLOQ)"
 
 #. Default: "Maximum holding time"
 #: bika/lims/content/abstractbaseanalysis.py:453
 msgid "label_analysis_maxholdingtime"
-msgstr ""
+msgstr "Maximale bewaartijd"
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
-msgstr ""
+msgstr "Sorteercriteria"
 
 #. Default: "Default Unit"
 #: bika/lims/content/abstractbaseanalysis.py:108
 msgid "label_analysis_unit"
-msgstr ""
+msgstr "Standaardeenheid"
 
 #. Default: "Units for Selection"
 #: bika/lims/content/abstractbaseanalysis.py:158
 msgid "label_analysis_unitchoices"
-msgstr ""
+msgstr "Eenheden voor selectie"
 
 #. of a parameter that can be reliably measured using a specified testing
 #. methodology. Beyond this limit, results may no longer be accurate or valid
@@ -8645,13 +9189,14 @@ msgstr ""
 #. the method."
 #. Default: "The Upper Limit of Detection (ULOD) is the highest concentration of a parameter that can be reliably measured using a specified testing methodology. Beyond this limit, results may no longer be accurate or valid due to instrument saturation or methodological limitations. Results exceeding this threshold are typically reported as '> ULOD', indicating that the parameter's concentration is above the reliable detection range of the method."
 #: bika/lims/content/abstractbaseanalysis.py:277
+#, fuzzy
 msgid "label_analysis_upper_limit_of_detection_description"
-msgstr ""
+msgstr "De bovengrens van detectie (ULOD) is de hoogste concentratie van een parameter die betrouwbaar kan worden gemeten met een bepaalde testmethode. Boven deze grens zijn resultaten mogelijk niet langer nauwkeurig of geldig vanwege instrumentverzadiging of methodologische beperkingen. Resultaten die deze drempel overschrijden worden doorgaans gerapporteerd als '> ULOD', wat aangeeft dat de concentratie van de parameter boven het betrouwbare detectiebereik van de methode ligt."
 
 #. Default: "Upper Limit of Detection (ULOD)"
 #: bika/lims/content/abstractbaseanalysis.py:274
 msgid "label_analysis_upper_limit_of_detection_title"
-msgstr ""
+msgstr "Bovengrens van detectie (ULOD)"
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
@@ -8660,2367 +9205,2405 @@ msgstr ""
 #. exact concentration cannot be determined reliably."
 #. Default: "The Upper Limit of Quantification (ULOQ) is the highest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results above this value cannot be quantified with confidence and are typically reported as '> ULOQ', indicating that its exact concentration cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:255
+#, fuzzy
 msgid "label_analysis_upper_limit_of_quantification_description"
-msgstr ""
+msgstr "De bovengrens van kwantificering (ULOQ) is de hoogste concentratie van een parameter die betrouwbaar en nauwkeurig kan worden gemeten met de bepaalde testmethode, met acceptabele niveaus van precisie en nauwkeurigheid. Resultaten boven deze waarde kunnen niet met vertrouwen worden gekwantificeerd en worden doorgaans gerapporteerd als '> ULOQ', wat aangeeft dat de exacte concentratie niet betrouwbaar kan worden bepaald."
 
 #. Default: "Upper Limit Of Quantification (ULOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:252
 msgid "label_analysis_upper_limit_of_quantification_title"
-msgstr ""
+msgstr "Bovengrens van kwantificering (ULOQ)"
 
 #. Default: "Sample types"
 #: senaite/core/content/analysisprofile.py:180
 msgid "label_analysisprofile_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Number of samples"
 #: bika/lims/content/analysisrequest.py:1437
 msgid "label_analysisrequest_numsamples"
-msgstr ""
+msgstr "Aantal monsters"
 
 #. Default: "Dynamic Analysis Specification"
 #: bika/lims/content/analysisspec.py:69
 msgid "label_analysisspec_dynamicspec"
-msgstr ""
+msgstr "Dynamische analysespecificatie"
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisspec.py:49
 msgid "label_analysisspec_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Contained Samples"
 #: bika/lims/content/arreport.py:79
 msgid "label_arreport_contained_samples"
-msgstr ""
+msgstr "Bevatte monsters"
 
 #. Default: "Primary Sample"
 #: bika/lims/content/arreport.py:49
 msgid "label_arreport_sample"
-msgstr ""
+msgstr "Primair monster"
 
 #. Default: "Analysis Profile"
 #: bika/lims/content/artemplate.py:254
 msgid "label_artemplate_profile"
-msgstr ""
+msgstr "Analyseprofiel"
 
 #. Default: "Sample Point"
 #: bika/lims/content/artemplate.py:55
 msgid "label_artemplate_samplepoint"
-msgstr ""
+msgstr "Monsterpunt"
 
 #. Default: "Sample Type"
 #: bika/lims/content/artemplate.py:86
 msgid "label_artemplate_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Attachment Type"
 #: bika/lims/content/attachment.py:61
 msgid "label_attachment_type"
-msgstr ""
+msgstr "Bijlagetype"
 
 #. Default: "Instrument"
 #: bika/lims/content/autoimportlog.py:50
 msgid "label_autoimportlog_instrument"
-msgstr ""
+msgstr "Instrument"
 
 #. Default: "Log Time"
 #: bika/lims/content/autoimportlog.py:87
 msgid "label_autoimportlog_logtime"
-msgstr ""
+msgstr "Logtijd"
 
 #. Default: "Results"
 #: bika/lims/content/autoimportlog.py:74
 msgid "label_autoimportlog_results"
-msgstr ""
+msgstr "Resultaten"
 
 #. Default: "Client"
 #: bika/lims/content/batch.py:78
 msgid "label_batch_client"
-msgstr ""
+msgstr "Client"
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Vastlegdatum van resultaat toestaan in te stellen"
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Altijd publicatie-e-mail naar verantwoordelijken sturen"
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Monsteranalyses categoriseren"
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
-msgstr ""
+msgstr "Bemonsteringsdatum vereist"
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
-msgstr ""
+msgstr "E-mailtekst voor meldingen over monsterpublicatie"
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
-msgstr ""
+msgstr "Publicatie-'Van'-adres"
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
-msgstr ""
+msgstr "Directe resultaatinvoer"
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
-msgstr ""
+msgstr "E-mailtekst voor meldingen over het ongeldig maken van monsters"
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
-msgstr ""
+msgstr "Reden voor ongeldig maken vereist"
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Monsteranalyses vereisen"
 
 #. Default: "DependentServices"
 #: senaite/core/content/calculation.py:352
 msgid "label_calculation_dependent_services"
-msgstr ""
+msgstr "Afhankelijke diensten"
 
 #. Default: "Dependent services"
 #: bika/lims/content/calculation.py:81
 msgid "label_calculation_dependentservices"
-msgstr ""
+msgstr "Afhankelijke diensten"
 
 #. Default: "Calculation Formula"
 #: senaite/core/content/calculation.py:287
 msgid "label_calculation_formula"
-msgstr ""
+msgstr "Berekeningsformule"
 
 #. Default: "Function"
 #: senaite/core/content/calculation.py:185
 msgid "label_calculation_import_function_name"
-msgstr ""
+msgstr "Functie"
 
 #. Default: "Module"
 #: senaite/core/content/calculation.py:179
 msgid "label_calculation_import_module_name"
-msgstr ""
+msgstr "Module"
 
 #. Default: "Additional Python Libraries"
 #: senaite/core/content/calculation.py:266
 msgid "label_calculation_imports"
-msgstr ""
+msgstr "Aanvullende Python-bibliotheken"
 
 #. Default: "Calculation Interim Fields"
 #: senaite/core/content/calculation.py:243
 msgid "label_calculation_interims"
-msgstr ""
+msgstr "Tussenvelden voor berekening"
 
 #. Default: "Raw Test Result"
 #: senaite/core/content/calculation.py:336
 msgid "label_calculation_raw_test_keywords"
-msgstr ""
+msgstr "Ruw testresultaat"
 
 #. Default: "Keyword"
 #: senaite/core/content/calculation.py:198
 msgid "label_calculation_test_param_keyword"
-msgstr ""
+msgstr "Sleutelwoord"
 
 #. Default: "Value"
 #: senaite/core/content/calculation.py:207
 msgid "label_calculation_test_param_value"
-msgstr ""
+msgstr "Waarde"
 
 #. Default: "Test Parameters"
 #: senaite/core/content/calculation.py:317
 msgid "label_calculation_test_params"
-msgstr ""
+msgstr "Testparameters"
 
 #. Default: "Test Result"
 #: senaite/core/content/calculation.py:343
 msgid "label_calculation_test_result"
-msgstr ""
+msgstr "Testresultaat"
 
 #. Default: "Department"
 #: bika/lims/content/analysiscategory.py:59
 msgid "label_category_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
-msgstr ""
+msgstr "Standaardcategorieën"
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
-msgstr ""
+msgstr "Categorieën beperken"
 
 #. Default: "Confirm password"
 #: senaite/core/browser/user/passwordpanel.py:43
 msgid "label_confirm_password"
-msgstr ""
+msgstr "Wachtwoord bevestigen"
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
-msgstr ""
+msgstr "Contactpersonen voor CC"
 
 #. Default: "Email Telephone Fax"
 #: senaite/core/content/person.py:137
 msgid "label_contact_information"
-msgstr ""
+msgstr "E-mail Telefoon Fax"
 
 #. Default: "Preservation"
 #: bika/lims/content/container.py:97
 msgid "label_container_preservation"
-msgstr ""
+msgstr "Conservering"
 
 #. Default: "Container Type"
 #: bika/lims/content/container.py:54
 msgid "label_container_type"
-msgstr ""
+msgstr "Containertype"
 
 #. Default: "Manager"
 #: senaite/core/content/department.py:102
 msgid "label_department_manager"
-msgstr ""
+msgstr "Manager"
 
 #. edit the container itself, ${go_here}."
 #. Default: "You are editing the default view of a container. If you wanted to edit the container itself, ${go_here}."
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
+#, fuzzy
 msgid "label_edit_default_view_container"
-msgstr ""
+msgstr "Je bewerkt de standaardweergave van een container. Als je de container zelf wilde bewerken, ${go_here}."
 
 #. Default: "go here"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
 msgid "label_edit_default_view_container_go_here"
-msgstr ""
+msgstr "ga hierheen"
 
 #. Default: "Bank Details"
 #: senaite/core/content/supplier.py:72
 msgid "label_fieldset_supplier_bank_details"
-msgstr ""
+msgstr "Bankgegevens"
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheettemplate.py:332
 msgid "label_fieldset_worksheettemplate_analyses"
-msgstr ""
+msgstr "Analyses"
 
 #. Default: "Layout"
 #: senaite/core/content/worksheettemplate.py:275
 msgid "label_fieldset_worksheettemplate_layout"
-msgstr ""
+msgstr "Indeling"
 
 #. Default: "Include client contacts"
 #: senaite/core/browser/controlpanel/contacts/templates/contacts_filter.pt:10
 msgid "label_include_client_contacts"
-msgstr ""
+msgstr "Klantcontactpersonen opnemen"
 
 #. Default: "Location"
 #: bika/lims/content/instrument.py:319
 msgid "label_instrument_instrumentlocation"
-msgstr ""
+msgstr "Locatie"
 
 #. Default: "Instrument type"
 #: bika/lims/content/instrument.py:79
 msgid "label_instrument_instrumenttype"
-msgstr ""
+msgstr "Instrumenttype"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/instrument.py:99
 msgid "label_instrument_manufacturer"
-msgstr ""
+msgstr "Fabrikant"
 
 #. Default: "Supported methods"
 #: bika/lims/content/instrument.py:172
 msgid "label_instrument_methods"
-msgstr ""
+msgstr "Ondersteunde methoden"
 
 #. Default: "Result files folders"
 #: bika/lims/content/instrument.py:265
 msgid "label_instrument_result_file_folder"
-msgstr ""
+msgstr "Mappen voor resultaatbestanden"
 
 #. Default: "Supplier"
 #: bika/lims/content/instrument.py:119
 msgid "label_instrument_supplier"
-msgstr ""
+msgstr "Leverancier"
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentcalibration.py:127
 msgid "label_instrumentcalibration_worker"
-msgstr ""
+msgstr "Uitgevoerd door"
 
 #. Default: "Prepared by"
 #: bika/lims/content/instrumentcertification.py:146
 msgid "label_instrumentcertification_preparator"
-msgstr ""
+msgstr "Voorbereid door"
 
 #. Default: "Approved by"
 #: bika/lims/content/instrumentcertification.py:170
 msgid "label_instrumentcertification_validator"
-msgstr ""
+msgstr "Goedgekeurd door"
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentvalidation.py:109
 msgid "label_instrumentvalidation_worker"
-msgstr ""
+msgstr "Uitgevoerd door"
 
 #. Default: "Allow empty"
 #: senaite/core/schema/interimfields.py:87
 msgid "label_interim_allow_empty"
-msgstr ""
+msgstr "Leeg toestaan"
 
 #. Default: "Apply wide"
 #: senaite/core/schema/interimfields.py:127
 msgid "label_interim_apply_wide"
-msgstr ""
+msgstr "Breed toepassen"
 
 #. Default: "Choices"
 #: senaite/core/schema/interimfields.py:67
 msgid "label_interim_choices"
-msgstr ""
+msgstr "Keuzes"
 
 #. Default: "Default value"
 #: senaite/core/schema/interimfields.py:57
 msgid "label_interim_default_value"
-msgstr ""
+msgstr "Standaardwaarde"
 
 #. Default: "Hidden"
 #: senaite/core/schema/interimfields.py:117
 msgid "label_interim_hidden"
-msgstr ""
+msgstr "Verborgen"
 
 #. Default: "Keyword"
 #: senaite/core/schema/interimfields.py:37
 msgid "label_interim_keyword"
-msgstr ""
+msgstr "Sleutelwoord"
 
 #. Default: "Report"
 #: senaite/core/schema/interimfields.py:107
 msgid "label_interim_report"
-msgstr ""
+msgstr "Rapport"
 
 #. Default: "Result type"
 #: senaite/core/schema/interimfields.py:76
 msgid "label_interim_result_type"
-msgstr ""
+msgstr "Resultaattype"
 
 #. Default: "Field title"
 #: senaite/core/schema/interimfields.py:47
 msgid "label_interim_title"
-msgstr ""
+msgstr "Veldtitel"
 
 #. Default: "Unit"
 #: senaite/core/schema/interimfields.py:97
 msgid "label_interim_unit"
-msgstr ""
+msgstr "Eenheid"
 
 #. Default: "Default Department"
 #: bika/lims/content/labcontact.py:86
 msgid "label_labcontact_default_department"
-msgstr ""
+msgstr "Standaardafdeling"
 
 #. Default: "Departments"
 #: bika/lims/content/labcontact.py:59
 msgid "label_labcontact_departments"
-msgstr ""
+msgstr "Afdelingen"
 
 #. Default: "Supervisor"
 #: senaite/core/content/laboratory.py:73
 msgid "label_laboratory_supervisor"
-msgstr ""
+msgstr "Supervisor"
 
 #. Default: "Document ID"
 #: senaite/core/content/multifile.py:39
 msgid "label_multifile_document_id"
-msgstr ""
+msgstr "Document-ID"
 
 #. Default: "Document Location"
 #: senaite/core/content/multifile.py:67
 msgid "label_multifile_document_location"
-msgstr ""
+msgstr "Documentlocatie"
 
 #. Default: "Document Type"
 #: senaite/core/content/multifile.py:79
 msgid "label_multifile_document_type"
-msgstr ""
+msgstr "Documenttype"
 
 #. Default: "Document Version"
 #: senaite/core/content/multifile.py:59
 msgid "label_multifile_document_version"
-msgstr ""
+msgstr "Documentversie"
 
 #. Default: "Document"
 #: senaite/core/content/multifile.py:47
 msgid "label_multifile_file"
-msgstr ""
+msgstr "Document"
 
 #. Default: "New password"
 #: senaite/core/browser/user/passwordpanel.py:36
 msgid "label_new_password"
-msgstr ""
+msgstr "Nieuw wachtwoord"
 
 #. Default: "Fax (business)"
 #: senaite/core/content/person.py:169
 msgid "label_person_business_fax"
-msgstr ""
+msgstr "Fax (zakelijk)"
 
 #. Default: "Phone (business)"
 #: senaite/core/content/person.py:160
 msgid "label_person_business_phone"
-msgstr ""
+msgstr "Telefoon (zakelijk)"
 
 #. Default: "Department"
 #: senaite/core/content/person.py:119
 msgid "label_person_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. Default: "Description"
 #: senaite/core/content/person.py:59
 msgid "label_person_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Email Address"
 #: senaite/core/content/person.py:151
 msgid "label_person_email_address"
-msgstr ""
+msgstr "E-mailadres"
 
 #. Default: "Firstname"
 #: senaite/core/content/person.py:79
 msgid "label_person_firstname"
-msgstr ""
+msgstr "Voornaam"
 
 #. Default: "Phone (home)"
 #: senaite/core/content/person.py:178
 msgid "label_person_home_phone"
-msgstr ""
+msgstr "Telefoon (privé)"
 
 #. Default: "Job title"
 #: senaite/core/content/person.py:111
 msgid "label_person_job_title"
-msgstr ""
+msgstr "Functietitel"
 
 #. Default: "Middle initial"
 #: senaite/core/content/person.py:87
 msgid "label_person_middleinitial"
-msgstr ""
+msgstr "Tussenletter"
 
 #. Default: "Middle name"
 #: senaite/core/content/person.py:95
 msgid "label_person_middlename"
-msgstr ""
+msgstr "Tussennaam"
 
 #. Default: "Phone (mobile)"
 #: senaite/core/content/person.py:187
 msgid "label_person_mobile_phone"
-msgstr ""
+msgstr "Telefoon (mobiel)"
 
 #. Default: "Physical address"
 #: senaite/core/content/person.py:210
 msgid "label_person_physical_address"
-msgstr ""
+msgstr "Fysiek adres"
 
 #. Default: "Postal address"
 #: senaite/core/content/person.py:219
 msgid "label_person_postal_address"
-msgstr ""
+msgstr "Postadres"
 
 #. Default: "Salutation"
 #: senaite/core/content/person.py:67
 msgid "label_person_salutation"
-msgstr ""
+msgstr "Aanhef"
 
 #. Default: "Surname"
 #: senaite/core/content/person.py:103
 msgid "label_person_surname"
-msgstr ""
+msgstr "Achternaam"
 
 #. Default: "Title"
 #: senaite/core/content/person.py:51
 msgid "label_person_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Username"
 #: senaite/core/content/person.py:127
 msgid "label_person_username"
-msgstr ""
+msgstr "Gebruikersnaam"
 
 #. Default: "SENAITE is powered by"
 #: senaite/core/browser/viewlets/templates/colophon.pt:11
 msgid "label_powered_by"
-msgstr ""
+msgstr "SENAITE draait op"
 
 #. Default: "Plone & Python"
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "label_powered_by_plone"
-msgstr ""
+msgstr "Plone & Python"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
-msgstr ""
+msgstr "Publicatievoorkeur"
 
 #. Default: "Blank"
 #: bika/lims/content/referencedefinition.py:75
 msgid "label_referencedefinition_blank"
-msgstr ""
+msgstr "Blanco"
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencedefinition.py:104
 msgid "label_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën"
 
 #. Default: "Hazardous"
 #: bika/lims/content/referencedefinition.py:89
 msgid "label_referencedefinition_hazardous"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #. Default: "Reference Values"
 #: bika/lims/content/referencedefinition.py:53
 msgid "label_referencedefinition_referencevalues"
-msgstr ""
+msgstr "Referentiewaarden"
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencesample.py:116
 msgid "label_referencesample_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/referencesample.py:133
 msgid "label_referencesample_manufacturer"
-msgstr ""
+msgstr "Fabrikant"
 
 #. Default: "Reference Definition"
 #: bika/lims/content/referencesample.py:79
 msgid "label_referencesample_referencedefinition"
-msgstr ""
+msgstr "Referentiedefinitie"
 
 #. Default: "Catalog mappings"
 #: senaite/core/registry/schema.py:274
 msgid "label_registry_catalog_mappings"
-msgstr ""
+msgstr "Catalogustoewijzingen"
 
 #. Default: "Portal type"
 #: senaite/core/registry/schema.py:286
 msgid "label_registry_catalog_mappings_key"
-msgstr ""
+msgstr "Portaaltype"
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:293
 msgid "label_registry_catalog_mappings_value"
-msgstr ""
+msgstr "Catalogi"
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:265
 msgid "label_registry_catalogs_fieldset"
-msgstr ""
+msgstr "Catalogi"
 
 #. Default: "Client landing page"
 #: senaite/core/registry/schema.py:47
 msgid "label_registry_client_landing_page"
-msgstr ""
+msgstr "Landingspagina voor klant"
 
 #. Default: "Portal types to skip on content structure export"
 #: senaite/core/registry/schema.py:234
 msgid "label_registry_generic_setup_skip_export_types"
-msgstr ""
+msgstr "Portaaltypes om over te slaan bij export van inhoudsstructuur"
 
 #. Default: "Import"
 #: senaite/core/registry/schema.py:428
 msgid "label_registry_import"
-msgstr ""
+msgstr "Importeren"
 
 #. Default: "Attach import file to Analyses"
 #: senaite/core/registry/schema.py:439
 msgid "label_registry_import_analysis_attach_attachment"
-msgstr ""
+msgstr "Importbestand aan analyses koppelen"
 
 #. Default: "Submit Analyses upon import"
 #: senaite/core/registry/schema.py:452
 msgid "label_registry_import_analysis_submit"
-msgstr ""
+msgstr "Analyses indienen bij import"
 
 #. Default: "Allow multi paste"
 #: senaite/core/registry/schema.py:371
 msgid "label_registry_sample_add_allow_multi_paste_fields"
-msgstr ""
+msgstr "Meervoudig plakken toestaan"
 
 #. Default: "Commit each sample in its own transaction"
 #: senaite/core/registry/schema.py:387
 msgid "label_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Elk monster in een eigen transactie vastleggen"
 
 #. Default: "Copy sample structure with partitions"
 #: senaite/core/registry/schema.py:324
 msgid "label_registry_sample_add_copy_partitions"
-msgstr ""
+msgstr "Monsterstructuur met partities kopiëren"
 
 #. Default: "Skip analyses workflow states on copy"
 #: senaite/core/registry/schema.py:355
 msgid "label_registry_sample_add_skip_analyses_in_states"
-msgstr ""
+msgstr "Werkstroomstatussen van analyses overslaan bij kopiëren"
 
 #. Default: "Skip partition analyses on copy"
 #: senaite/core/registry/schema.py:340
 msgid "label_registry_sample_add_skip_partition_analyses"
-msgstr ""
+msgstr "Partitieanalyses overslaan bij kopiëren"
 
 #. Default: "Samples"
 #: senaite/core/registry/schema.py:309
 msgid "label_registry_samples"
-msgstr ""
+msgstr "Monsters"
 
 #. Default: "Trigger events on sample creation"
 #: senaite/core/registry/schema.py:406
 msgid "label_registry_trigger_events_on_sample_creation"
-msgstr ""
+msgstr "Gebeurtenissen activeren bij aanmaken monster"
 
 #. Default: "Worksheet"
 #: senaite/core/registry/schema.py:95
 msgid "label_registry_worksheet_settings"
-msgstr ""
+msgstr "Werkblad"
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
-msgstr ""
+msgstr "Bevatte monsters"
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
-msgstr ""
+msgstr "Primair monster"
 
 #. Default: "Batch"
 #: bika/lims/content/analysisrequest.py:328
 msgid "label_sample_batch"
-msgstr ""
+msgstr "Batch"
 
 #. Default: "CC Contact"
 #: bika/lims/content/analysisrequest.py:197
 msgid "label_sample_cccontact"
-msgstr ""
+msgstr "CC-contact"
 
 #. Default: "Client"
 #: bika/lims/content/analysisrequest.py:255
 msgid "label_sample_client"
-msgstr ""
+msgstr "Client"
 
 #. Default: "Contact"
 #: bika/lims/content/analysisrequest.py:156
 msgid "label_sample_contact"
-msgstr ""
+msgstr "Contact"
 
 #. Default: "Container"
 #: bika/lims/content/analysisrequest.py:566
 msgid "label_sample_container"
-msgstr ""
+msgstr "Container"
 
 #. Default: "Date Sampled"
 #: bika/lims/content/analysisrequest.py:449
 msgid "label_sample_datesampled"
-msgstr ""
+msgstr "Datum bemonsterd"
 
 #. Default: "Detached from sample"
 #: bika/lims/content/analysisrequest.py:1308
 msgid "label_sample_detached_from"
-msgstr ""
+msgstr "Losgekoppeld van monster"
 
 #. Default: "Duplicated from sample"
 #: bika/lims/content/analysisrequest.py:1280
 msgid "label_sample_duplicated_from"
-msgstr ""
+msgstr "Gedupliceerd van monster"
 
 #. Default: "Invoice"
 #: bika/lims/content/analysisrequest.py:1046
 msgid "label_sample_invoice"
-msgstr ""
+msgstr "Factuur"
 
 #. Default: "Parent sample"
 #: bika/lims/content/analysisrequest.py:1252
 msgid "label_sample_parent_sample"
-msgstr ""
+msgstr "Bovenliggend monster"
 
 #. Default: "Preservation"
 #: bika/lims/content/analysisrequest.py:597
 msgid "label_sample_preservation"
-msgstr ""
+msgstr "Conservering"
 
 #. Default: "Primary Sample"
 #: bika/lims/content/analysisrequest.py:292
 msgid "label_sample_primary"
-msgstr ""
+msgstr "Primair monster"
 
 #. Default: "Analysis Profiles"
 #: bika/lims/content/analysisrequest.py:418
 msgid "label_sample_profiles"
-msgstr ""
+msgstr "Analyseprofielen"
 
 #. Default: "Publication Specification"
 #: bika/lims/content/analysisrequest.py:734
 msgid "label_sample_publicationspecification"
-msgstr ""
+msgstr "Publicatiespecificatie"
 
 #. Default: "Retest from sample"
 #: bika/lims/content/analysisrequest.py:1336
 msgid "label_sample_retracted"
-msgstr ""
+msgstr "Hertest van monster"
 
 #. Default: "Sample Condition"
 #: bika/lims/content/analysisrequest.py:897
 msgid "label_sample_samplecondition"
-msgstr ""
+msgstr "Monstertoestand"
 
 #. Default: "Sample Point"
 #: bika/lims/content/analysisrequest.py:767
 msgid "label_sample_samplepoint"
-msgstr ""
+msgstr "Monsterpunt"
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisrequest.py:538
 msgid "label_sample_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Expected Sampling Date"
 #: bika/lims/content/analysisrequest.py:512
 msgid "label_sample_samplingdate"
-msgstr ""
+msgstr "Verwachte monsternamedatum"
 
 #. Default: "Sampling Deviation"
 #: bika/lims/content/analysisrequest.py:869
 msgid "label_sample_samplingdeviation"
-msgstr ""
+msgstr "Monsternameafwijking"
 
 #. Default: "Analysis Specification"
 #: bika/lims/content/analysisrequest.py:690
 msgid "label_sample_specification"
-msgstr ""
+msgstr "Analysespecificatie"
 
 #. Default: "Storage Location"
 #: bika/lims/content/analysisrequest.py:791
 msgid "label_sample_storagelocation"
-msgstr ""
+msgstr "Opslaglocatie"
 
 #. Default: "Batch Sub-group"
 #: bika/lims/content/analysisrequest.py:363
 msgid "label_sample_subgroup"
-msgstr ""
+msgstr "Batch-subgroep"
 
 #. Default: "Sample Template"
 #: bika/lims/content/analysisrequest.py:390
 msgid "label_sample_template"
-msgstr ""
+msgstr "Monstersjabloon"
 
 #. Default: "Sample Types"
 #: bika/lims/content/samplepoint.py:95
 msgid "label_samplepoint_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Category"
 #: senaite/core/content/samplepreservation.py:55
 msgid "label_samplepreservation_category"
-msgstr ""
+msgstr "Categorie"
 
 #. Default: "Container"
 #: senaite/core/content/sampletemplate.py:81
 msgid "label_sampletemplate_partition_container"
-msgstr ""
+msgstr "Container"
 
 #. Default: "Partition ID"
 #: senaite/core/content/sampletemplate.py:60
 msgid "label_sampletemplate_partition_part_id"
-msgstr ""
+msgstr "Partitie-ID"
 
 #. Default: "Preservation"
 #: senaite/core/content/sampletemplate.py:103
 msgid "label_sampletemplate_partition_preservation"
-msgstr ""
+msgstr "Conservering"
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:125
 msgid "label_sampletemplate_partition_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:243
 msgid "label_sampletemplate_partitions"
-msgstr ""
+msgstr "Partities"
 
 #. Default: "Sample Point"
 #: senaite/core/content/sampletemplate.py:185
 msgid "label_sampletemplate_samplepoint"
-msgstr ""
+msgstr "Monsterpunt"
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:207
 msgid "label_sampletemplate_sampletype"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Admitted stickers for the sample type"
 #: senaite/core/content/sampletype.py:100
 msgid "label_sampletype_admitted"
-msgstr ""
+msgstr "Toegestane stickers voor het monstertype"
 
 #. Default: "Admitted sticker templates"
 #: senaite/core/content/sampletype.py:279
 msgid "label_sampletype_admitted_stickers_templates"
-msgstr ""
+msgstr "Toegestane stickersjablonen"
 
 #. Default: "Default Container Type"
 #: senaite/core/content/sampletype.py:254
 msgid "label_sampletype_containertype"
-msgstr ""
+msgstr "Standaard containertype"
 
 #. Default: "Description"
 #: senaite/core/content/sampletype.py:142
 msgid "label_sampletype_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Default large sticker"
 #: senaite/core/content/sampletype.py:120
 msgid "label_sampletype_large_default"
-msgstr ""
+msgstr "Standaard grote sticker"
 
 #. Default: "Sample Matrix"
 #: senaite/core/content/sampletype.py:204
 msgid "label_sampletype_samplematrix"
-msgstr ""
+msgstr "Monstermatrix"
 
 #. Default: "Default small sticker"
 #: senaite/core/content/sampletype.py:111
 msgid "label_sampletype_small_default"
-msgstr ""
+msgstr "Standaard kleine sticker"
 
 #. Default: "Name"
 #: senaite/core/content/sampletype.py:134
 msgid "label_sampletype_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
-msgstr ""
+msgstr "Opslaan"
 
 #. Default: "SENAITE LIMS"
 #: senaite/core/browser/viewlets/templates/footer.pt:14
 msgid "label_senaite"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
-msgstr ""
+msgstr "Maximumwaarde voor het veld 'Aantal monsters' bij registratie"
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
-msgstr ""
+msgstr "Startpagina"
 
 #. Default: "Item"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:78
 msgid "label_setupview_item"
-msgstr ""
+msgstr "Item"
 
 #. Default: "Items"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:81
 msgid "label_setupview_items"
-msgstr ""
+msgstr "Items"
 
 #. Default: "Out of range comment"
 #: bika/lims/browser/fields/resultrangefield.py:42
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:136
 msgid "label_specs_rangecomment"
-msgstr ""
+msgstr "Opmerking buiten bereik"
 
 #. Default: "Time zone"
 #: senaite/core/browser/user/personalpreferences.py:38
 msgid "label_timezone"
-msgstr ""
+msgstr "Tijdzone"
 
 #. Default: "Title"
 #: senaite/core/browser/install/templates/senaite-addsite.pt:62
 msgid "label_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Upgrade…"
 #: senaite/core/browser/install/templates/senaite-overview.pt:67
 msgid "label_upgrade_hellip"
-msgstr ""
+msgstr "Upgraden…"
 
 #. Default: "Contact"
 #: senaite/core/browser/user/userdatapanel.py:81
 msgid "label_user_contact"
-msgstr ""
+msgstr "Contact"
 
 #. Default: "Email"
 #: senaite/core/browser/user/userdatapanel.py:70
 msgid "label_user_email"
-msgstr ""
+msgstr "E-mail"
 
 #. Default: "Full Name"
 #: senaite/core/browser/user/userdatapanel.py:64
 msgid "label_user_full_name"
-msgstr ""
+msgstr "Volledige naam"
 
 #. Default: "Preferred instrument"
 #: senaite/core/content/worksheettemplate.py:262
 msgid "label_worksheettemplate_instrument"
-msgstr ""
+msgstr "Voorkeursinstrument"
 
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
-msgstr ""
+msgstr "Beperken tot methode"
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr "${count} label(s) toegevoegd aan ${affected} monster(s)"
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+#, fuzzy
+msgid "labels_changed"
+msgstr "${added} toegevoegd en ${removed} verwijderd toegepast op ${affected} monster(s)"
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
+msgstr "${count} label(s) verwijderd van ${affected} monster(s)"
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
 msgid "listing_add_analyses_column_category_title"
-msgstr ""
+msgstr "Categorie"
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:93
 msgid "listing_add_analyses_column_client"
-msgstr ""
+msgstr "Client"
 
 #. Default: "Order"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:102
 msgid "listing_add_analyses_column_client_order_number"
-msgstr ""
+msgstr "Order"
 
 #. Default: "Date Received"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:132
 msgid "listing_add_analyses_column_date_received"
-msgstr ""
+msgstr "Datum ontvangen"
 
 #. Default: "Due Date"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:139
 msgid "listing_add_analyses_column_due_date"
-msgstr ""
+msgstr "Vervaldatum"
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:110
 msgid "listing_add_analyses_column_request_id"
-msgstr ""
+msgstr "Aanvraag-ID"
 
 #. Default: "Analysis"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:125
 msgid "listing_add_analyses_column_title"
-msgstr ""
+msgstr "Analyse"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:150
 msgid "listing_add_analyses_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Filter by template method"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:221
 msgid "listing_add_analyses_state_restrict_to_method"
-msgstr ""
+msgstr "Filteren op sjabloonmethode"
 
 #. Default: "Filter by template services"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:203
 msgid "listing_add_analyses_state_restrict_to_services"
-msgstr ""
+msgstr "Filteren op sjabloondiensten"
 
 #. Default: "Add Analyses"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:74
 msgid "listing_add_analyses_title"
-msgstr ""
+msgstr "Analyses toevoegen"
 
 #. Default: "Add Blank Reference"
 #: senaite/core/browser/worksheets/worksheet/add_blank.py:44
 msgid "listing_add_blank_title"
-msgstr ""
+msgstr "Blancoreferentie toevoegen"
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/add_control.py:43
 msgid "listing_add_control_title"
-msgstr ""
+msgstr "Controlereferentie toevoegen"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:99
 msgid "listing_add_duplicate_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Add Duplicate"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:51
 msgid "listing_add_duplicate_title"
-msgstr ""
+msgstr "Duplicaat toevoegen"
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:81
 msgid "listing_add_duplication_column_client"
-msgstr ""
+msgstr "Client"
 
 #. Default: "Date Requested"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:88
 msgid "listing_add_duplication_column_created"
-msgstr ""
+msgstr "Datum aangevraagd"
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:74
 msgid "listing_add_duplication_column_request_id"
-msgstr ""
+msgstr "Aanvraag-ID"
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:67
 msgid "listing_add_duplication_column_title"
-msgstr ""
+msgstr "Positie"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:50
 msgid "listing_analysiscategories_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Department"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:80
 msgid "listing_analysiscategories_column_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:72
 msgid "listing_analysiscategories_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:87
 msgid "listing_analysiscategories_column_sort_key"
-msgstr ""
+msgstr "Sorteersleutel"
 
 #. Default: "Category"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:66
 msgid "listing_analysiscategories_column_title"
-msgstr ""
+msgstr "Categorie"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:98
 msgid "listing_analysiscategories_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:114
 msgid "listing_analysiscategories_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:106
 msgid "listing_analysiscategories_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Analysis Categories"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:57
 msgid "listing_analysiscategories_title"
-msgstr ""
+msgstr "Analysecategorieën"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:54
 msgid "listing_analysisprofiles_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:76
 msgid "listing_analysisprofiles_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Profile Key"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:83
 msgid "listing_analysisprofiles_column_profilekey"
-msgstr ""
+msgstr "Profielsleutel"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:91
 msgid "listing_analysisprofiles_column_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Profile"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:69
 msgid "listing_analysisprofiles_column_title"
-msgstr ""
+msgstr "Profiel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:103
 msgid "listing_analysisprofiles_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:119
 msgid "listing_analysisprofiles_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:111
 msgid "listing_analysisprofiles_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Analysis Profiles"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:61
 msgid "listing_analysisprofiles_title"
-msgstr ""
+msgstr "Analyseprofielen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:50
 msgid "listing_attachmenttypes_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:73
 msgid "listing_attachmenttypes_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:67
 msgid "listing_attachmenttypes_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:83
 msgid "listing_attachmenttypes_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:99
 msgid "listing_attachmenttypes_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:91
 msgid "listing_attachmenttypes_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Attachment Types"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:57
 msgid "listing_attachmenttypes_title"
-msgstr ""
+msgstr "Bijlagetypes"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:50
 msgid "listing_batchlabels_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:67
 msgid "listing_batchlabels_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:77
 msgid "listing_batchlabels_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:93
 msgid "listing_batchlabels_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:85
 msgid "listing_batchlabels_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Batch Labels"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:57
 msgid "listing_batchlabels_title"
-msgstr ""
+msgstr "Batchlabels"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/calculations/view.py:51
 msgid "listing_calculation_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/calculations/view.py:75
 msgid "listing_calculation_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Formula"
 #: senaite/core/browser/controlpanel/calculations/view.py:82
 msgid "listing_calculation_formula"
-msgstr ""
+msgstr "Formule"
 
 #. Default: "Calculation"
 #: senaite/core/browser/controlpanel/calculations/view.py:68
 msgid "listing_calculation_title"
-msgstr ""
+msgstr "Berekening"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/calculations/view.py:93
 msgid "listing_calculations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/calculations/view.py:111
 msgid "listing_calculations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/calculations/view.py:102
 msgid "listing_calculations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Calculations"
 #: senaite/core/browser/controlpanel/calculations/view.py:58
 msgid "listing_calculations_title"
-msgstr ""
+msgstr "Berekeningen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/containertypes/view.py:51
 msgid "listing_containertypes_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/containertypes/view.py:72
 msgid "listing_containertypes_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/containertypes/view.py:66
 msgid "listing_containertypes_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/containertypes/view.py:82
 msgid "listing_containertypes_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/containertypes/view.py:98
 msgid "listing_containertypes_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/containertypes/view.py:90
 msgid "listing_containertypes_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Container Types"
 #: senaite/core/browser/controlpanel/containertypes/view.py:58
 msgid "listing_containertypes_title"
-msgstr ""
+msgstr "Containertypes"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:52
 msgid "listing_dynamic_analysisspec_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:61
 msgid "listing_dynamic_analysisspec_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:76
 msgid "listing_dynamic_analysisspecs_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:70
 msgid "listing_dynamic_analysisspecs_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:86
 msgid "listing_dynamic_analysisspecs_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:102
 msgid "listing_dynamic_analysisspecs_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:94
 msgid "listing_dynamic_analysisspecs_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Dynamic Analysis Specifications"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:61
 msgid "listing_dynamic_analysisspecs_title"
-msgstr ""
+msgstr "Dynamische analysespecificaties"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:52
 msgid "listing_instrumentlocations_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:74
 msgid "listing_instrumentlocations_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Location"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:67
 msgid "listing_instrumentlocations_column_title"
-msgstr ""
+msgstr "Locatie"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:94
 msgid "listing_instrumentlocations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:86
 msgid "listing_instrumentlocations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:102
 msgid "listing_instrumentlocations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Instrument Locations"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:58
 msgid "listing_instrumentlocations_title"
-msgstr ""
+msgstr "Instrumentlocaties"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:49
 msgid "listing_instrumenttypes_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:72
 msgid "listing_instrumenttypes_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:65
 msgid "listing_instrumenttypes_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:83
 msgid "listing_instrumenttypes_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:101
 msgid "listing_instrumenttypes_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:92
 msgid "listing_instrumenttypes_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Instrument Types"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:56
 msgid "listing_instrumenttypes_title"
-msgstr ""
+msgstr "Instrumenttypes"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:52
 msgid "listing_interpretationtemplates_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:75
 msgid "listing_interpretationtemplates_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:81
 msgid "listing_interpretationtemplates_column_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Text"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:88
 msgid "listing_interpretationtemplates_column_text"
-msgstr ""
+msgstr "Tekst"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:68
 msgid "listing_interpretationtemplates_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:99
 msgid "listing_interpretationtemplates_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:115
 msgid "listing_interpretationtemplates_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:107
 msgid "listing_interpretationtemplates_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Interpretation Templates"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:58
 msgid "listing_interpretationtemplates_title"
-msgstr ""
+msgstr "Interpretatiesjablonen"
 
 #. Default: "Add"
 #: view.py:49
 msgid "listing_labproduct_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Price"
 #: view.py:87
 msgid "listing_labproducts_column_price"
-msgstr ""
+msgstr "Prijs"
 
 #. Default: "Product"
 #: view.py:66
 msgid "listing_labproducts_column_title"
-msgstr ""
+msgstr "Product"
 
 #. Default: "Total Price"
 #: view.py:102
 msgid "listing_labproducts_column_total_price"
-msgstr ""
+msgstr "Totaalprijs"
 
 #. Default: "Unit"
 #: view.py:80
 msgid "listing_labproducts_column_unit"
-msgstr ""
+msgstr "Eenheid"
 
 #. Default: "VAT Amount"
 #: view.py:95
 msgid "listing_labproducts_column_vatamount"
-msgstr ""
+msgstr "Btw-bedrag"
 
 #. Default: "Volume"
 #: view.py:73
 msgid "listing_labproducts_column_volume"
-msgstr ""
+msgstr "Volume"
 
 #. Default: "Active"
 #: view.py:114
 msgid "listing_labproducts_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: view.py:132
 msgid "listing_labproducts_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: view.py:123
 msgid "listing_labproducts_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Lab Products"
 #: view.py:56
 msgid "listing_labproducts_title"
-msgstr ""
+msgstr "Labproducten"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:51
 msgid "listing_manufacturers_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:80
 msgid "listing_manufacturers_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:74
 msgid "listing_manufacturers_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:91
 msgid "listing_manufacturers_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:107
 msgid "listing_manufacturers_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:99
 msgid "listing_manufacturers_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Manufacturers"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:58
 msgid "listing_manufacturers_title"
-msgstr ""
+msgstr "Fabrikanten"
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:87
 msgid "listing_reference_samples_column_position"
-msgstr ""
+msgstr "Positie"
 
 #. Default: "Supported Services"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:79
 msgid "listing_reference_samples_column_supported_services"
-msgstr ""
+msgstr "Ondersteunde diensten"
 
 #. Default: "Reference Sample"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:72
 msgid "listing_reference_samples_column_title"
-msgstr ""
+msgstr "Referentiemonster"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:98
 msgid "listing_reference_samples_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:54
 msgid "listing_reference_samples_title"
-msgstr ""
+msgstr "Controlereferentie toevoegen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/referencesamples.py:36
 msgid "listing_referencesamples_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:51
 msgid "listing_sampleconatiners_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Capacity"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:86
 msgid "listing_sampleconatiners_column_capacity"
-msgstr ""
+msgstr "Capaciteit"
 
 #. Default: "Container Type"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:79
 msgid "listing_sampleconatiners_column_containertype"
-msgstr ""
+msgstr "Containertype"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:72
 msgid "listing_sampleconatiners_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Pre-preserved"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:93
 msgid "listing_sampleconatiners_column_pre_preserved"
-msgstr ""
+msgstr "Voorgeconserveerd"
 
 #. Default: "Security seal intact"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:100
 msgid "listing_sampleconatiners_column_security_seal_intact"
-msgstr ""
+msgstr "Veiligheidszegel intact"
 
 #. Default: "Container"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:65
 msgid "listing_sampleconatiners_column_title"
-msgstr ""
+msgstr "Container"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:111
 msgid "listing_sampleconatiners_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:127
 msgid "listing_sampleconatiners_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:119
 msgid "listing_sampleconatiners_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Containers"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:56
 msgid "listing_sampleconatiners_title"
-msgstr ""
+msgstr "Monstercontainers"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:47
 msgid "listing_sampleconditions_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:68
 msgid "listing_sampleconditions_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Condition"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:62
 msgid "listing_sampleconditions_column_title"
-msgstr ""
+msgstr "Monstertoestand"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:78
 msgid "listing_sampleconditions_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:96
 msgid "listing_sampleconditions_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:87
 msgid "listing_sampleconditions_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Conditions"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:54
 msgid "listing_sampleconditions_title"
-msgstr ""
+msgstr "Monstertoestanden"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:47
 msgid "listing_samplematrices_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:68
 msgid "listing_samplematrices_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Matrix"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:62
 msgid "listing_samplematrices_column_title"
-msgstr ""
+msgstr "Monstermatrix"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:78
 msgid "listing_samplematrices_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:94
 msgid "listing_samplematrices_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:86
 msgid "listing_samplematrices_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Matrices"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:54
 msgid "listing_samplematrices_title"
-msgstr ""
+msgstr "Monstermatrices"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:51
 msgid "listing_samplepoints_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:73
 msgid "listing_samplepoints_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:80
 msgid "listing_samplepoints_column_sampletypes"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Sample Point"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:66
 msgid "listing_samplepoints_column_title"
-msgstr ""
+msgstr "Monsterpunt"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:92
 msgid "listing_samplepoints_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:108
 msgid "listing_samplepoints_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:100
 msgid "listing_samplepoints_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Points"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:58
 msgid "listing_samplepoints_title"
-msgstr ""
+msgstr "Monsterpunten"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:47
 msgid "listing_samplepreservations_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:68
 msgid "listing_samplepreservations_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Preservation"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:62
 msgid "listing_samplepreservations_column_title"
-msgstr ""
+msgstr "Monsterconservering"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:78
 msgid "listing_samplepreservations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:96
 msgid "listing_samplepreservations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:87
 msgid "listing_samplepreservations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Preservations"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:54
 msgid "listing_samplepreservations_title"
-msgstr ""
+msgstr "Monsterconserveringen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:52
 msgid "listing_sampletemplates_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:73
 msgid "listing_sampletemplates_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sample Template"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:67
 msgid "listing_sampletemplates_column_title"
-msgstr ""
+msgstr "Monstersjabloon"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:83
 msgid "listing_sampletemplates_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:99
 msgid "listing_sampletemplates_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:91
 msgid "listing_sampletemplates_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Templates"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:59
 msgid "listing_sampletemplates_title"
-msgstr ""
+msgstr "Monstersjablonen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:52
 msgid "listing_sampletypes_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Default Container"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:109
 msgid "listing_sampletypes_column_default_container"
-msgstr ""
+msgstr "Standaardcontainer"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:72
 msgid "listing_sampletypes_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Hazardous"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:79
 msgid "listing_sampletypes_column_hazardous"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #. Default: "Minimum Volume"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:91
 msgid "listing_sampletypes_column_min_vol"
-msgstr ""
+msgstr "Minimumvolume"
 
 #. Default: "Prefix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:85
 msgid "listing_sampletypes_column_prefix"
-msgstr ""
+msgstr "Voorvoegsel"
 
 #. Default: "Retention Period"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:97
 msgid "listing_sampletypes_column_retention_period"
-msgstr ""
+msgstr "Bewaartermijn"
 
 #. Default: "SampleMatrix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:103
 msgid "listing_sampletypes_column_sample_matrix"
-msgstr ""
+msgstr "Monstermatrix"
 
 #. Default: "Sample Type"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:66
 msgid "listing_sampletypes_column_title"
-msgstr ""
+msgstr "Monstertype"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:119
 msgid "listing_sampletypes_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:135
 msgid "listing_sampletypes_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:127
 msgid "listing_sampletypes_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:58
 msgid "listing_sampletypes_title"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:49
 msgid "listing_samplingdeviations_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:72
 msgid "listing_samplingdeviations_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sampling Deviation"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:65
 msgid "listing_samplingdeviations_column_title"
-msgstr ""
+msgstr "Monsternameafwijking"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:92
 msgid "listing_samplingdeviations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:84
 msgid "listing_samplingdeviations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:100
 msgid "listing_samplingdeviations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sampling Deviations"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:56
 msgid "listing_samplingdeviations_title"
-msgstr ""
+msgstr "Monsternameafwijkingen"
 
 #. Default: "Calculation"
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:70
 msgid "listing_services_column_calculation"
-msgstr ""
+msgstr "Berekening"
 
 #. Default: "Hidden"
 #: senaite/core/browser/widgets/services_widget.py:112
 msgid "listing_services_column_hidden"
-msgstr ""
+msgstr "Verborgen"
 
 #. Default: "Keyword"
 #: senaite/core/browser/widgets/services_widget.py:84
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:56
 msgid "listing_services_column_keyword"
-msgstr ""
+msgstr "Sleutelwoord"
 
 #. Default: "Methods"
 #: senaite/core/browser/widgets/services_widget.py:91
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:63
 msgid "listing_services_column_methods"
-msgstr ""
+msgstr "Methoden"
 
 #. Default: "Partition"
 #: senaite/core/browser/widgets/sampletemplate_services_widget.py:51
 msgid "listing_services_column_partition"
-msgstr ""
+msgstr "Partitie"
 
 #. Default: "Price"
 #: senaite/core/browser/widgets/services_widget.py:105
 msgid "listing_services_column_price"
-msgstr ""
+msgstr "Prijs"
 
 #. Default: "Service"
 #: senaite/core/browser/widgets/services_widget.py:76
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:48
 msgid "listing_services_column_title"
-msgstr ""
+msgstr "Dienst"
 
 #. Default: "Unit"
 #: senaite/core/browser/widgets/services_widget.py:98
 msgid "listing_services_column_unit"
-msgstr ""
+msgstr "Eenheid"
 
 #. Default: "All"
 #: senaite/core/browser/widgets/services_widget.py:127
 msgid "listing_services_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:49
 msgid "listing_storagelocations_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:75
 msgid "listing_storagelocations_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Location Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:104
 msgid "listing_storagelocations_column_location_code"
-msgstr ""
+msgstr "Locatiecode"
 
 #. Default: "Location Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:97
 msgid "listing_storagelocations_column_location_title"
-msgstr ""
+msgstr "Locatietitel"
 
 #. Default: "Shelf Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:118
 msgid "listing_storagelocations_column_shelf_code"
-msgstr ""
+msgstr "Schapcode"
 
 #. Default: "Shelf Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:111
 msgid "listing_storagelocations_column_shelf_title"
-msgstr ""
+msgstr "Schaptitel"
 
 #. Default: "Site Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:90
 msgid "listing_storagelocations_column_site_code"
-msgstr ""
+msgstr "Sitecode"
 
 #. Default: "Site Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:83
 msgid "listing_storagelocations_column_site_title"
-msgstr ""
+msgstr "Sitetitel"
 
 #. Default: "Storage Location"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:68
 msgid "listing_storagelocations_column_title"
-msgstr ""
+msgstr "Opslaglocatie"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:129
 msgid "listing_storagelocations_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:147
 msgid "listing_storagelocations_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:138
 msgid "listing_storagelocations_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Storage Locations"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:55
 msgid "listing_storagelocations_title"
-msgstr ""
+msgstr "Opslaglocaties"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/subgroups/view.py:51
 msgid "listing_subgroup_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/subgroups/view.py:73
 msgid "listing_subgroups_column_description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/subgroups/view.py:80
 msgid "listing_subgroups_column_sortkey"
-msgstr ""
+msgstr "Sorteersleutel"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/subgroups/view.py:67
 msgid "listing_subgroups_column_title"
-msgstr ""
+msgstr "Titel"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/subgroups/view.py:91
 msgid "listing_subgroups_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/subgroups/view.py:109
 msgid "listing_subgroups_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/subgroups/view.py:100
 msgid "listing_subgroups_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Sub-Groups"
 #: senaite/core/browser/controlpanel/subgroups/view.py:58
 msgid "listing_subgroups_title"
-msgstr ""
+msgstr "Subgroepen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:51
 msgid "listing_suppliercontacts_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Business Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:79
 msgid "listing_suppliercontacts_column_businessphone"
-msgstr ""
+msgstr "Zakelijk telefoonnummer"
 
 #. Default: "Email Address"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:73
 msgid "listing_suppliercontacts_column_emailaddress"
-msgstr ""
+msgstr "E-mailadres"
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:91
 msgid "listing_suppliercontacts_column_fax"
-msgstr ""
+msgstr "Fax"
 
 #. Default: "FullName"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:67
 msgid "listing_suppliercontacts_column_fullname"
-msgstr ""
+msgstr "Volledige naam"
 
 #. Default: "Mobile Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:85
 msgid "listing_suppliercontacts_column_mobilephone"
-msgstr ""
+msgstr "Mobiele telefoon"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:101
 msgid "listing_suppliercontacts_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Contacts"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:58
 msgid "listing_suppliercontacts_title"
-msgstr ""
+msgstr "Contactpersonen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/view.py:54
 msgid "listing_suppliers_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Email"
 #: senaite/core/browser/controlpanel/suppliers/view.py:77
 msgid "listing_suppliers_column_email"
-msgstr ""
+msgstr "E-mail"
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/view.py:91
 msgid "listing_suppliers_column_fax"
-msgstr ""
+msgstr "Fax"
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/suppliers/view.py:70
 msgid "listing_suppliers_column_name"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Phone"
 #: senaite/core/browser/controlpanel/suppliers/view.py:84
 msgid "listing_suppliers_column_phone"
-msgstr ""
+msgstr "Telefoon"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/suppliers/view.py:102
 msgid "listing_suppliers_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/view.py:118
 msgid "listing_suppliers_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/suppliers/view.py:110
 msgid "listing_suppliers_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Suppliers"
 #: senaite/core/browser/controlpanel/suppliers/view.py:61
 msgid "listing_suppliers_title"
-msgstr ""
+msgstr "Leveranciers"
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
-msgstr ""
+msgstr "Analist"
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
-msgstr ""
+msgstr "Aangemaakt"
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
-msgstr ""
+msgstr "Routineanalyses"
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
-msgstr ""
+msgstr "QC-analyses"
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
-msgstr ""
+msgstr "Monsters"
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
-msgstr ""
+msgstr "Voortgang"
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
-msgstr ""
+msgstr "Status"
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
-msgstr ""
+msgstr "Sjabloon"
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
-msgstr ""
+msgstr "Werkblad"
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
-msgstr ""
+msgstr "Mijn"
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
-msgstr ""
+msgstr "Open"
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
-msgstr ""
+msgstr "Te verifiëren"
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
-msgstr ""
+msgstr "Geverifieerd"
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
-msgstr ""
+msgstr "Werkbladen"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:54
 msgid "listing_worksheettemplates_action_add"
-msgstr ""
+msgstr "Toevoegen"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:77
 msgid "listing_worksheettemplates_column_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Instrument"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:91
 msgid "listing_worksheettemplates_column_instrument"
-msgstr ""
+msgstr "Instrument"
 
 #. Default: "Method"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:84
 msgid "listing_worksheettemplates_column_method"
-msgstr ""
+msgstr "Methode"
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:70
 msgid "listing_worksheettemplates_column_name"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:103
 msgid "listing_worksheettemplates_state_active"
-msgstr ""
+msgstr "Actief"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:119
 msgid "listing_worksheettemplates_state_all"
-msgstr ""
+msgstr "Alle"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:111
 msgid "listing_worksheettemplates_state_inactive"
-msgstr ""
+msgstr "Inactief"
 
 #. Default: "Worksheet Templates"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:61
 msgid "listing_worksheettemplates_title"
-msgstr ""
+msgstr "Werkbladsjablonen"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "minutes"
-msgstr ""
+msgstr "minuten"
+
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr "gewijzigd"
 
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
-msgstr ""
+msgstr "maandelijks"
 
 #. Default: "No analyses added to this worksheet."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:177
 msgid "no_analyses_added_to_this_worksheet"
-msgstr ""
+msgstr "Geen analyses toegevoegd aan dit werkblad."
 
 #. Default: "No analyses were added"
 #: senaite/core/browser/worksheets/worksheet/view.py:39
 msgid "no_analyses_were_added_message"
-msgstr ""
+msgstr "Er zijn geen analyses toegevoegd"
 
 #. Default: "Instrument has no data interface selected"
 #: senaite/core/browser/worksheets/worksheet/export.py:47
 msgid "no_data_instrument_message"
-msgstr ""
+msgstr "Voor het instrument is geen data-interface geselecteerd"
 
 #. Default: "Keyword '${duplicate}' duplicate found for a Analysis Service"
 #: senaite/core/validators/interimfields.py:97
 msgid "no_dup_service_keyword_validator_error"
-msgstr ""
+msgstr "Sleutelwoord '${duplicate}' dubbel gevonden voor een Analysedienst"
 
 #. Default: "'${duplicate}' duplicates found"
 #: senaite/core/validators/interimfields.py:83
 msgid "no_dups_values_validator_error"
-msgstr ""
+msgstr "'${duplicate}' duplicaten gevonden"
 
 #. Default: "Wildcards for  are not allowed: ${wildcards}"
 #: senaite/core/validators/formula.py:45
 msgid "no_wildcards__error"
-msgstr ""
+msgstr "Jokertekens voor  zijn niet toegestaan: ${wildcards}"
 
 #. Default: "'${field_name}' is required"
 #: senaite/core/validators/interimfields.py:54
 msgid "non_blank_validator_error"
-msgstr ""
+msgstr "'${field_name}' is verplicht"
 
 #. view."
 #. Default: "Layout view '${view}' not found. Set '${default}' as layout view."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:66
+#, fuzzy
 msgid "not_found_worksheet_layout_message"
-msgstr ""
+msgstr "Lay-outweergave '${view}' niet gevonden. '${default}' ingesteld als lay-outweergave."
 
 #. Default: "Set"
 #: senaite/core/browser/form/adapters/worksheettemplate.py:239
 msgid "num_of_positions_button_title"
-msgstr ""
+msgstr "Instellen"
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
-msgstr ""
+msgstr "van"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr "origineel"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
-msgstr ""
+msgstr "overzicht"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr "per lijst"
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
-msgstr ""
+msgstr "per kwartaal"
 
 #: bika/lims/content/instrumentscheduledtask.py:137
 msgid "repeating every"
-msgstr ""
+msgstr "herhaalt elke"
 
 #: bika/lims/content/instrumentscheduledtask.py:138
 msgid "repeatperiod"
-msgstr ""
+msgstr "herhaalperiode"
 
 #. Default: "Not detected"
 #: bika/lims/content/abstractanalysis.py:1120
 msgid "result_below_llod"
-msgstr ""
+msgstr "Niet gedetecteerd"
 
 #. Default: "Detected but < ${LLOQ}"
 #: bika/lims/content/abstractanalysis.py:1131
 msgid "result_below_lloq"
-msgstr ""
+msgstr "Gedetecteerd maar < ${LLOQ}"
 
 #. Default: "Field Preservation"
 #: senaite/core/config/vocabularies.py:24
 msgid "sample_preservation_category_vocab_field"
-msgstr ""
+msgstr "Veldconservering"
 
 #. Default: "Lab Preservation"
 #: senaite/core/config/vocabularies.py:28
 msgid "sample_preservation_category_vocab_lab"
-msgstr ""
+msgstr "Labconservering"
 
 #. Default: "Only ASCII characters in prefix allowed"
 #: senaite/core/content/sampletype.py:88
 msgid "sampletype_prefix_ascii_validator_message"
-msgstr ""
+msgstr "Alleen ASCII-tekens in prefix toegestaan"
 
 #. Default: "No whitespaces in prefix allowed"
 #: senaite/core/content/sampletype.py:81
 msgid "sampletype_prefix_no_whitespace_validator_message"
-msgstr ""
+msgstr "Geen spaties in prefix toegestaan"
 
 #. Default: "You must select an instrument"
 #: senaite/core/browser/worksheets/worksheet/export.py:37
 msgid "select_instrument_message"
-msgstr ""
+msgstr "U moet een instrument selecteren"
 
 #. Default: "Condition"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:35
 msgid "set_analysis_conditions_colname_condition"
-msgstr ""
+msgstr "Voorwaarde"
 
 #. Default: "Show in report"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:37
 msgid "set_analysis_conditions_colname_report"
-msgstr ""
+msgstr "Tonen in rapport"
 
 #. Default: "Value"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:36
 msgid "set_analysis_conditions_colname_value"
-msgstr ""
+msgstr "Waarde"
 
 #. Default: "Folder to import the instrument results from"
 #: bika/lims/content/instrument.py:250
 msgid "subfield_label_instrument_import_folder"
-msgstr ""
+msgstr "Map waaruit de instrumentresultaten worden geïmporteerd"
 
 #. Default: "Interface Code"
 #: bika/lims/content/instrument.py:248
 msgid "subfield_label_instrument_interface_name"
-msgstr ""
+msgstr "Interfacecode"
 
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
-msgstr ""
+msgstr "Dit monster is verzonden door ${actor} op ${date}"
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
+msgstr "Dit monster is afgevoerd door ${actor} op ${date}"
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11031,1083 +11614,1098 @@ msgstr ""
 #. ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "time_format"
-msgstr ""
+msgstr "${H}:${M}"
 
 #. Default: "Accreditation"
 #: senaite/core/content/laboratory.py:170
 msgid "title_accreditation"
-msgstr ""
+msgstr "Accreditatie"
 
 #. Default: "Accreditation Body Abbreviation"
 #: senaite/core/content/laboratory.py:149
 msgid "title_accreditation_body"
-msgstr ""
+msgstr "Afkorting accreditatie-instantie"
 
 #. Default: "Accreditation Logo"
 #: senaite/core/content/laboratory.py:195
 msgid "title_accreditation_body_logo"
-msgstr ""
+msgstr "Accreditatielogo"
 
 #. Default: "Accreditation Body URL"
 #: senaite/core/content/laboratory.py:160
 msgid "title_accreditation_body_url"
-msgstr ""
+msgstr "URL accreditatie-instantie"
 
 #. Default: "Accreditation page header"
 #: senaite/core/content/laboratory.py:216
 msgid "title_accreditation_page_header"
-msgstr ""
+msgstr "Paginakop accreditatie"
 
 #. Default: "Accreditation Reference"
 #: senaite/core/content/laboratory.py:182
 msgid "title_accreditation_reference"
-msgstr ""
+msgstr "Accreditatiereferentie"
 
 #. Default: "Address"
 #: senaite/core/content/laboratory.py:88
 #: senaite/core/content/organization.py:82
 msgid "title_addresses_tab"
-msgstr ""
+msgstr "Adres"
 
 #. Default: "Comments"
 #: senaite/core/content/analysiscategory.py:60
 msgid "title_analysiscategory_comments"
-msgstr ""
+msgstr "Opmerkingen"
 
 #. Default: "Department"
 #: senaite/core/content/analysiscategory.py:81
 msgid "title_analysiscategory_department"
-msgstr ""
+msgstr "Afdeling"
 
 #. Default: "Description"
 #: senaite/core/content/analysiscategory.py:52
 msgid "title_analysiscategory_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Sort Key"
 #: senaite/core/content/analysiscategory.py:95
 msgid "title_analysiscategory_sort_key"
-msgstr ""
+msgstr "Sorteersleutel"
 
 #. Default: "Name"
 #: senaite/core/content/analysiscategory.py:44
 msgid "title_analysiscategory_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Commercial ID"
 #: senaite/core/content/analysisprofile.py:121
 msgid "title_analysisprofile_commercial_id"
-msgstr ""
+msgstr "Commerciële ID"
 
 #. Default: "Description"
 #: senaite/core/content/analysisprofile.py:82
 msgid "title_analysisprofile_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Profile Keyword"
 #: senaite/core/content/analysisprofile.py:90
 msgid "title_analysisprofile_profile_key"
-msgstr ""
+msgstr "Profielsleutelwoord"
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/analysisprofile.py:145
 msgid "title_analysisprofile_profile_price"
-msgstr ""
+msgstr "Prijs (exclusief btw)"
 
 #. Default: "VAT %"
 #: senaite/core/content/analysisprofile.py:157
 msgid "title_analysisprofile_profile_vat"
-msgstr ""
+msgstr "Btw %"
 
 #. Default: "Profile Analyses"
 #: senaite/core/content/analysisprofile.py:106
 msgid "title_analysisprofile_services"
-msgstr ""
+msgstr "Profielanalyses"
 
 #. Default: "Name"
 #: senaite/core/content/analysisprofile.py:74
 msgid "title_analysisprofile_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Use analysis profile price"
 #: senaite/core/content/analysisprofile.py:133
 msgid "title_analysisprofile_use_profile_price"
-msgstr ""
+msgstr "Analyseprofielprijs gebruiken"
 
 #. Default: "Analyst"
 #: senaite/core/permissions/localroles.py:30
 msgid "title_analyst_role"
-msgstr ""
+msgstr "Analist"
 
 #. Default: "Description"
 #: senaite/core/content/attachmenttype.py:44
 msgid "title_attachmenttype_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/attachmenttype.py:36
 msgid "title_attachmenttype_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Bank Details"
 #: senaite/core/content/organization.py:110
 msgid "title_bank_details_tab"
-msgstr ""
+msgstr "Bankgegevens"
 
 #. Default: "Name"
 #: senaite/core/content/batchlabel.py:36
 msgid "title_batchlabel_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "This site was built using the Plone Open Source CMS/WCM."
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "title_built_with_plone"
-msgstr ""
+msgstr "Deze site is gebouwd met het Plone Open Source CMS/WCM."
 
 #. Default: "Description"
 #: senaite/core/content/calculation.py:228
 msgid "title_calculation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/calculation.py:220
 msgid "title_calculation_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Confidence Level %"
 #: senaite/core/content/laboratory.py:123
 msgid "title_confidence_level"
-msgstr ""
+msgstr "Betrouwbaarheidsniveau %"
 
 #. Default: "Description"
 #: senaite/core/content/containertype.py:44
 msgid "title_containertype_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/containertype.py:36
 msgid "title_containertype_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Copyright"
 #: senaite/core/browser/viewlets/templates/footer.pt:11
 msgid "title_copyright"
-msgstr ""
+msgstr "Auteursrecht"
 
 #. Default: "Description"
 #: senaite/core/content/department.py:60
 msgid "title_department_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Department ID"
 #: senaite/core/content/department.py:76
 msgid "title_department_id"
-msgstr ""
+msgstr "Afdelings-ID"
 
 #. Default: "Name"
 #: senaite/core/content/department.py:48
 msgid "title_department_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "No instrument"
 #: senaite/core/vocabularies/instruments.py:43
 msgid "title_instrument_no_instrument"
-msgstr ""
+msgstr "Geen instrument"
 
 #. Default: "Description"
 #: senaite/core/content/instrumentlocation.py:44
 msgid "title_instrumentlocation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/instrumentlocation.py:36
 msgid "title_instrumentlocation_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/instrumenttype.py:44
 msgid "title_instrumenttype_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/instrumenttype.py:36
 msgid "title_instrumenttype_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/interpretationtemplate.py:51
 msgid "title_interpretationtemplate_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/interpretationtemplate.py:43
 msgid "title_interpretationtemplate_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Lab Clerk"
 #: senaite/core/permissions/localroles.py:44
 msgid "title_lab_clerk_role"
-msgstr ""
+msgstr "Labmedewerker"
 
 #. Default: "Lab Manager"
 #: senaite/core/permissions/localroles.py:79
 msgid "title_lab_manager_role"
-msgstr ""
+msgstr "Labmanager"
+
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr "Kleur"
 
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Laboratory Accredited"
 #: senaite/core/content/laboratory.py:136
 msgid "title_laboratory_accredited"
-msgstr ""
+msgstr "Laboratorium geaccrediteerd"
 
 #. Default: "Lab URL"
 #: senaite/core/content/laboratory.py:98
 msgid "title_laboratory_lab_url"
-msgstr ""
+msgstr "Lab-URL"
 
 #. Default: "Description"
 #: senaite/core/content/labproduct.py:60
 msgid "title_labproduct_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/labproduct.py:85
 msgid "title_labproduct_price"
-msgstr ""
+msgstr "Prijs (exclusief btw)"
 
 #. Default: "Name"
 #: senaite/core/content/labproduct.py:52
 msgid "title_labproduct_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Total Price"
 #: senaite/core/content/labproduct.py:123
 msgid "title_labproduct_total_price"
-msgstr ""
+msgstr "Totaalprijs"
 
 #. Default: "Unit"
 #: senaite/core/content/labproduct.py:76
 msgid "title_labproduct_unit"
-msgstr ""
+msgstr "Eenheid"
 
 #. Default: "VAT %"
 #: senaite/core/content/labproduct.py:98
 msgid "title_labproduct_vat"
-msgstr ""
+msgstr "Btw %"
 
 #. Default: "VAT"
 #: senaite/core/content/labproduct.py:114
 msgid "title_labproduct_vat_amount"
-msgstr ""
+msgstr "Btw"
 
 #. Default: "Volume"
 #: senaite/core/content/labproduct.py:68
 msgid "title_labproduct_volume"
-msgstr ""
+msgstr "Volume"
 
 #. Default: "Blank Reference"
 #: senaite/core/content/worksheettemplate.py:132
 msgid "title_layout_record_blank_ref"
-msgstr ""
+msgstr "Blancoreferentie"
 
 #. Default: "Control Reference"
 #: senaite/core/content/worksheettemplate.py:158
 msgid "title_layout_record_control_ref"
-msgstr ""
+msgstr "Controlereferentie"
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:191
 msgid "title_layout_record_dup"
-msgstr ""
+msgstr "Duplicaat van"
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:180
 msgid "title_layout_record_dup_proxy"
-msgstr ""
+msgstr "Duplicaat van"
 
 #. Default: "Position"
 #: senaite/core/content/worksheettemplate.py:96
 msgid "title_layout_record_pos"
-msgstr ""
+msgstr "Positie"
 
 #. Default: "Reference"
 #: senaite/core/content/worksheettemplate.py:169
 msgid "title_layout_record_reference_proxy"
-msgstr ""
+msgstr "Referentie"
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
-msgstr ""
+msgstr "Analysetype"
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
+msgstr "Viewlets beheren"
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
 msgid "title_manager_role"
-msgstr ""
+msgstr "Manager"
 
 #. Default: "Description"
 #: senaite/core/content/manufacturer.py:44
 msgid "title_manufacturer_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/manufacturer.py:36
 msgid "title_manufacturer_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Not specified"
 #: senaite/core/vocabularies/methods.py:43
 msgid "title_method_not_specified"
-msgstr ""
+msgstr "Niet opgegeven"
 
 #. Default: "Bank Branch"
 #: senaite/core/content/organization.py:156
 msgid "title_organization_account_bank_branch"
-msgstr ""
+msgstr "Bankfiliaal"
 
 #. Default: "Bank Name"
 #: senaite/core/content/organization.py:148
 msgid "title_organization_account_bank_name"
-msgstr ""
+msgstr "Banknaam"
 
 #. Default: "Account Name"
 #: senaite/core/content/organization.py:132
 msgid "title_organization_account_name"
-msgstr ""
+msgstr "Rekeningnaam"
 
 #. Default: "Account Number"
 #: senaite/core/content/organization.py:140
 msgid "title_organization_account_number"
-msgstr ""
+msgstr "Rekeningnummer"
 
 #. Default: "Account Type"
 #: senaite/core/content/organization.py:124
 msgid "title_organization_account_type"
-msgstr ""
+msgstr "Rekeningtype"
 
 #. Default: "Email"
 #: senaite/core/content/organization.py:93
 msgid "title_organization_email"
-msgstr ""
+msgstr "E-mail"
 
 #. Default: "Fax"
 #: senaite/core/content/organization.py:73
 msgid "title_organization_fax"
-msgstr ""
+msgstr "Fax"
 
 #. Default: "Name"
 #: senaite/core/content/organization.py:47
 msgid "title_organization_name"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Phone"
 #: senaite/core/content/organization.py:64
 msgid "title_organization_phone"
-msgstr ""
+msgstr "Telefoon"
 
 #. Default: "VAT number"
 #: senaite/core/content/organization.py:55
 msgid "title_organization_tax_number"
-msgstr ""
+msgstr "Btw-nummer"
 
 #. Default: "Owner"
 #: senaite/core/permissions/localroles.py:37
 msgid "title_owner_role"
-msgstr ""
+msgstr "Eigenaar"
 
 #. Default: "Preserver"
 #: senaite/core/permissions/localroles.py:51
 msgid "title_preserver_role"
-msgstr ""
+msgstr "Conserveerder"
 
 #. Default: "Publisher"
 #: senaite/core/permissions/localroles.py:58
 msgid "title_publisher_role"
-msgstr ""
+msgstr "Publiceerder"
 
 #. Default: "Required"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:47
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:91
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:137
 msgid "title_required"
-msgstr ""
+msgstr "Verplicht"
 
 #. Default: "Description"
 #: senaite/core/content/samplecondition.py:44
 msgid "title_samplecondition_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplecondition.py:36
 msgid "title_samplecondition_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/samplecontainer.py:52
 msgid "title_samplecontainer_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplecontainer.py:44
 msgid "title_samplecontainer_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/samplematrix.py:44
 msgid "title_samplematrix_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplematrix.py:36
 msgid "title_samplematrix_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Attachment"
 #: senaite/core/content/samplepoint.py:159
 msgid "title_samplepoint_attachment_file"
-msgstr ""
+msgstr "Bijlage"
 
 #. Default: "Composite"
 #: senaite/core/content/samplepoint.py:143
 msgid "title_samplepoint_composite"
-msgstr ""
+msgstr "Samengesteld"
 
 #. Default: "Description"
 #: senaite/core/content/samplepoint.py:64
 msgid "title_samplepoint_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Elevation"
 #: senaite/core/content/samplepoint.py:87
 msgid "title_samplepoint_elevation"
-msgstr ""
+msgstr "Hoogte"
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:72
 msgid "title_samplepoint_location"
-msgstr ""
+msgstr "Locatie"
 
 #. Default: "Sampling Frequency"
 #: senaite/core/content/samplepoint.py:99
 msgid "title_samplepoint_sampling_frequency"
-msgstr ""
+msgstr "Monsternamefrequentie"
 
 #. Default: "Sample Types"
 #: senaite/core/content/samplepoint.py:122
 msgid "title_samplepoint_sampling_sample_types"
-msgstr ""
+msgstr "Monstertypes"
 
 #. Default: "Name"
 #: senaite/core/content/samplepoint.py:56
 msgid "title_samplepoint_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Description"
 #: senaite/core/content/samplepreservation.py:47
 msgid "title_samplepreservation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplepreservation.py:39
 msgid "title_samplepreservation_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Sampler"
 #: senaite/core/permissions/localroles.py:65
 msgid "title_sampler_role"
-msgstr ""
+msgstr "Monsternemer"
 
 #. Default: "Auto-partition on sample reception"
 #: senaite/core/content/sampletemplate.py:256
 msgid "title_sampletemplate_auto_partition"
-msgstr ""
+msgstr "Automatisch partitioneren bij monsterontvangst"
 
 #. Default: "Composite"
 #: senaite/core/content/sampletemplate.py:217
 msgid "title_sampletemplate_composite"
-msgstr ""
+msgstr "Samengesteld"
 
 #. Default: "Description"
 #: senaite/core/content/sampletemplate.py:167
 msgid "title_sampletemplate_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Sample collected by the laboratory"
 #: senaite/core/content/sampletemplate.py:226
 msgid "title_sampletemplate_sampling_required"
-msgstr ""
+msgstr "Monster genomen door het laboratorium"
 
 #. Default: "Services"
 #: senaite/core/content/sampletemplate.py:269
 msgid "title_sampletemplate_services"
-msgstr ""
+msgstr "Diensten"
 
 #. Default: "Name"
 #: senaite/core/content/sampletemplate.py:161
 msgid "title_sampletemplate_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Retention Period"
 #: senaite/core/content/sampletype.py:151
 msgid "title_sampletype_duration_period"
-msgstr ""
+msgstr "Bewaartermijn"
 
 #. Default: "Hazard categories"
 #: senaite/core/content/sampletype.py:178
 msgid "title_sampletype_hazard_categories"
-msgstr ""
+msgstr "Gevarencategorieën"
 
 #. Default: "Hazardous"
 #: senaite/core/content/sampletype.py:166
 msgid "title_sampletype_hazardous"
-msgstr ""
+msgstr "Gevaarlijk"
 
 #. Default: "Minimum Volume"
 #: senaite/core/content/sampletype.py:231
 msgid "title_sampletype_min_volume"
-msgstr ""
+msgstr "Minimumvolume"
 
 #. Default: "Sample Type Prefix"
 #: senaite/core/content/sampletype.py:218
 msgid "title_sampletype_prefix"
-msgstr ""
+msgstr "Monstertypeprefix"
 
 #. Default: "Description"
 #: senaite/core/content/samplingdeviation.py:44
 msgid "title_samplingdeviation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Name"
 #: senaite/core/content/samplingdeviation.py:36
 msgid "title_samplingdeviation_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Toestaan om de vastlegdatum van het resultaat in te stellen"
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
-msgstr ""
+msgstr "Indienen van resultaten voor niet-toegewezen analyses toestaan"
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Publicatie-e-mail altijd naar verantwoordelijken sturen"
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
-msgstr ""
+msgstr "Automatisch afmelden"
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
-msgstr ""
+msgstr "Automatische verificatie van monsters"
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
-msgstr ""
+msgstr "Analysediensten categoriseren"
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Monsteranalyses categoriseren"
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
-msgstr ""
+msgstr "Valuta"
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
-msgstr ""
+msgstr "Dashboard als standaard startpagina gebruiken"
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
-msgstr ""
+msgstr "Monsternamedatum verplicht"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
-msgstr ""
+msgstr "Standaard decimaalteken"
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
-msgstr ""
+msgstr "Land"
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
-msgstr ""
+msgstr "Standaard aantal toe te voegen monsters."
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
-msgstr ""
+msgstr "Publicatie 'Van'-adres"
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
-msgstr ""
+msgstr "Een opmerkingenveld aan alle analyses toevoegen"
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
-msgstr ""
+msgstr "Monsterspecificaties inschakelen"
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
-msgstr ""
+msgstr "De afwijzingsworkflow inschakelen"
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
-msgstr ""
+msgstr "Drempel voor exponentiële notatie"
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
-msgstr ""
+msgstr "Reden voor ongeldigverklaring verplicht"
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
-msgstr ""
+msgstr "Landingspagina"
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
-msgstr ""
+msgstr "Ledenkorting %"
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
-msgstr ""
+msgstr "Minimumaantal resultaten voor QC-statistiekberekeningen"
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
-msgstr ""
+msgstr "Aantal vereiste verificaties"
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
-msgstr ""
+msgstr "Tekst publicatie-e-mail"
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
-msgstr ""
+msgstr "Afwijzingsredenen"
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
-msgstr ""
+msgstr "Werkbladbeheer beperken tot labmanagers"
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
-msgstr ""
+msgstr "Werkbladtoegang beperken tot toegewezen analisten"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
-msgstr ""
+msgstr "Standaard decimaalteken"
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Monsterduplicatie toestaan"
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Monsteranalyses vereisen"
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
-msgstr ""
+msgstr "Analysekolommen in monsterweergave"
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
-msgstr ""
+msgstr "Standaard wetenschappelijke notatie voor rapporten"
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
-msgstr ""
+msgstr "Standaard wetenschappelijke notatie voor resultaten"
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
-msgstr ""
+msgstr "Zelfverificatie van resultaten toestaan"
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
-msgstr ""
+msgstr "Laboratoriumnaam tonen op de aanmeldpagina"
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
-msgstr ""
+msgstr "Monsterpartities tonen aan klanten"
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
-msgstr ""
+msgstr "Prijsinformatie opnemen en tonen"
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
-msgstr ""
+msgstr "Navigatiemappen zijbalk"
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
-msgstr ""
+msgstr "Navigatiediepte zijbalk"
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
-msgstr ""
+msgstr "Overgeslagen portaltypes zijbalk"
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
-msgstr ""
+msgstr "Type multiverificatie"
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
-msgstr ""
+msgstr "Btw %"
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
-msgstr ""
+msgstr "Standaard lay-out in werkbladweergave"
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
-msgstr ""
+msgstr "Analysekolommen in werkbladweergave"
 
 #. Default: "Service UID"
 #: senaite/core/content/worksheettemplate.py:86
 msgid "title_service_uid"
-msgstr ""
+msgstr "Dienst-UID"
 
 #. Default: "Description"
 #: senaite/core/content/storagelocation.py:46
 msgid "title_storagelocation_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Location Code"
 #: senaite/core/content/storagelocation.py:102
 msgid "title_storagelocation_location_code"
-msgstr ""
+msgstr "Locatiecode"
 
 #. Default: "Location Description"
 #: senaite/core/content/storagelocation.py:114
 msgid "title_storagelocation_location_description"
-msgstr ""
+msgstr "Locatiebeschrijving"
 
 #. Default: "Location Title"
 #: senaite/core/content/storagelocation.py:90
 msgid "title_storagelocation_location_title"
-msgstr ""
+msgstr "Locatietitel"
 
 #. Default: "Location Type"
 #: senaite/core/content/storagelocation.py:126
 msgid "title_storagelocation_location_type"
-msgstr ""
+msgstr "Locatietype"
 
 #. Default: "Shelf Code"
 #: senaite/core/content/storagelocation.py:150
 msgid "title_storagelocation_shelf_code"
-msgstr ""
+msgstr "Schapcode"
 
 #. Default: "Shelf Description"
 #: senaite/core/content/storagelocation.py:162
 msgid "title_storagelocation_shelf_description"
-msgstr ""
+msgstr "Schapbeschrijving"
 
 #. Default: "Shelf Title"
 #: senaite/core/content/storagelocation.py:138
 msgid "title_storagelocation_shelf_title"
-msgstr ""
+msgstr "Schaptitel"
 
 #. Default: "Site Code"
 #: senaite/core/content/storagelocation.py:66
 msgid "title_storagelocation_site_code"
-msgstr ""
+msgstr "Sitecode"
 
 #. Default: "Site Description"
 #: senaite/core/content/storagelocation.py:78
 msgid "title_storagelocation_site_description"
-msgstr ""
+msgstr "Sitebeschrijving"
 
 #. Default: "Site Title"
 #: senaite/core/content/storagelocation.py:54
 msgid "title_storagelocation_site_title"
-msgstr ""
+msgstr "Sitetitel"
 
 #. Default: "Address"
 #: senaite/core/content/storagelocation.py:38
 msgid "title_storagelocation_title"
-msgstr ""
+msgstr "Adres"
 
 #. Default: "Description"
 #: senaite/core/content/subgroup.py:48
 msgid "title_subgroup_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Sort Key"
 #: senaite/core/content/subgroup.py:56
 msgid "title_subgroup_sort_key"
-msgstr ""
+msgstr "Sorteersleutel"
 
 #. Default: "Name"
 #: senaite/core/content/subgroup.py:40
 msgid "title_subgroup_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "IBAN"
 #: senaite/core/content/supplier.py:96
 msgid "title_supplier_iban"
-msgstr ""
+msgstr "IBAN"
 
 #. Default: "Lab Account Number"
 #: senaite/core/content/supplier.py:47
 msgid "title_supplier_lab_contact_number"
-msgstr ""
+msgstr "Labrekeningnummer"
 
 #. Default: "NIB"
 #: senaite/core/content/supplier.py:84
 msgid "title_supplier_nib"
-msgstr ""
+msgstr "NIB"
 
 #. Default: "Remarks"
 #: senaite/core/content/supplier.py:55
 msgid "title_supplier_remarks"
-msgstr ""
+msgstr "Opmerkingen"
 
 #. Default: "SWIFT code"
 #: senaite/core/content/supplier.py:108
 msgid "title_supplier_swift_code"
-msgstr ""
+msgstr "SWIFT-code"
 
 #. Default: "Website"
 #: senaite/core/content/supplier.py:63
 msgid "title_supplier_website"
-msgstr ""
+msgstr "Website"
 
 #. Default: "Verifier"
 #: senaite/core/permissions/localroles.py:72
 msgid "title_verifier_role"
-msgstr ""
+msgstr "Verifieerder"
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheet.py:165
 msgid "title_worksheet_analyses"
-msgstr ""
+msgstr "Analyses"
 
 #. Default: "Analyst"
 #: senaite/core/content/worksheet.py:187
 msgid "title_worksheet_analyst"
-msgstr ""
+msgstr "Analist"
 
 #. Default: "Description"
 #: senaite/core/content/worksheet.py:136
 msgid "title_worksheet_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Instrument"
 #: senaite/core/content/worksheet.py:197
 msgid "title_worksheet_instrument"
-msgstr ""
+msgstr "Instrument"
 
 #. Default: "Layout"
 #: senaite/core/content/worksheet.py:154
 msgid "title_worksheet_layout"
-msgstr ""
+msgstr "Lay-out"
 
 #. Default: "Analysis"
 #: senaite/core/content/worksheet.py:110
 msgid "title_worksheet_layout_analysis"
-msgstr ""
+msgstr "Analyse"
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheet.py:90
 msgid "title_worksheet_layout_analysis_type"
-msgstr ""
+msgstr "Analysetype"
 
 #. Default: "Container"
 #: senaite/core/content/worksheet.py:100
 msgid "title_worksheet_layout_container"
-msgstr ""
+msgstr "Container"
 
 #. Default: "Position"
 #: senaite/core/content/worksheet.py:81
 msgid "title_worksheet_layout_position"
-msgstr ""
+msgstr "Positie"
 
 #. Default: "Method"
 #: senaite/core/content/worksheet.py:176
 msgid "title_worksheet_method"
-msgstr ""
+msgstr "Methode"
 
 #. Default: "Remarks"
 #: senaite/core/content/worksheet.py:209
 msgid "title_worksheet_remarks"
-msgstr ""
+msgstr "Opmerkingen"
 
 #. Default: "Results Layout"
 #: senaite/core/content/worksheet.py:217
 msgid "title_worksheet_results_layout"
-msgstr ""
+msgstr "Resultatenlay-out"
 
 #. Default: "Name"
 #: senaite/core/content/worksheet.py:127
 msgid "title_worksheet_title"
-msgstr ""
+msgstr "Naam"
 
 #. Default: "Worksheet Template"
 #: senaite/core/content/worksheet.py:144
 msgid "title_worksheet_worksheettemplate"
-msgstr ""
+msgstr "Werkbladsjabloon"
 
 #. Default: "Description"
 #: senaite/core/content/worksheettemplate.py:213
 msgid "title_worksheettemplate_description"
-msgstr ""
+msgstr "Beschrijving"
 
 #. Default: "Number of Positions"
 #: senaite/core/content/worksheettemplate.py:290
 msgid "title_worksheettemplate_num_of_positions"
-msgstr ""
+msgstr "Aantal posities"
 
 #. Default: "Analysis Services"
 #: senaite/core/content/worksheettemplate.py:346
 msgid "title_worksheettemplate_services"
-msgstr ""
+msgstr "Analysediensten"
 
 #. Default: "Worksheet Layout"
 #: senaite/core/content/worksheettemplate.py:311
 msgid "title_worksheettemplate_template_layout"
-msgstr ""
+msgstr "Werkbladlay-out"
 
 #. Default: "Name"
 #: senaite/core/content/worksheettemplate.py:205
 msgid "title_worksheettemplate_title"
-msgstr ""
+msgstr "Naam"
 
 #: bika/lims/content/instrumentscheduledtask.py:140
 msgid "until"
-msgstr ""
+msgstr "tot"
 
 #. Lower Limit of Quantification (LLOQ)."
 #. Default: "The Lower Limit of Detection (LLOD) cannot be greater than the Lower Limit of Quantification (LLOQ)."
 #: bika/lims/validators.py:1491
+#, fuzzy
 msgid "validator_llod_above_lloq"
-msgstr ""
+msgstr "De onderste detectielimiet (LLOD) mag niet groter zijn dan de onderste kwantificeringslimiet (LLOQ)."
 
 #. or equal to the Upper Limit of Quantification (ULOQ)."
 #. Default: "The Lower Limit of Quantification (LLOQ) cannot be greater than or equal to the Upper Limit of Quantification (ULOQ)."
 #: bika/lims/validators.py:1519
+#, fuzzy
 msgid "validator_lloq_above_uloq"
-msgstr ""
+msgstr "De onderste kwantificeringslimiet (LLOQ) mag niet groter dan of gelijk aan de bovenste kwantificeringslimiet (ULOQ) zijn."
 
 #. associated with other objects, such as QC analyses."
 #. Default: "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
 #: bika/lims/validators.py:1586
+#, fuzzy
 msgid "validator_referencesample_id_children"
-msgstr ""
+msgstr "De referentiemonster-ID kan niet worden gewijzigd omdat deze al gekoppeld is aan andere objecten, zoals QC-analyses."
 
 #. Default: "A Reference Sample with the ID '%s' already exists."
 #: bika/lims/validators.py:1601
 msgid "validator_referencesample_id_exists"
-msgstr ""
+msgstr "Er bestaat al een referentiemonster met de ID '%s'."
 
 #. letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no
 #. other Reference Sample with the same ID already exists."
 #. Default: "The Reference Sample ID is invalid. Ensure it contains only letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no other Reference Sample with the same ID already exists."
 #: bika/lims/validators.py:1576
+#, fuzzy
 msgid "validator_referencesample_id_invalid"
-msgstr ""
+msgstr "De referentiemonster-ID is ongeldig. Zorg ervoor dat deze alleen letters, cijfers, underscores ('_') of koppeltekens ('-') bevat, en controleer dat er geen ander referentiemonster met dezelfde ID al bestaat."
 
 #. the Upper Limit of Detection (ULOD)."
 #. Default: "The Upper Limit of Quantification (LLOQ) cannot be greater than the Upper Limit of Detection (ULOD)."
 #: bika/lims/validators.py:1547
+#, fuzzy
 msgid "validator_uloq_above_ulod"
-msgstr ""
+msgstr "De bovenste kwantificeringslimiet (LLOQ) mag niet groter zijn dan de bovenste detectielimiet (ULOD)."
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
-msgstr ""
+msgstr "verificatie(s) in behandeling"
 
 #: bika/lims/content/instrumentcertification.py:251
 msgid "weekly"
-msgstr ""
+msgstr "wekelijks"
 
 #. Default: "Created worksheet ${ws_id}"
 #: senaite/core/browser/modals/sample.py:67
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:63
 msgid "worksheet_created"
-msgstr ""
+msgstr "Werkblad ${ws_id} aangemaakt"
 
 #. Default: "Worksheet not created."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:56
 msgid "worksheet_not_created"
-msgstr ""
+msgstr "Werkblad niet aangemaakt."
 
 #: bika/lims/content/instrumentcertification.py:255
 msgid "yearly"
-msgstr ""
+msgstr "jaarlijks"
 
 #: senaite/core/exportimport/instruments/importer.py:783
 msgid "{request_id}: calculated result for '{analysis_keyword}': '{analysis_result}'"
-msgstr ""
+msgstr "{request_id}: berekend resultaat voor '{analysis_keyword}': '{analysis_result}'"
 
 #: senaite/core/exportimport/instruments/importer.py:532
 msgid "{request_id}: {keywords} imported sucessfully"
-msgstr ""
+msgstr "{request_id}: {keywords} succesvol geïmporteerd"
 
 #: senaite/core/exportimport/instruments/importer.py:731
 msgid "{sid} Updated field '{field}' with '{value}'"
-msgstr ""
+msgstr "{sid} Veld '{field}' bijgewerkt met '{value}'"
 
 #: senaite/core/exportimport/instruments/importer.py:613
 msgid "{sid} result for '{analysis_keyword}:{interim_keyword}': '{value}'"
-msgstr ""
+msgstr "{sid} resultaat voor '{analysis_keyword}:{interim_keyword}': '{value}'"
 
 #: senaite/core/exportimport/instruments/importer.py:680
 msgid "{sid} result for '{keyword}': '{result}'"
-msgstr ""
+msgstr "{sid} resultaat voor '{keyword}': '{result}'"
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
-msgstr ""
+msgstr "{} (Verouderd)"
 
 #: bika/lims/controlpanel/bika_instruments.py:173
 msgid "{} weeks and {} day(s)"
-msgstr ""
+msgstr "{} weken en {} dag(en)"

--- a/src/senaite/core/locales/nl/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/nl/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Dutch (https://app.transifex.com/senaite/teams/87045/nl/)\n"
@@ -21,84 +21,84 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
-msgstr " <p>De ID-server levert unieke opeenvolgende ID's voor objecten zoals Monsters en Werkbladen enz., op basis van een formaat dat per inhoudstype is opgegeven.</p><p>Het formaat wordt op vergelijkbare wijze opgebouwd als de Python-formaatsyntaxis, met vooraf gedefinieerde variabelen per inhoudstype, waarbij de ID's worden opgehoogd via een volgnummer, 'seq', en de opvulling ervan als een aantal cijfers, bijv. '03d' voor een reeks ID's van 001 tot 999.</p><p>Alfanumerieke voorvoegsels voor ID's worden ongewijzigd in de formaten opgenomen, bijv. WS voor Werkblad in WS-{seq:03d} levert opeenvolgende Werkblad-ID's op: WS-001, WS-002, WS-003 enz.</p><p>Voor dynamische generatie van alfanumerieke en opeenvolgende ID's kan het jokerteken {alpha} worden gebruikt. Bijv. WS-{alpha:2a3d} levert WS-AA001, WS-AA002, WS-AB034 enz. op.</p><p>Variabelen die kunnen worden gebruikt zijn onder andere:<table><tr><th style='width:150px'>Inhoudstype</th><th>Variabelen</th></tr><tr><td>Client-ID</td><td>{clientId}</td></tr><tr><td>Jaar</td><td>{year}</td></tr><tr><td>Monster-ID</td><td>{sampleId}</td></tr><tr><td>Monstertype</td><td>{sampleType}</td></tr><tr><td>Monsternamedatum</td><td>{samplingDate}</td></tr><tr><td>Datum bemonsterd</td><td>{dateSampled}</td></tr></table></p><p>Configuratie-instellingen:<ul><li>formaat:<ul><li>een python-formaattekenreeks opgebouwd uit vooraf gedefinieerde variabelen zoals sampleId, clientId, sampleType.</li><li>de speciale variabele 'seq' moet als laatste in de formaattekenreeks worden geplaatst</li></ul></li><li>reekstype: [generated|counter]</li><li>context: bij type counter levert dit context aan de telfunctie</li><li>tellertype: [backreference|contained]</li><li>tellerreferentie: een parameter voor de telfunctie</li><li>voorvoegsel: standaardvoorvoegsel als er geen is opgegeven in de formaattekenreeks</li><li>splitslengte: het aantal delen dat in het voorvoegsel wordt opgenomen</li></ul></p>"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:143
 msgid "${amount} attachments with a total size of ${total_size}"
-msgstr "${amount} bijlagen met een totale grootte van ${total_size}"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
 #: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
-msgstr "${back_link}"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:32
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
-msgstr "${contact_fullname} kan inloggen op de LIMS met ${contact_username} als gebruikersnaam. Contactpersonen moeten hun eigen wachtwoord wijzigen. Als een wachtwoord vergeten is, kan een contactpersoon via het inlogformulier een nieuw wachtwoord aanvragen."
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:105
 msgid "${items} were successfully created."
-msgstr "${items} zijn met succes aangemaakt."
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:110
 msgid "${item} was successfully created."
-msgstr "${item} is met succes aangemaakt."
+msgstr ""
 
 #: bika/lims/utils/analysisrequest.py:885
 msgid "%s has been rejected"
-msgstr "%s is afgewezen"
+msgstr ""
 
 #: senaite/core/exportimport/setupdata/__init__.py:89
 msgid "%s has no '%s' column."
-msgstr "%s heeft geen '%s'-kolom."
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
 #: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
-msgstr "&larr; Terug"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "&larr; Back to the ${back_link}"
-msgstr "&larr; Terug naar de ${back_link}"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:30
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:35
 msgid "&larr; Go back"
-msgstr "&larr; Ga terug"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/multi_results.pt:46
 msgid "&larr; Go back to see all samples"
-msgstr "&larr; Ga terug om alle monsters te bekijken"
+msgstr ""
 
 #: bika/lims/validators.py:884
 msgid "'Max' value must be above 'Min' value"
-msgstr "De waarde 'Max' moet boven de waarde 'Min' liggen"
+msgstr ""
 
 #: bika/lims/validators.py:879
 msgid "'Max' value must be numeric"
-msgstr "De waarde 'Max' moet numeriek zijn"
+msgstr ""
 
 #: bika/lims/validators.py:877
 msgid "'Min' value must be numeric"
-msgstr "De waarde 'Min' moet numeriek zijn"
+msgstr ""
 
 #: bika/lims/validators.py:898
 msgid "'Warn Max' value must be above 'Max' value"
-msgstr "De waarde 'Waarschuw Max' moet boven de waarde 'Max' liggen"
+msgstr ""
 
 #: bika/lims/validators.py:895
 msgid "'Warn Max' value must be numeric or empty"
-msgstr "De waarde 'Waarschuw Max' moet numeriek of leeg zijn"
+msgstr ""
 
 #: bika/lims/validators.py:891
 msgid "'Warn Min' value must be below 'Min' value"
-msgstr "De waarde 'Waarschuw Min' moet onder de waarde 'Min' liggen"
+msgstr ""
 
 #: bika/lims/validators.py:888
 msgid "'Warn Min' value must be numeric or empty"
-msgstr "De waarde 'Waarschuw Min' moet numeriek of leeg zijn"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:255
 msgid "(Blank)"
@@ -118,7 +118,7 @@ msgstr "(Vereist)"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:26
 msgid "*** This is an automatically generated email, please do not reply to this message. ***"
-msgstr "*** Dit is een automatisch gegenereerd e-mailbericht, gelieve niet op dit bericht te antwoorden. ***"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:91
 msgid "+-"
@@ -126,69 +126,69 @@ msgstr "±"
 
 # senaite.app.listing: Column-filter row — boolean select placeholder
 msgid "-- Select --"
-msgstr "-- Selecteren --"
+msgstr ""
 
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
-msgstr "... Kies een Instrument ..."
+msgstr ""
 
 #: bika/lims/browser/fields/resultrangefield.py:40
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:126
 msgid "< Min"
-msgstr "< Min"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:61
 msgid "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Go to worksheet template setup"
-msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Ga naar werkbladsjabloon-instellingen"
+msgstr ""
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:15
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
-msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Welkom bij SENAITE"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
-msgstr "<p>De ID-server levert unieke opeenvolgende ID's voor objecten zoals Monsters en Werkbladen enz., op basis van een formaat dat per inhoudstype is opgegeven. Het formaat wordt op vergelijkbare wijze opgebouwd als de Python-formaatsyntaxis, bijv. <code>WS-{seq:03d}</code> levert <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> enz. op.</p><p>De huidige persistente tellerwaarden worden beheerd in de <a href='ng'>weergave Nummergenerator</a>.</p><details class='id-server-cheatsheet'><summary>Beschikbare variabelen</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variabele</th><th>Beschrijving</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeriek volgnummer, optioneel met voorloopnullen.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alfanumerieke teller, bijv. <code>{alpha:2a3d}</code> levert AA001, AA002, ..., AB001, ... op</td></tr><tr><td><code>{year}</code></td><td>Huidig jaar met twee cijfers (bijv. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Huidige datum als <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client-ID (alleen monsters).</td></tr><tr><td><code>{sampleType}</code></td><td>Voorvoegsel monstertype.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Monsterdata (Python <code>strftime</code>-specificaties zijn van toepassing).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>Voor partities/hertesten/secundairen: de bovenliggende monster-ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Partitieteller per bovenliggend monster.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Tellers voor hertesten, secundairen en totaal aantal testen.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuratievelden</summary><ul><li><strong>Formaat</strong>: het ID-sjabloon.</li><li><strong>Reekstype</strong>: <code>generated</code> gebruikt de persistente nummerteller; <code>counter</code> gebruikt het aantal gerelateerde objecten.</li><li><strong>Context</strong>: alleen gebruikt door het type <code>counter</code>; de benoemde context waarop de teller van toepassing is.</li><li><strong>Tellertype</strong>: <code>backreference</code> (verouderd) of <code>contained</code>.</li><li><strong>Tellerreferentie</strong>: relatienaam (backreference) of metatype (contained).</li><li><strong>Voorvoegsel</strong>: standaardvoorvoegsel als er geen in het formaat staat.</li><li><strong>Splitslengte</strong>: hoeveel segmenten van het formaat het voorvoegsel van de opslagsleutel worden. Bepaalt hoe de teller wordt gepartitioneerd (bijv. per jaar, per monstertype).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
+msgstr ""
 
 #: bika/lims/content/calculation.py:133
 msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-msgstr "<p>De formule die u hier typt, wordt dynamisch berekend wanneer een analyse die deze berekening gebruikt wordt weergegeven.</p><p>Om een Berekening in te voeren, gebruikt u standaard rekenkundige operatoren,  + - * / ( ), en alle beschikbare sleutelwoorden, zowel van andere Analysediensten als van de hier opgegeven Tussentijdse velden, als variabelen. Plaats ze tussen vierkante haken [ ].</p><p>Bijv. de berekening voor Totale hardheid, het totaal van Calcium (ppm)- en Magnesium (ppm)-ionen in water, wordt ingevoerd als [Ca] + [Mg], waarbij Ca en MG de sleutelwoorden zijn voor die twee Analysediensten.</p>"
+msgstr ""
 
 #: bika/lims/browser/fields/resultrangefield.py:41
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:131
 msgid "> Max"
-msgstr "> Max"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "A Document/File attachment"
-msgstr "Een document-/bestandsbijlage"
+msgstr ""
 
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "A published results report"
-msgstr "Een gepubliceerd resultatenrapport"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:66
 msgid "A short title for the site. This will be shown in the title of the browser window on each page."
-msgstr "Een korte titel voor de site. Deze wordt op elke pagina in de titel van het browservenster weergegeven."
+msgstr ""
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "A simple file attachment"
-msgstr "Een eenvoudige bestandsbijlage"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "A simple image attachment"
-msgstr "Een eenvoudige afbeeldingsbijlage"
+msgstr ""
 
 #: bika/lims/profiles/default/types/ARTemplate.xml
 msgid "AR Template"
-msgstr "AR-sjabloon"
+msgstr ""
 
 #: bika/lims/profiles/default/types/ARTemplates.xml
 msgid "AR Templates"
-msgstr "AR-sjablonen"
+msgstr ""
 
 #: bika/lims/profiles/default/types/ARReport.xml
 msgid "ARReport"
-msgstr "ARReport"
+msgstr ""
 
 #: bika/lims/content/organisation.py:130
 msgid "Account Name"
@@ -205,7 +205,7 @@ msgstr "Rekeningtype"
 #: senaite/core/content/analysisprofile.py:64
 #: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
-msgstr "Boekhouding"
+msgstr ""
 
 #: senaite/core/content/laboratory.py:109
 msgid "Accreditation"
@@ -221,7 +221,7 @@ msgstr "Accreditatie-instelling URL"
 
 #: bika/lims/content/laboratory.py:162
 msgid "Accreditation Logo"
-msgstr "Accreditatielogo"
+msgstr ""
 
 #: bika/lims/content/laboratory.py:152
 msgid "Accreditation Reference"
@@ -229,7 +229,7 @@ msgstr "Accreditatie referentie"
 
 #: bika/lims/content/laboratory.py:175
 msgid "Accreditation page header"
-msgstr "Koptekst accreditatiepagina"
+msgstr ""
 
 #: senaite/core/browser/widgets/services_widget.py:323
 msgid "Accredited"
@@ -244,7 +244,7 @@ msgstr "Actie"
 #: senaite/core/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
 msgid "Activate"
-msgstr "Activeren"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
@@ -254,11 +254,11 @@ msgstr "Actieve"
 
 #: senaite/core/content/resultsreport.py:52
 msgid "Actor"
-msgstr "Actor"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
-msgstr "Volledige naam actor"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
@@ -272,7 +272,7 @@ msgstr "Toevoegen van Analyses"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:301
 msgid "Add Attachment"
-msgstr "Bijlage toevoegen"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Blank Reference"
@@ -280,94 +280,94 @@ msgstr "Lege verwijzing toevoegen"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Control Reference"
-msgstr "Controlereferentie toevoegen"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Duplicate"
-msgstr "Duplicaat toevoegen"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/add_samples.pt:22
 msgid "Add Samples"
-msgstr "Monsters toevoegen"
+msgstr ""
 
 #: senaite/core/api/remarks.py:492
 msgid "Add a remark..."
-msgstr "Een opmerking toevoegen..."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
-msgstr "Een opmerkingenveld toevoegen aan alle analyses"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
-msgstr "Voeg aangepaste CSS-regels toe voor het logo, bijv. height:15px; width:150px;"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
-msgstr "Standaard selecteerbare labels toevoegen"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:205
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:38
 msgid "Add new Attachment"
-msgstr "Nieuwe bijlage toevoegen"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1026
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
-msgstr "Voeg een of meer bijlagen toe om het monster in dit monster te beschrijven of om uw aanvraag te specificeren."
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:879
 msgid "Add or remove labels on the selected samples"
-msgstr "Labels toevoegen aan of verwijderen van de geselecteerde monsters"
+msgstr ""
 
 #: senaite/core/api/remarks.py:477
 msgid "Add remarks"
-msgstr "Opmerkingen toevoegen"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:169
 msgid "Add-ons"
-msgstr "Add-ons"
+msgstr ""
 
 #: bika/lims/content/calculation.py:111
 msgid "Additional Python Libraries"
-msgstr "Aanvullende Python-bibliotheken"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:237
 msgid "Additional email addresses to be notified"
-msgstr "Aanvullende e-mailadressen die op de hoogte moeten worden gebracht"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:117
 msgid "Additional result values"
-msgstr "Aanvullende resultaatwaarden"
+msgstr ""
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:137
 #: senaite/core/z3cform/widgets/address.py:119
 msgid "Address"
-msgstr "Adres"
+msgstr ""
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Adds the ability to add/remove labels"
-msgstr "Voegt de mogelijkheid toe om labels toe te voegen/te verwijderen"
+msgstr ""
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "Adds the ability to share a content across clients"
-msgstr "Voegt de mogelijkheid toe om inhoud te delen tussen klanten"
+msgstr ""
 
 #: bika/lims/content/sampletype.py:231
 msgid "Admitted sticker templates"
-msgstr "Toegestane stickersjablonen"
+msgstr ""
 
 #: bika/lims/content/sampletype.py:204
 msgid "Admitted stickers for the sample type"
-msgstr "Toegestane stickers voor het monstertype"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:138
 msgid "Advanced"
-msgstr "Geavanceerd"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:660
 #: bika/lims/content/instrumentcertification.py:92
 msgid "Agency"
-msgstr "Instantie"
+msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:87
 #: senaite/core/browser/clients/client/contacts/view.py:95
@@ -377,11 +377,11 @@ msgstr "Alle"
 
 #: bika/lims/browser/accreditation.py:75
 msgid "All Accredited analysis services are listed here."
-msgstr "Alle geaccrediteerde analysediensten worden hier vermeld."
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:41
 msgid "All Analyses of Service"
-msgstr "Alle analyses van dienst"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
@@ -389,64 +389,64 @@ msgstr "Alle analyses toegewezen"
 
 # senaite.app.listing: Column config — empty state when no columns are visible
 msgid "All columns are hidden."
-msgstr "Alle kolommen zijn verborgen."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
-msgstr "Handmatige invoer van detectiegrens toestaan"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:728
 msgid "Allow Manual Entry"
-msgstr "Handmatige invoer toestaan"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
-msgstr "Leeg toestaan"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:685
 msgid "Allow manual uncertainty value input"
-msgstr "Handmatige invoer van onzekerheidswaarde toestaan"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:175
 msgid "Allow same user to verify multiple times"
-msgstr "Dezelfde gebruiker toestaan meerdere keren te verifiëren"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:177
 msgid "Allow same user to verify multiple times, but not consecutively"
-msgstr "Dezelfde gebruiker toestaan meerdere keren te verifiëren, maar niet achtereenvolgens"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
-msgstr "Zelfverificatie van resultaten toestaan"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
-msgstr "Indiening van resultaten voor niet-toegewezen analyses toestaan"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:336
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
-msgstr "De analist toestaan de standaard detectiegrenzen (LDL en UDL) handmatig te vervangen in de weergaven voor resultaatinvoer"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:686
 msgid "Allow the analyst to manually replace the default uncertainty value."
-msgstr "De analist toestaan de standaard onzekerheidswaarde handmatig te vervangen."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:379
 msgid "Allow to introduce analysis results manually"
-msgstr "Toestaan analyseresultaten handmatig in te voeren"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:371
 msgid "Allowed analysis states: {allowed_states}, "
-msgstr "Toegestane analysestatussen: {allowed_states}, "
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:368
 msgid "Allowed sample states: {allowed_states}, "
-msgstr "Toegestane monsterstatussen: {allowed_states}, "
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:60
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:60
 msgid "Analysed by"
-msgstr "Geanalyseerd door"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:506
 #: senaite/core/browser/samples/view.py:248
@@ -456,23 +456,23 @@ msgstr "Analyses"
 
 #: senaite/core/browser/dashboard/dashboard.py:485
 msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr "Analyses toegewezen aan een werkblad, in afwachting van resultaten"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:498
 msgid "Analyses included in a published report"
-msgstr "Analyses opgenomen in een gepubliceerd rapport"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:480
 msgid "Analyses not yet assigned to a worksheet"
-msgstr "Analyses die nog niet aan een werkblad zijn toegewezen"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
-msgstr "Aangevraagde analyses"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:494
 msgid "Analyses that have been verified"
-msgstr "Analyses die zijn geverifieerd"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -482,46 +482,46 @@ msgstr "Analyse"
 
 #: senaite/core/exportimport/instruments/importer.py:657
 msgid "Analysis '{keyword}' of sample '{sid}' has the result '{result}' set, which is kept due to the selected override option"
-msgstr "Analyse '{keyword}' van monster '{sid}' heeft het resultaat '{result}' ingesteld, dat behouden blijft vanwege de geselecteerde overschrijfoptie"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:362
 msgid "Analysis Keyword"
-msgstr "Analyse-sleutelwoord"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:93
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Profiles"
-msgstr "Analyseprofielen"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisreport_info.pt:22
 msgid "Analysis Report"
-msgstr "Analyserapport"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:55
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Reports"
-msgstr "Analyserapporten"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:310
 msgid "Analysis Results for {}"
-msgstr "Analyseresultaten voor {}"
+msgstr ""
 
 #: bika/lims/browser/fields/referenceresultsfield.py:34
 #: bika/lims/browser/fields/resultrangefield.py:33
 #: bika/lims/browser/referencesample.py:222
 msgid "Analysis Service"
-msgstr "Analysedienst"
+msgstr ""
 
 #: bika/lims/config.py:61
 #: bika/lims/controlpanel/bika_analysisservices.py:149
 #: bika/lims/profiles/default/types/AnalysisServices.xml
 msgid "Analysis Services"
-msgstr "Analysediensten"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:76
 #: bika/lims/profiles/default/types/AnalysisSpec.xml
 msgid "Analysis Specification"
-msgstr "Analysespecificatie"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:64
 #: bika/lims/profiles/default/types/AnalysisSpecs.xml
@@ -535,35 +535,35 @@ msgstr "Soort analyse"
 
 #: bika/lims/content/analysisservice.py:266
 msgid "Analysis conditions"
-msgstr "Analysecondities"
+msgstr ""
 
 #: senaite/core/browser/modals/conditions.py:165
 msgid "Analysis conditions updated: {}"
-msgstr "Analysecondities bijgewerkt: {}"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
-msgstr "Analysespecificaties die rechtstreeks op het monster worden bewerkt."
+msgstr ""
 
 #: senaite/core/content/interpretationtemplate.py:59
 msgid "Analysis templates"
-msgstr "Analysesjablonen"
+msgstr ""
 
 #: senaite/core/profiles/default/types/AnalysisCategories.xml
 msgid "AnalysisCategories"
-msgstr "AnalysisCategories"
+msgstr ""
 
 #: senaite/core/profiles/default/types/AnalysisCategory.xml
 msgid "AnalysisCategory"
-msgstr "AnalysisCategory"
+msgstr ""
 
 #: senaite/core/profiles/default/types/AnalysisProfile.xml
 msgid "AnalysisProfile"
-msgstr "AnalysisProfile"
+msgstr ""
 
 #: senaite/core/profiles/default/types/AnalysisProfiles.xml
 msgid "AnalysisProfiles"
-msgstr "AnalysisProfiles"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:87
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:35
@@ -572,7 +572,7 @@ msgstr "Analist"
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:42
 msgid "Analyst must be specified."
-msgstr "Analist moet worden opgegeven."
+msgstr ""
 
 #: bika/lims/browser/fields/partitionsetupfield.py:57
 msgid "Any"
@@ -580,11 +580,11 @@ msgstr "Elke"
 
 #: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
-msgstr "Weergave"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:217
 msgid "Apply"
-msgstr "Toepassen"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
@@ -592,19 +592,19 @@ msgstr "Sjabloon toepassen"
 
 # senaite.app.listing: Saved filter presets — apply button tooltip
 msgid "Apply this filter"
-msgstr "Deze filter toepassen"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
-msgstr "Breed toepassen"
+msgstr ""
 
 #: bika/lims/content/instrument.py:308
 msgid "Asset Number"
-msgstr "Inventarisnummer"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Assign"
-msgstr "Toewijzen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:147
 #: senaite/core/browser/samples/view.py:443
@@ -614,27 +614,27 @@ msgstr "Toegewezen"
 
 #: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr "Toegewezen aan: ${worksheet_id}"
+msgstr ""
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
-msgstr "Er zijn ten minste twee opties voor het keuzeveld vereist"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:244
 msgid "Attach to Sample"
-msgstr "Aan monster koppelen"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:815
 msgid "Attached file '{filename}' to worksheet {worksheet}"
-msgstr "Bestand '{filename}' gekoppeld aan werkblad {worksheet}"
+msgstr ""
 
 #: senaite/core/extender/label.py:62
 msgid "Attached labels"
-msgstr "Gekoppelde labels"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:854
 msgid "Attaching '{attachment}' to Analysis '{analysis}'"
-msgstr "'{attachment}' wordt gekoppeld aan analyse '{analysis}'"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1025
 #: bika/lims/content/attachment.py:52
@@ -644,7 +644,7 @@ msgstr "Bijlage"
 
 #: senaite/core/exportimport/instruments/importer.py:860
 msgid "Attachment '{attachment}' was already linked to analysis {analysis}"
-msgstr "Bijlage '{attachment}' was al gekoppeld aan analyse {analysis}"
+msgstr ""
 
 #: bika/lims/content/attachment.py:91
 msgid "Attachment Keys"
@@ -660,31 +660,31 @@ msgstr "Bijlagentypen"
 
 #: senaite/core/browser/attachment/attachment.py:215
 msgid "Attachment added to all '{}' analyses"
-msgstr "Bijlage toegevoegd aan alle '{}'-analyses"
+msgstr ""
 
 #: senaite/core/browser/attachment/attachment.py:182
 msgid "Attachment added to analysis '{}'"
-msgstr "Bijlage toegevoegd aan analyse '{}'"
+msgstr ""
 
 #: senaite/core/browser/attachment/attachment.py:281
 msgid "Attachment added to the current sample"
-msgstr "Bijlage toegevoegd aan het huidige monster"
+msgstr ""
 
 #: senaite/core/browser/widgets/services_widget.py:326
 msgid "Attachment required"
-msgstr "Bijlage vereist"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:348
 msgid "Attachment required for verification"
-msgstr "Bijlage vereist voor verificatie"
+msgstr ""
 
 #: senaite/core/browser/attachment/attachment.py:349
 msgid "Attachment(s) deleted"
-msgstr "Bijlage(n) verwijderd"
+msgstr ""
 
 #: senaite/core/browser/attachment/attachment.py:138
 msgid "Attachment(s) updated"
-msgstr "Bijlage(n) bijgewerkt"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:10
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:10
@@ -694,215 +694,215 @@ msgstr "Bijlagen"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Audit Log"
-msgstr "Auditlogboek"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:215
 msgid "Authorized by"
-msgstr "Geautoriseerd door"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:56
 msgid "Auto Import"
-msgstr "Automatisch importeren"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:759
 msgid "Auto Import Logs of %s"
-msgstr "Logboeken automatisch importeren van %s"
+msgstr ""
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Auto-Generate ID Behavior for Dexterity Contents"
-msgstr "Gedrag voor automatisch genereren van ID voor Dexterity-inhoud"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Auto-Import Logs"
-msgstr "Logboeken automatisch importeren"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — star action tooltip
 msgid "Auto-apply on open"
-msgstr "Automatisch toepassen bij openen"
+msgstr ""
 
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
-msgstr "Automatisch partitioneren bij ontvangst"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
-msgstr "Monsters automatisch ontvangen"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:166
 msgid "Autofill"
-msgstr "Automatisch invullen"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
-msgstr "Automatisch stickers afdrukken"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
-msgstr "Automatisch afmelden"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
-msgstr "Automatische verificatie van monsters"
+msgstr ""
 
 #: bika/lims/content/artemplate.py:242
 msgid "Automatically redirect the user to the partitions creation view when Sample is received."
-msgstr "Leid de gebruiker automatisch naar de weergave voor het aanmaken van partities wanneer het monster wordt ontvangen."
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:76
 msgid "Available instruments based on the selected methods."
-msgstr "Beschikbare instrumenten op basis van de geselecteerde methoden."
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:61
 msgid "Available methods to perform the test"
-msgstr "Beschikbare methoden om de test uit te voeren"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:119
 msgid "Available templates"
-msgstr "Beschikbare sjablonen"
+msgstr ""
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:46
 msgid "Back"
-msgstr "Terug"
+msgstr ""
 
 #: bika/lims/content/organisation.py:154
 msgid "Bank branch"
-msgstr "Bankfiliaal"
+msgstr ""
 
 #: bika/lims/content/organisation.py:146
 msgid "Bank name"
-msgstr "Banknaam"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:138
 msgid "Base configuration"
-msgstr "Basisconfiguratie"
+msgstr ""
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:44
 #: bika/lims/browser/templates/referencesample_analyses.pt:42
 msgid "Basis"
-msgstr "Basis"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:76
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/vocabularies/__init__.py:128
 msgid "Batch"
-msgstr "Batch"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 msgid "Batch Book"
-msgstr "Batchboek"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
-msgstr "Batch-ID"
+msgstr ""
 
 #: senaite/core/profiles/default/types/BatchLabel.xml
 msgid "Batch Label"
-msgstr "Batchlabel"
+msgstr ""
 
 #: senaite/core/profiles/default/types/BatchLabels.xml
 msgid "Batch Labels"
-msgstr "Batchlabels"
+msgstr ""
 
 #: bika/lims/browser/batchfolder.py:49
 #: bika/lims/profiles/default/types/BatchFolder.xml
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Batches"
-msgstr "Batches"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:19
 msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges defined in the Specifications list below."
-msgstr "Houd er rekening mee dat de bereiken die in het spreadsheetbestand van de dynamische specificatie worden opgegeven, de bereiken die in de onderstaande Specificatielijst zijn gedefinieerd, kunnen overschrijven."
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:19
 msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges manually defined in the list below."
-msgstr "Houd er rekening mee dat de bereiken die in het spreadsheetbestand van de dynamische specificatie worden opgegeven, de bereiken die handmatig in de onderstaande lijst zijn gedefinieerd, kunnen overschrijven."
+msgstr ""
 
 #: bika/lims/browser/fields/coordinatefield.py:39
 msgid "Bearing"
-msgstr "Richting"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:139
 msgid "Biannual"
-msgstr "Halfjaarlijks"
+msgstr ""
 
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
-msgstr "Factuuradres"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:593
 msgid "Blank"
-msgstr "Blanco"
+msgstr ""
 
 #: bika/lims/config.py:88
 msgid "Blank QC analyses"
-msgstr "Blanco QC-analyses"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_instruments.py:80
 msgid "Brand"
-msgstr "Merk"
+msgstr ""
 
 #: bika/lims/browser/clientfolder.py:90
 msgid "Bulk Discount"
-msgstr "Bulkkorting"
+msgstr ""
 
 #: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
-msgstr "Bulkkorting is van toepassing"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:561
 msgid "Bulk price (excluding VAT)"
-msgstr "Bulkprijs (exclusief btw)"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:78
 #: senaite/core/browser/controlpanel/contacts/view.py:66
 msgid "Business Phone"
-msgstr "Zakelijk telefoonnummer"
+msgstr ""
 
 #: senaite/core/z3cform/widgets/address.py:123
 msgid "Business address"
-msgstr "Zakelijk adres"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
-msgstr "Op 'Weergavewaarde' oplopend"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
-msgstr "Op 'Weergavewaarde' aflopend"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
-msgstr "Op 'Resultaatwaarde' oplopend"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
-msgstr "Op 'Resultaatwaarde' aflopend"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:348
 msgid "CBID"
-msgstr "CBID"
+msgstr ""
 
 #: bika/lims/content/client.py:133
 msgid "CC Contacts"
-msgstr "CC-contactpersonen"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
 #: bika/lims/content/client.py:166
 msgid "CC Emails"
-msgstr "CC-e-mails"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:663
 msgid "Calculate Precision from Uncertainties"
-msgstr "Precisie berekenen op basis van onzekerheden"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Calculation.xml
 msgid "Calculation"
-msgstr "Berekening"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/method.py:100
 msgid "Calculation '{}' is used by service '{}'"
-msgstr "Berekening '{}' wordt gebruikt door dienst '{}'"
+msgstr ""
 
 #: bika/lims/content/calculation.py:132
 msgid "Calculation Formula"
@@ -915,7 +915,7 @@ msgstr "Berekeningvelden Interim"
 
 #: bika/lims/content/analysisservice.py:106
 msgid "Calculation to be assigned to this content."
-msgstr "Berekening die aan deze inhoud moet worden toegewezen."
+msgstr ""
 
 #: senaite/core/profiles/default/types/Calculations.xml
 msgid "Calculations"
@@ -923,40 +923,40 @@ msgstr "Berekeningen"
 
 #: bika/lims/content/instrumentscheduledtask.py:118
 msgid "Calibration"
-msgstr "Kalibratie"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:637
 #: bika/lims/browser/templates/instrument_certifications.pt:40
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Calibration Certificates"
-msgstr "Kalibratiecertificaten"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:69
 msgid "Calibration report date"
-msgstr "Datum kalibratierapport"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Calibrations"
-msgstr "Kalibraties"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentcalibration.py:96
 msgid "Calibrator"
-msgstr "Kalibrator"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
-msgstr "Kan verifiëren, maar ingediend door huidige gebruiker"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
-msgstr "Kan verifiëren, maar al geverifieerd door huidige gebruiker"
+msgstr ""
 
 #: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
 msgid "Cancel"
-msgstr "Annuleren"
+msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
 #: senaite/core/browser/samples/dispose_samples.py:70
@@ -966,48 +966,48 @@ msgstr "Geannuleerd"
 
 #: bika/lims/content/calculation.py:460
 msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
-msgstr "Kan berekening niet activeren, omdat de volgende dienstafhankelijkheden inactief zijn: ${inactive_services}"
+msgstr ""
 
 #: bika/lims/content/calculation.py:480
 msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
-msgstr "Kan berekening niet deactiveren, omdat deze in gebruik is door de volgende diensten: ${calc_services}"
+msgstr ""
 
 #: senaite/core/browser/samples/invalidate_samples.py:93
 msgid "Cannot invalidate ${sample_id}: ${error}"
-msgstr "Kan ${sample_id} niet ongeldig maken: ${error}"
+msgstr ""
 
 #: senaite/core/browser/samples/invalidate_samples.py:262
 msgid "Cannot send email for ${sample_id}: ${error}"
-msgstr "Kan geen e-mail verzenden voor ${sample_id}: ${error}"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
-msgstr "Kan niet verifiëren, laatst geverifieerd door huidige gebruiker"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
-msgstr "Kan niet verifiëren, ingediend door huidige gebruiker"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
-msgstr "Kan niet verifiëren, is geverifieerd door huidige gebruiker"
+msgstr ""
 
 #: senaite/core/content/samplecontainer.py:78
 msgid "Capacity"
-msgstr "Capaciteit"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:112
 msgid "Captured"
-msgstr "Vastgelegd"
+msgstr ""
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:45
 #: bika/lims/browser/templates/referencesample_analyses.pt:43
 msgid "Cardinal"
-msgstr "Hoofdrichting"
+msgstr ""
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Catalog Dexterity contents in multiple catalogs"
-msgstr "Dexterity-inhoud in meerdere catalogi catalogiseren"
+msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:57
 #: bika/lims/content/referencesample.py:151
@@ -1016,7 +1016,7 @@ msgstr "Catalogusnummer"
 
 #: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
-msgstr "Analysediensten categoriseren"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:59
 #: bika/lims/browser/worksheet/views/add_analyses.py:107
@@ -1026,99 +1026,99 @@ msgstr "Categorie"
 
 #: bika/lims/content/analysiscategory.py:118
 msgid "Category cannot be deactivated because it contains Analysis Services"
-msgstr "Categorie kan niet worden gedeactiveerd omdat deze analysediensten bevat"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:659
 msgid "Cert. Num"
-msgstr "Cert.nr."
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:209
 msgid "Certificate Code"
-msgstr "Certificaatcode"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:96
 #: bika/lims/controlpanel/auditlog.py:103
 msgid "Changes"
-msgstr "Wijzigingen"
+msgstr ""
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:64
 msgid "Changes Saved"
-msgstr "Wijzigingen opgeslagen"
+msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
 #: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
-msgstr "Wijzigingen opgeslagen."
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
-msgstr "Wijzigingen worden doorgevoerd naar partities"
+msgstr ""
 
 #: bika/lims/content/method.py:67
 msgid "Check if the method has been accredited"
-msgstr "Aanvinken als de methode is geaccrediteerd"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:495
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
-msgstr "Vink dit vakje aan als de analysedienst is opgenomen in het overzicht van geaccrediteerde analyses van het laboratorium"
+msgstr ""
 
 #: bika/lims/content/samplepoint.py:122
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
-msgstr "Vink dit vakje aan als de monsters die op dit punt worden genomen 'samengesteld' zijn en zijn samengesteld uit meer dan één deelmonster, bijv. meerdere oppervlaktemonsters van een stuwmeer die samen zijn gemengd tot een representatief monster voor het stuwmeer. De standaardinstelling, niet aangevinkt, duidt op 'grijpmonsters'"
+msgstr ""
 
 #: senaite/core/content/samplecontainer.py:86
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
-msgstr "Vink dit vakje aan als deze container al geconserveerd is. Hiermee wordt de conserveringsworkflow voor monsterpartities die in deze container zijn opgeslagen, overgeslagen."
+msgstr ""
 
 #: bika/lims/content/laboratory.py:112
 msgid "Check this box if your laboratory is accredited"
-msgstr "Vink dit vakje aan als uw laboratorium geaccrediteerd is"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:130
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
-msgstr "Vink dit vakje aan om ervoor te zorgen dat er een aparte monstercontainer wordt gebruikt voor deze analysedienst"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:260
 msgid "Checkbox"
-msgstr "Selectievakje"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:55
 #: bika/lims/content/analysisservice.py:223
 msgid "Choices"
-msgstr "Keuzes"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
-msgstr "Kies het standaardsjabloon voor 'grote' stickers. Let op: monsterspecifieke 'grote' stickers worden geconfigureerd op basis van hun monstertype."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
-msgstr "Kies het standaardsjabloon voor 'grote' stickers.<br/><strong>Let op:</strong> monsterspecifieke 'grote' stickers worden geconfigureerd op basis van hun monstertype."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
-msgstr "Kies het standaardsjabloon voor 'kleine' stickers. Let op: monsterspecifieke 'kleine' stickers worden geconfigureerd op basis van hun monstertype."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
-msgstr "Kies het standaardsjabloon voor 'kleine' stickers.<br/><strong>Let op:</strong> monsterspecifieke 'kleine' stickers worden geconfigureerd op basis van hun monstertype."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
-msgstr "Kies het type meervoudige verificatie voor dezelfde gebruiker. Met deze instelling kan meer dan één keer verifiëren/achtereenvolgens verifiëren voor dezelfde gebruiker worden in-/uitgeschakeld."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
-msgstr "Kies wanneer stickers automatisch moeten worden afgedrukt:<br/><ul><li><strong>Registreren:</strong> Stickers worden automatisch afgedrukt wanneer nieuwe monsters worden aangemaakt.</li><li><strong>Ontvangen:</strong> Stickers worden automatisch afgedrukt wanneer monsters worden ontvangen.</li><li><strong>Geen:</strong> Schakelt automatisch afdrukken van stickers uit.</li></ul>"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
-msgstr "Kies wanneer stickers automatisch moeten worden afgedrukt:<br/><ul><li><strong>Registreren:</strong> Stickers worden automatisch afgedrukt wanneer nieuwe monsters worden aangemaakt.</li><li><strong>Ontvangen:</strong> Stickers worden automatisch afgedrukt wanneer monsters worden ontvangen.</li><li><strong>Geen:</strong> Schakelt automatisch afdrukken van stickers uit.</li></ul>"
+msgstr ""
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:113
 #: senaite/core/z3cform/widgets/address.py:225
 msgid "City"
-msgstr "Plaats"
+msgstr ""
 
 #: bika/lims/config.py:125
 msgid "Classic"
@@ -1126,29 +1126,29 @@ msgstr "Classic"
 
 # senaite.app.listing: Column-filter row — clear button tooltip
 msgid "Clear filter"
-msgstr "Filter wissen"
+msgstr ""
 
 # senaite.app.listing: Search box — undo button tooltip when only clearing
 # search
 msgid "Clear search"
-msgstr "Zoekopdracht wissen"
+msgstr ""
 
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
-msgstr "Selectie wissen"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
-msgstr "Klik om deze categorie uit te vouwen"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — release button tooltip on the
 # applied preset
 msgid "Click to release this filter"
-msgstr "Klik om deze filter op te heffen"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
-msgstr "Klik om de zichtbaarheid te wisselen of sleep om de volgorde te wijzigen"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
 #: senaite/core/browser/samples/view.py:191
@@ -1159,7 +1159,7 @@ msgstr "Client"
 #: bika/lims/browser/batchfolder.py:84
 #: bika/lims/content/batch.py:101
 msgid "Client Batch ID"
-msgstr "Client-batch-ID"
+msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
@@ -1169,21 +1169,21 @@ msgstr "Client-ID"
 
 #: bika/lims/profiles/default/registry.xml
 msgid "Client Landing Page"
-msgstr "Client-landingspagina"
+msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:85
 msgid "Client Name"
-msgstr "Clientnaam"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
-msgstr "Clientorder"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:115
 #: bika/lims/browser/batch/batchbook.py:81
 #: bika/lims/content/analysisrequest.py:817
 msgid "Client Order Number"
-msgstr "Clientordernummer"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
@@ -1204,11 +1204,11 @@ msgstr "Client Monster-ID"
 
 #: senaite/core/registry/schema.py:39
 msgid "Client Settings"
-msgstr "Clientinstellingen"
+msgstr ""
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "ClientShareableBehavior"
-msgstr "ClientShareableBehavior"
+msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:58
 msgid "Clients"
@@ -1216,81 +1216,81 @@ msgstr "Klanten"
 
 #: senaite/core/behaviors/clientshareable.py:59
 msgid "Clients with whom this content will be shared across. This content will become available on searches to users that belong to any of the selected clients thanks to the role 'ClientGuest'"
-msgstr "Klanten met wie deze inhoud wordt gedeeld. Deze inhoud wordt beschikbaar in zoekopdrachten voor gebruikers die tot een van de geselecteerde klanten behoren dankzij de rol 'ClientGuest'"
+msgstr ""
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:13
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 msgid "Close"
-msgstr "Sluiten"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 msgid "Closed"
-msgstr "Gesloten"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:59
 msgid "Code for the location"
-msgstr "Code voor de locatie"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:44
 msgid "Code for the site"
-msgstr "Code voor de site"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
-msgstr "Code voor de plank"
+msgstr ""
 
 #: senaite/core/registry/schema.py:133
 msgid "Collapse field analysis table"
-msgstr "Veldanalysetabel inklappen"
+msgstr ""
 
 #: senaite/core/registry/schema.py:134
 msgid "Collapse field analysis table in sample view"
-msgstr "Veldanalysetabel inklappen in monsterweergave"
+msgstr ""
 
 #: senaite/core/registry/schema.py:140
 msgid "Collapse lab analysis table"
-msgstr "Labanalysetabel inklappen"
+msgstr ""
 
 #: senaite/core/registry/schema.py:141
 msgid "Collapse lab analysis table in sample view"
-msgstr "Labanalysetabel inklappen in monsterweergave"
+msgstr ""
 
 #: senaite/core/registry/schema.py:147
 msgid "Collapse qc analysis table"
-msgstr "QC-analysetabel inklappen"
+msgstr ""
 
 #: senaite/core/registry/schema.py:148
 msgid "Collapse qc analysis table in sample view"
-msgstr "QC-analysetabel inklappen in monsterweergave"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:117
 msgid "Collected"
-msgstr "Verzameld"
+msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:94
 msgid "Column '{}' is missing"
-msgstr "Kolom '{}' ontbreekt"
+msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:88
 msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
-msgstr "Kolom {} van de koprij heeft geen naam. Verwijder lege kolommen uit de spreadsheet en upload deze opnieuw."
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
-msgstr "Komma (,)"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:51
 msgid "Comments"
-msgstr "Opmerkingen"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1368
 msgid "Comments or results interpretation"
-msgstr "Opmerkingen of interpretatie van resultaten"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
-msgstr "Commerciële ID"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:957
 #: bika/lims/content/samplepoint.py:121
@@ -1299,43 +1299,43 @@ msgstr "Composiet"
 
 #: bika/lims/content/artemplate.py:109
 msgid "Composite sample"
-msgstr "Samengesteld monster"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:267
 msgid "Conditions to ask for this analysis on sample registration. For instance, laboratory may want the user to input the temperature, the ramp and flow when a thermogravimetric (TGA) analysis is selected on sample registration. The information provided will be later considered by the laboratory personnel when performing the test."
-msgstr "Condities om voor deze analyse op te vragen bij monsterregistratie. Zo kan het laboratorium bijvoorbeeld willen dat de gebruiker de temperatuur, de opwarmsnelheid en de flow invoert wanneer een thermogravimetrische (TGA-)analyse wordt geselecteerd bij monsterregistratie. De verstrekte informatie wordt later door het laboratoriumpersoneel in aanmerking genomen bij het uitvoeren van de test."
+msgstr ""
 
 #: bika/lims/content/laboratory.py:99
 msgid "Confidence Level %"
-msgstr "Betrouwbaarheidsniveau %"
+msgstr ""
 
 # senaite.app.listing: Configuration
 msgid "Configuration"
-msgstr "Configuratie"
+msgstr ""
 
 #: senaite/core/registry/schema.py:227
 msgid "Configuration for Generic Setup"
-msgstr "Configuratie voor Generic Setup"
+msgstr ""
 
 #: senaite/core/registry/schema.py:161
 msgid "Configuration for the sample header information"
-msgstr "Configuratie voor de kopinformatie van het monster"
+msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:119
 msgid "Configuration restored to default values."
-msgstr "Configuratie hersteld naar standaardwaarden."
+msgstr ""
 
 # senaite.app.listing: Column config — trigger button label
 msgid "Configure"
-msgstr "Configureren"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
-msgstr "Tabelkolommen configureren"
+msgstr ""
 
 #: bika/lims/content/artemplate.py:173
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
-msgstr "Configureer de monsterpartities en conserveringen voor dit sjabloon. Wijs analyses toe aan de verschillende partities op het tabblad Analyses van het sjabloon"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:253
 msgid "Confirm password"
@@ -1345,7 +1345,7 @@ msgstr "Bevestig wachtwoord"
 #: bika/lims/content/instrumentmaintenancetask.py:93
 #: bika/lims/content/instrumentscheduledtask.py:86
 msgid "Considerations"
-msgstr "Overwegingen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
@@ -1354,11 +1354,11 @@ msgstr "Contact"
 
 #: bika/lims/browser/analysisrequest/add2.py:2066
 msgid "Contact does not belong to the selected client"
-msgstr "Contactpersoon behoort niet tot de geselecteerde client"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:118
 msgid "Contact is deactivated. User cannot be unlinked."
-msgstr "Contactpersoon is gedeactiveerd. Gebruiker kan niet worden ontkoppeld."
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:65
 #: senaite/core/profiles/default/types/Contacts.xml
@@ -1368,726 +1368,726 @@ msgstr "Contactpersonen"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:72
 msgid "Contained Samples"
-msgstr "Bevatte monsters"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:175
 msgid "Container"
-msgstr "Container"
+msgstr ""
 
 #: senaite/core/content/samplecontainer.py:70
 #: senaite/core/profiles/default/types/ContainerType.xml
 msgid "Container Type"
-msgstr "Containertype"
+msgstr ""
 
 #: senaite/core/profiles/default/types/ContainerTypes.xml
 msgid "Container Types"
-msgstr "Containertypen"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_containers.py:58
 msgid "Containers"
-msgstr "Containers"
+msgstr ""
 
 #: bika/lims/browser/dynamic_analysisspec.py:45
 msgid "Contents of the file {}"
-msgstr "Inhoud van het bestand {}"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:224
 msgid "Context"
-msgstr "Context"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:590
 msgid "Control"
-msgstr "Controle"
+msgstr ""
 
 #: bika/lims/config.py:89
 msgid "Control QC analyses"
-msgstr "Controle-QC-analyses"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:56
 #: bika/lims/content/analysisservice.py:222
 msgid "Control type"
-msgstr "Controletype"
+msgstr ""
 
 #: bika/lims/validators.py:441
 msgid "Control type is not supported for empty choices"
-msgstr "Controletype wordt niet ondersteund voor lege keuzes"
+msgstr ""
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:54
 msgid "Copy"
-msgstr "Kopiëren"
+msgstr ""
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:11
 msgid "Copy analysis services"
-msgstr "Analysediensten kopiëren"
+msgstr ""
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:49
 msgid "Copy from"
-msgstr "Kopiëren van"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
-msgstr "Kopieer de momenteel weergegeven kolomwaarde naar de andere kolommen rechts"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
-msgstr "Kopieer de waarde van het eerste monster naar de andere"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
-msgstr "Kopiëren naar nieuw"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:131
 msgid "Could not convert {} value(s) to integer: {}"
-msgstr "Kon {} waarde(n) niet naar een geheel getal converteren: {}"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
-msgstr "Kon de volgende monster(s) niet aanmaken vanwege transactieconflicten, probeer ze opnieuw: ${rows}"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:228
 msgid "Could not link User: ${error}"
-msgstr "Kon gebruiker niet koppelen: ${error}"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
-msgstr "Kon PDF voor monster {} niet laden"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:558
 msgid "Could not send email to {0} ({1})"
-msgstr "Kon geen e-mail verzenden naar {0} ({1})"
+msgstr ""
 
 #: bika/lims/browser/workflow/analysisrequest.py:217
 msgid "Could not transition samples to the sampled state"
-msgstr "Kon monsters niet overzetten naar de status bemonsterd"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:103
 msgid "Counter <span class=\"sort-indicator\" />"
-msgstr "Teller <span class=\"sort-indicator\" />"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
-msgstr "Tellerreferentie"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
-msgstr "Tellertype"
+msgstr ""
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:28
 #: senaite/core/z3cform/widgets/address.py:222
 msgid "Country"
-msgstr "Land"
+msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Create Invoice PDF"
-msgstr "Factuur-PDF aanmaken"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
-msgstr "Partities aanmaken"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:214
 msgid "Create SENAITE Site"
-msgstr "SENAITE-site aanmaken"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
-msgstr "Werkblad aanmaken"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:134
 msgid "Create a new SENAITE site"
-msgstr "Een nieuwe SENAITE-site aanmaken"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:215
 msgid "Create a new User"
-msgstr "Een nieuwe gebruiker aanmaken"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
-msgstr "Een nieuw werkblad aanmaken voor de geselecteerde monsters"
+msgstr ""
 
 #: senaite/core/browser/worksheets/templates/view.pt:26
 msgid "Create new worksheet"
-msgstr "Nieuw werkblad aanmaken"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Create partitions"
-msgstr "Partities aanmaken"
+msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:71
 msgid "Created"
-msgstr "Aangemaakt"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:404
 msgid "Created by"
-msgstr "Aangemaakt door"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:46
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:46
 msgid "Created on"
-msgstr "Aangemaakt op"
+msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:113
 msgid "Created {} partitions: {}"
-msgstr "{} partities aangemaakt: {}"
+msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
 #: senaite/core/browser/samples/view.py:148
 msgid "Creator"
-msgstr "Aanmaker"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:403
 #: bika/lims/content/instrumentscheduledtask.py:76
 msgid "Criteria"
-msgstr "Criteria"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:254
 msgid "Currency"
-msgstr "Valuta"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Current"
-msgstr "Huidig"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — dirty tag hover tooltip
 msgid "Current view differs from saved"
-msgstr "Huidige weergave verschilt van de opgeslagen weergave"
+msgstr ""
 
 #: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
-msgstr "Aangepast decimaalteken"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
-msgstr "DL"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:135
 msgid "Daily"
-msgstr "Dagelijks"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
-msgstr "Data-interface"
+msgstr ""
 
 #: bika/lims/content/instrument.py:291
 msgid "Data Interface Options"
-msgstr "Data-interface-opties"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/data_import.py:72
 msgid "Data import successful"
-msgstr "Data-import geslaagd"
+msgstr ""
 
 #: bika/lims/browser/batchfolder.py:76
 #: bika/lims/browser/instrument.py:661
 #: bika/lims/content/abstractbaseanalysis.py:700
 msgid "Date"
-msgstr "Datum"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:126
 msgid "Date Created"
-msgstr "Aanmaakdatum"
+msgstr ""
 
 #: bika/lims/content/referencesample.py:204
 msgid "Date Disposed"
-msgstr "Datum afgevoerd"
+msgstr ""
 
 #: bika/lims/content/referencesample.py:197
 msgid "Date Expired"
-msgstr "Vervaldatum"
+msgstr ""
 
 #: bika/lims/content/attachment.py:100
 msgid "Date Loaded"
-msgstr "Datum geladen"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:82
 #: bika/lims/controlpanel/auditlog.py:76
 msgid "Date Modified"
-msgstr "Datum gewijzigd"
+msgstr ""
 
 #: bika/lims/browser/referencesample.py:364
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:98
 msgid "Date Opened"
-msgstr "Datum geopend"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
-msgstr "Datum geconserveerd"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
-msgstr "Datum afgedrukt"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
-msgstr "Datum gepubliceerd"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
-msgstr "Datum ontvangen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
-msgstr "Datum geregistreerd"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_duplicate.py:76
 msgid "Date Requested"
-msgstr "Datum aangevraagd"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1075
 msgid "Date Sample Received"
-msgstr "Datum monster ontvangen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
-msgstr "Datum bemonsterd"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
-msgstr "Datum geverifieerd"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:79
 msgid "Date from which the instrument is under calibration"
-msgstr "Datum vanaf wanneer het instrument in kalibratie is"
+msgstr ""
 
 #: bika/lims/content/instrumentmaintenancetask.py:66
 msgid "Date from which the instrument is under maintenance"
-msgstr "Datum vanaf wanneer het instrument in onderhoud is"
+msgstr ""
 
 #: bika/lims/content/instrumentvalidation.py:61
 msgid "Date from which the instrument is under validation"
-msgstr "Datum vanaf wanneer het instrument in validatie is"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:100
 msgid "Date granted"
-msgstr "Datum verleend"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:112
 msgid "Date received"
-msgstr "Datum ontvangen"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:137
 msgid "Date until the certificate is valid"
-msgstr "Datum tot wanneer het certificaat geldig is"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:76
 #: bika/lims/content/instrumentvalidation.py:71
 msgid "Date until the instrument will not be available"
-msgstr "Datum tot wanneer het instrument niet beschikbaar is"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:101
 msgid "Date when the calibration certificate was granted"
-msgstr "Datum waarop het kalibratiecertificaat werd verleend"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:127
 msgid "Date when the certificate is valid"
-msgstr "Datum waarop het certificaat geldig is"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
-msgstr "Datum waarop het rapport werd afgedrukt"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:101
 #: bika/lims/content/abstractbaseanalysis.py:701
 msgid "Datetime"
-msgstr "Datum-tijd"
+msgstr ""
 
 #: bika/lims/browser/fields/durationfield.py:36
 msgid "Days"
-msgstr "Dagen"
+msgstr ""
 
 #: bika/lims/content/instrument.py:186
 msgid "De-activate until next calibration test"
-msgstr "Deactiveren tot de volgende kalibratietest"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_client_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
 msgid "Deactivate"
-msgstr "Deactiveren"
+msgstr ""
 
 #: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
-msgstr "Decimaalteken dat gebruikt wordt in de rapporten van deze client."
+msgstr ""
 
 #: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
-msgstr "Standaard CC-contactpersonen voor nieuwe monsters. Indien ingesteld, worden deze contactpersonen automatisch geselecteerd in het formulier voor het toevoegen van monsters."
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:165
 msgid "Default Container"
-msgstr "Standaard container"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_labcontacts.py:80
 msgid "Default Department"
-msgstr "Standaard afdeling"
+msgstr ""
 
 #: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
-msgstr "Standaard e-mailadressen om alle gepubliceerde monsters voor deze client in CC te zetten"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:414
 msgid "Default Instrument"
-msgstr "Standaard instrument"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:430
 msgid "Default Method"
-msgstr "Standaard methode"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
-msgstr "Standaard aantal kopieën"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:145
 msgid "Default Preservation"
-msgstr "Standaard conservering"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
-msgstr "Standaard stickersjabloon"
+msgstr ""
 
 #: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
-msgstr "Standaard contactpersoon voor nieuwe monsters. Indien ingesteld, wordt deze contactpersoon automatisch geselecteerd in het formulier voor het toevoegen van monsters."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
-msgstr "Standaard aantal toe te voegen monsters."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:312
 #: bika/lims/content/client.py:229
 msgid "Default decimal mark"
-msgstr "Standaard decimaalteken"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:415
 msgid "Default instrument used for analyses of this type"
-msgstr "Standaard instrument dat gebruikt wordt voor analyses van dit type"
+msgstr ""
 
 #: bika/lims/content/sampletype.py:208
 msgid "Default large sticker"
-msgstr "Standaard grote sticker"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
-msgstr "Standaard lay-out in werkbladweergave"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:431
 msgid "Default method used for analyses of this type"
-msgstr "Standaard methode die gebruikt wordt voor analyses van dit type"
+msgstr ""
 
 #: senaite/core/registry/schema.py:110
 msgid "Default printing templates order for worksheet"
-msgstr "Standaardvolgorde van afdruksjablonen voor werkblad"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:195
 msgid "Default result"
-msgstr "Standaard resultaat"
+msgstr ""
 
 #: bika/lims/validators.py:1379
 msgid "Default result is not a valid date"
-msgstr "Standaard resultaat is geen geldige datum"
+msgstr ""
 
 #: bika/lims/validators.py:1383
 msgid "Default result is not numeric"
-msgstr "Standaard resultaat is niet numeriek"
+msgstr ""
 
 #: bika/lims/validators.py:1389
 msgid "Default result must be one of the following result options: {}"
-msgstr "Standaard resultaat moet een van de volgende resultaatopties zijn: {}"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:196
 msgid "Default result to display on result entry"
-msgstr "Standaard resultaat om weer te geven bij resultaatinvoer"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
-msgstr "Standaard bewaartermijn voor monsters"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
-msgstr "Standaard wetenschappelijke notatie-indeling voor rapporten"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
-msgstr "Standaard wetenschappelijke notatie-indeling voor resultaten"
+msgstr ""
 
 #: bika/lims/content/sampletype.py:206
 msgid "Default small sticker"
-msgstr "Standaard kleine sticker"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:97
 msgid "Default timezone"
-msgstr "Standaard tijdzone"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
-msgstr "Standaard doorlooptijd voor analyses."
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:54
 #: bika/lims/content/analysisservice.py:224
 msgid "Default value"
-msgstr "Standaardwaarde"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-msgstr "Standaardwaarde van het 'Aantal monsters' wanneer gebruikers op de knop 'TOEVOEGEN' klikken om nieuwe monsters aan te maken"
+msgstr ""
 
 #: bika/lims/content/method.py:57
 msgid "Define an identifier code for the method. It must be unique."
-msgstr "Definieer een identificatiecode voor de methode. Deze moet uniek zijn."
+msgstr ""
 
 #: bika/lims/content/calculation.py:60
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
-msgstr "Definieer tussenvelden zoals vaatmassa of verdunningsfactoren, mocht uw berekening deze nodig hebben. De hier opgegeven veldtitel wordt gebruikt als kolomkop en veldbeschrijving waar de tussenvelden worden weergegeven. Als 'Breed toepassen' is ingeschakeld, wordt het veld weergegeven in een keuzevak bovenaan het werkblad, zodat een specifieke waarde op alle overeenkomstige velden op het blad kan worden toegepast."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:177
 msgid "Define the number of decimals to be used for this result."
-msgstr "Definieer het aantal decimalen dat voor dit resultaat gebruikt moet worden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:191
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
-msgstr "Definieer de precisie bij het omzetten van waarden naar exponentnotatie.  De standaardwaarde is 7."
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:494
 msgid "Define the sampler supposed to do the sample in the scheduled date"
-msgstr "Definieer de monsternemer die het monster op de geplande datum moet nemen"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
-msgstr "Definieer het sjabloon voor de e-mailtekst die automatisch wordt verstuurd naar primaire contactpersonen en laboratoriummanagers wanneer een monster ongeldig wordt verklaard. De volgende plaatshouders worden ondersteund: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
+msgstr ""
 
 #: bika/lims/content/sampletype.py:232
 msgid "Defines the stickers to use for this sample type."
-msgstr "Definieert de stickers die voor dit monstertype gebruikt moeten worden."
+msgstr ""
 
 #: bika/lims/browser/fields/coordinatefield.py:36
 msgid "Degrees"
-msgstr "Graden"
+msgstr ""
 
 #: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
-msgstr "Verwijderen"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Delete filter"
-msgstr "Filter verwijderen"
+msgstr ""
 
 #: senaite/core/api/remarks.py:484
 msgid "Delete this remark?"
-msgstr "Deze opmerking verwijderen?"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
 msgid "Department"
-msgstr "Afdeling"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:68
 msgid "Department ID"
-msgstr "Afdelings-ID"
+msgstr ""
 
 #: senaite/core/content/department.py:134
 msgid "Department ID must be unique"
-msgstr "Afdelings-ID moet uniek zijn"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:601
 #: bika/lims/content/analysiscategory.py:72
 msgid "Department Name"
-msgstr "Afdelingsnaam"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Departments.xml
 msgid "Departments"
-msgstr "Afdelingen"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:201
 msgid "Dependent Analyses"
-msgstr "Afhankelijke analyses"
+msgstr ""
 
 #: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
 #: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
-msgstr "Beschrijving"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:119
 msgid "Description of the actions made during the calibration"
-msgstr "Beschrijving van de tijdens de kalibratie uitgevoerde acties"
+msgstr ""
 
 #: bika/lims/content/instrumentmaintenancetask.py:104
 msgid "Description of the actions made during the maintenance process"
-msgstr "Beschrijving van de tijdens het onderhoudsproces uitgevoerde acties"
+msgstr ""
 
 #: bika/lims/content/instrumentvalidation.py:101
 msgid "Description of the actions made during the validation"
-msgstr "Beschrijving van de tijdens de validatie uitgevoerde acties"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:64
 msgid "Description of the location"
-msgstr "Beschrijving van de locatie"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:84
 msgid "Description of the shelf"
-msgstr "Beschrijving van de plank"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:49
 msgid "Description of the site"
-msgstr "Beschrijving van de site"
+msgstr ""
 
 msgid "Deselect all"
-msgstr "Alles deselecteren"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Detach"
-msgstr "Loskoppelen"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:105
 msgid "Detection Limit"
-msgstr "Detectielimiet"
+msgstr ""
 
 # senaite.app.listing: Disable auto fetch transitions
 msgid "Disable auto fetch transitions"
-msgstr "Automatisch ophalen van overgangen uitschakelen"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:180
 msgid "Disable multi-verification for the same user"
-msgstr "Meervoudige verificatie voor dezelfde gebruiker uitschakelen"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — Revert action tooltip
 msgid "Discard edits and restore preset"
-msgstr "Bewerkingen verwerpen en voorinstelling herstellen"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
-msgstr "Korting"
+msgstr ""
 
 #: bika/lims/content/pricelist.py:66
 msgid "Discount %"
-msgstr "Korting %"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:78
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatch"
-msgstr "Verzenden"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:15
 msgid "Dispatch samples"
-msgstr "Monsters verzenden"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
-msgstr "Verzonden"
+msgstr ""
 
 # bika.lims.bikalisting.js
 msgid "Display Columns"
-msgstr "Kolommen weergeven"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:727
 msgid "Display Value"
-msgstr "Weergavewaarde"
+msgstr ""
 
 #: bika/lims/validators.py:675
 msgid "Display Value is required"
-msgstr "Weergavewaarde is vereist"
+msgstr ""
 
 #: bika/lims/validators.py:687
 msgid "Display Value must be unique"
-msgstr "Weergavewaarde moet uniek zijn"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:316
 msgid "Display a Detection Limit selector"
-msgstr "Een detectielimietselector weergeven"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
-msgstr "Monsterpartities aan clients tonen"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
-msgstr "Afvoeren"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:15
 msgid "Dispose samples"
-msgstr "Monsters afvoeren"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
-msgstr "Afgevoerd"
+msgstr ""
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:87
 #: senaite/core/z3cform/widgets/address.py:224
 msgid "District"
-msgstr "District"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:664
 #: bika/lims/content/multifile.py:47
 msgid "Document"
-msgstr "Document"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:809
 #: bika/lims/content/multifile.py:39
 msgid "Document ID"
-msgstr "Document-ID"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:812
 #: bika/lims/content/multifile.py:63
 msgid "Document Location"
-msgstr "Documentlocatie"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:813
 #: bika/lims/content/multifile.py:73
 msgid "Document Type"
-msgstr "Documenttype"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:811
 #: bika/lims/content/multifile.py:55
 msgid "Document Version"
-msgstr "Documentversie"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Documents"
-msgstr "Documenten"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:375
 msgid "Don't override analysis results"
-msgstr "Analyseresultaten niet overschrijven"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/multi_results.pt:79
 msgid "Done"
-msgstr "Klaar"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:113
 msgid "Dot (.)"
-msgstr "Punt (.)"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:87
 msgid "Down from"
-msgstr "Omlaag vanaf"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:88
 msgid "Down to"
-msgstr "Omlaag tot"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:150
 msgid "Download"
-msgstr "Downloaden"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:80
 msgid "Download PDF"
-msgstr "PDF downloaden"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:145
 msgid "Download selected reports"
-msgstr "Geselecteerde rapporten downloaden"
+msgstr ""
 
 # senaite.app.listing: Column config — drag handle tooltip / aria-label
 msgid "Drag to reorder"
-msgstr "Sleep om te herordenen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:327
 msgid "Due"
@@ -2096,76 +2096,76 @@ msgstr "Verschuldigd"
 #: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
-msgstr "Vervaldatum"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:199
 msgid "Dup Var"
-msgstr "Dup Var"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:556
 msgid "Duplicate"
-msgstr "Dupliceren"
+msgstr ""
 
 #: bika/lims/profiles/default/types/DuplicateAnalysis.xml
 msgid "Duplicate Analysis"
-msgstr "Duplicaatanalyse"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
-msgstr "Dubbele ID-indeling voor portaltype '${pt}' (rijen ${a} en ${b}). Alleen de eerste rij wordt gebruikt; verwijder of voeg het duplicaat samen."
+msgstr ""
 
 #: bika/lims/content/worksheettemplate.py:59
 msgid "Duplicate Of"
-msgstr "Duplicaat van"
+msgstr ""
 
 #: bika/lims/config.py:90
 msgid "Duplicate QC analyses"
-msgstr "QC-analyses dupliceren"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr "Monster dupliceren"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
-msgstr "Duplicaatvariatie %"
+msgstr ""
 
 #: bika/lims/validators.py:461
 msgid "Duplicate keys in choices field"
-msgstr "Dubbele sleutels in keuzeveld"
+msgstr ""
 
 #: bika/lims/browser/workflow/analysisrequest.py:443
 msgid "Duplicated samples: {}"
-msgstr "Gedupliceerde monsters: {}"
+msgstr ""
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpec.xml
 msgid "Dynamic Analysis Specification"
-msgstr "Dynamische analysespecificatie"
+msgstr ""
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpecs.xml
 msgid "Dynamic Analysis Specifications"
-msgstr "Dynamische analysespecificaties"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:82
 msgid "Dynamic Specification"
-msgstr "Dynamische specificatie"
+msgstr ""
 
 #: bika/lims/content/laboratory.py:122
 msgid "E.g. SANAS, APLAC, etc."
-msgstr "Bijv. SANAS, APLAC, enz."
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:165
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
-msgstr "Elke import-interface kan een map definiëren waar het systeem naar de resultaatbestanden zoekt bij het automatisch importeren van resultaten wanneer de <code>auto_import_results</code>-weergave wordt aangeroepen."
+msgstr ""
 
 #: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
-msgstr "Bewerken"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/multi_results.pt:15
 msgid "Edit Multiple Analyses Results"
-msgstr "Resultaten van meerdere analyses bewerken"
+msgstr ""
 
 #: bika/lims/content/samplepoint.py:74
 msgid "Elevation"
@@ -2185,202 +2185,202 @@ msgstr "E-mailadres"
 
 #: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
-msgstr "E-mailbijlagen"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
-msgstr "E-mailtekst"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisreport_info.pt:96
 msgid "Email Log"
-msgstr "E-maillogboek"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
-msgstr "E-mailontvangers"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
-msgstr "E-mailverantwoordelijken"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
-msgstr "Verzenddatum e-mail"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
-msgstr "E-mailonderwerp"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
-msgstr "E-mailtekst voor meldingen van monsterongeldigverklaring"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
-msgstr "E-mailtekst voor meldingen van monsterafwijzing"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:158
 msgid "Email cancelled"
-msgstr "E-mail geannuleerd"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:126
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:129
 msgid "Email notification"
-msgstr "E-mailmelding"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
-msgstr "E-mailmelding bij monsterafwijzing"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
-msgstr "Logboek van verzonden e-mails"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
-msgstr "E-mail verzonden"
+msgstr ""
 
 #: bika/lims/api/snapshot.py:585
 msgid "Empty"
-msgstr "Leeg"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
-msgstr "Lege sleutels worden niet ondersteund"
+msgstr ""
 
 #: bika/lims/content/worksheettemplate.py:140
 msgid "Enable Multiple Use of Instrument in Worksheets."
-msgstr "Meervoudig gebruik van instrument in werkbladen inschakelen."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
-msgstr "Monsterconservering inschakelen"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
-msgstr "Monsterspecificaties inschakelen"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
-msgstr "Monstername inschakelen"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
-msgstr "Planning van monstername inschakelen"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
-msgstr "Globaal auditlogboek inschakelen"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
-msgstr "Globaal auditlogboek inschakelen"
+msgstr ""
 
 #: bika/lims/content/artemplate.py:119
 msgid "Enable sampling workflow for the created sample"
-msgstr "Monsternameworkflow inschakelen voor het aangemaakte monster"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
-msgstr "De workflow voor het afdrukken van resultaatrapporten inschakelen"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1000
 msgid "Enable the Sample Dispatch workflow"
-msgstr "De workflow voor monsterverzending inschakelen"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:990
 msgid "Enable the Sample Dispose workflow"
-msgstr "De workflow voor monsterafvoer inschakelen"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
-msgstr "Einddatum"
+msgstr ""
 
 #: bika/lims/content/instrumentmaintenancetask.py:165
 #: bika/lims/content/instrumentscheduledtask.py:119
 msgid "Enhancement"
-msgstr "Verbetering"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:231
 msgid "Enter a user name, usually something like 'jsmith'. No spaces or special characters. Usernames and passwords are case sensitive, make sure the caps lock key is not enabled. This is the name used to log in."
-msgstr "Voer een gebruikersnaam in, meestal iets als 'jsmith'. Geen spaties of speciale tekens. Gebruikersnamen en wachtwoorden zijn hoofdlettergevoelig; zorg ervoor dat Caps Lock niet is ingeschakeld. Dit is de naam die wordt gebruikt om aan te melden."
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:268
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
-msgstr "Voer een e-mailadres in. Dit is nodig voor het geval het wachtwoord verloren gaat. Wij respecteren uw privacy en geven het adres niet door aan derden en maken het nergens openbaar."
+msgstr ""
 
 #: bika/lims/content/pricelist.py:67
 msgid "Enter discount percentage value"
-msgstr "Voer de kortingspercentagewaarde in"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
-msgstr "Voer voor dit veld individuele waarden per monster in"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:576
 #: bika/lims/content/labproduct.py:48
 msgid "Enter percentage value eg. 14.0"
-msgstr "Voer de percentagewaarde in, bijv. 14.0"
+msgstr ""
 
 #: bika/lims/content/analysisprofile.py:123
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
-msgstr "Voer de percentagewaarde in, bijv. 14.0. Dit percentage wordt alleen op het analyseprofiel toegepast en overschrijft de systeem-btw"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
-msgstr "Voer de percentagewaarde in, bijv. 14.0. Dit percentage wordt systeembreed toegepast, maar kan op individuele items worden overschreven"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1120
 msgid "Enter percentage value eg. 33.0"
-msgstr "Voer de percentagewaarde in, bijv. 33.0"
+msgstr ""
 
 #: bika/lims/content/samplepoint.py:57
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
-msgstr "Voer de breedtegraad van het monsterpunt in graden 0-90, minuten 0-59, seconden 0-59 en N/Z-indicator in"
+msgstr ""
 
 #: bika/lims/content/samplepoint.py:66
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
-msgstr "Voer de lengtegraad van het monsterpunt in graden 0-180, minuten 0-59, seconden 0-59 en O/W-indicator in"
+msgstr ""
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:18
 msgid "Enter the details of each of the analysis services you want to copy."
-msgstr "Voer de gegevens in van elke analysedienst die u wilt kopiëren."
+msgstr ""
 
 #: bika/lims/content/laboratory.py:176
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
-msgstr "Voer hier de gegevens van de dienstaccreditaties van uw lab in. De volgende velden zijn beschikbaar:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
-msgstr "Voer het resultaat in decimale of wetenschappelijke notatie in, bijv. 0.00005 of 1e-5, 10000 of 1e5"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:939
 msgid "Environmental conditions"
-msgstr "Omgevingscondities"
+msgstr ""
 
 #: senaite/core/browser/samples/invalidate_samples.py:282
 msgid "Erroneous result publication: ${sample_id}"
-msgstr "Foutieve resultaatpublicatie: ${sample_id}"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
-msgstr "Evolutie van analyses"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
-msgstr "Evolutie van monsters"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
-msgstr "Evolutie van werkbladen"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:172
 msgid "Example Cronjob to execute the auto import every 10 minutes"
-msgstr "Voorbeeld-cronjob om de automatische import elke 10 minuten uit te voeren"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:125
 msgid "Example content"
-msgstr "Voorbeeldinhoud"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
@@ -2394,15 +2394,15 @@ msgstr "Verwachte resultaat"
 
 #: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
-msgstr "Verwachte monsternamedatum"
+msgstr ""
 
 #: bika/lims/content/referencesample.py:214
 msgid "Expected Values"
-msgstr "Verwachte waarden"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Expire"
-msgstr "Verlopen"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Expired"
@@ -2416,27 +2416,27 @@ msgstr "Vervaldatum"
 
 #: bika/lims/content/abstractbaseanalysis.py:190
 msgid "Exponential format precision"
-msgstr "Precisie van exponentiële notatie"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
-msgstr "Drempel van exponentiële notatie"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Export"
-msgstr "Exporteren"
+msgstr ""
 
 #: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
-msgstr "Kon sticker niet laden"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:150
 msgid "Failed to send Email(s)"
-msgstr "Kon e-mail(s) niet verzenden"
+msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:101
 msgid "Failed to update registry records. Please check the server log for details."
-msgstr "Kon registerrecords niet bijwerken. Raadpleeg het serverlogboek voor details."
+msgstr ""
 
 #: bika/lims/browser/clientfolder.py:86
 #: bika/lims/content/organisation.py:66
@@ -2446,7 +2446,7 @@ msgstr "Fax"
 
 #: bika/lims/content/person.py:118
 msgid "Fax (business)"
-msgstr "Fax (zakelijk)"
+msgstr ""
 
 #: bika/lims/config.py:77
 msgid "Female"
@@ -2454,7 +2454,7 @@ msgstr "Vrouw"
 
 # senaite.app.listing: Fetch transitions
 msgid "Fetch Transitions"
-msgstr "Overgangen ophalen"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:191
 msgid "Field"
@@ -2462,7 +2462,7 @@ msgstr "Veld"
 
 #: bika/lims/browser/analysisrequest/add2.py:2122
 msgid "Field '{}' is required"
-msgstr "Veld '{}' is vereist"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/multi_results.pt:125
 #: senaite/core/browser/viewlets/sampleanalyses.py:69
@@ -2471,11 +2471,11 @@ msgstr "Veld Analyses"
 
 #: senaite/core/registry/schema.py:214
 msgid "Field Name"
-msgstr "Veldnaam"
+msgstr ""
 
 #: bika/lims/config.py:56
 msgid "Field Preservation"
-msgstr "Veldconservering"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:53
 msgid "Field Title"
@@ -2483,11 +2483,11 @@ msgstr "Veld Titel"
 
 #: bika/lims/browser/analysisrequest/add2.py:1460
 msgid "Field flushed"
-msgstr "Veld leeggemaakt"
+msgstr ""
 
 #: senaite/core/registry/schema.py:212
 msgid "Field visibility"
-msgstr "Veldzichtbaarheid"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:814
 msgid "File"
@@ -2495,55 +2495,55 @@ msgstr "Bestand"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:194
 msgid "File Deleted"
-msgstr "Bestand verwijderd"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:262
 msgid "File upload"
-msgstr "Bestand uploaden"
+msgstr ""
 
 #: bika/lims/content/multifile.py:48
 msgid "File upload "
-msgstr "Bestand uploaden "
+msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:59
 msgid "Filename"
-msgstr "Bestandsnaam"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:82
 msgid "Filesize"
-msgstr "Bestandsgrootte"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
-msgstr "Analyses op naam filteren..."
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:190
 msgid "Filter by template method"
-msgstr "Filteren op sjabloonmethode"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:175
 msgid "Filter by template services"
-msgstr "Filteren op sjabloondiensten"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
-msgstr "Sleutels filteren (regex ondersteund)"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — inline editor placeholder
 msgid "Filter name"
-msgstr "Filternaam"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:601
 msgid "Filter samples by this analysis"
-msgstr "Monsters op deze analyse filteren"
+msgstr ""
 
 # senaite.app.listing: Column-filter row — text-input placeholder
 msgid "Filter..."
-msgstr "Filteren..."
+msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
-msgstr "Het eerste blad bevat geen geldige kolomdefinitie"
+msgstr ""
 
 #: bika/lims/content/person.py:51
 msgid "Firstname"
@@ -2553,15 +2553,15 @@ msgstr "Voornaam"
 #: bika/lims/content/analysiscategory.py:83
 #: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
-msgstr "Kommagetal van 0.0 - 1000.0 dat de sorteervolgorde aangeeft. Dubbele waarden worden alfabetisch geordend."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:212
 msgid "Format"
-msgstr "Indeling"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
-msgstr "Opmaakconfiguratie"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:183
 #: bika/lims/controlpanel/bika_calculations.py:79
@@ -2570,21 +2570,21 @@ msgstr "Formule"
 
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:239
 msgid "Found Dynamic Analysis Specification for '{}' in '{}'"
-msgstr "Dynamische analysespecificatie gevonden voor '{}' in '{}'"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:160
 msgid "Friday"
-msgstr "Vrijdag"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:47
 #: bika/lims/content/instrumentcalibration.py:78
 #: bika/lims/content/instrumentmaintenancetask.py:65
 msgid "From"
-msgstr "Van"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:134
 msgid "From ${from} to ${to} (updated every 2 hours)"
-msgstr "Van ${from} tot ${to} (elke 2 uur bijgewerkt)"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
@@ -2594,95 +2594,95 @@ msgstr "Volledige naam"
 
 #: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
-msgstr "Volledige naam"
+msgstr ""
 
 #: bika/lims/content/calculation.py:100
 msgid "Function"
-msgstr "Functie"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
-msgstr "Monster met datum in de toekomst"
+msgstr ""
 
 #: senaite/core/browser/dexterity/views.py:206
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:27
 msgid "General"
-msgstr "Algemeen"
+msgstr ""
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Generates an ID with the IDServer"
-msgstr "Genereert een ID met de IDServer"
+msgstr ""
 
 #: senaite/core/registry/schema.py:226
 msgid "Generic Setup"
-msgstr "Generieke instellingen"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:11
 msgid "Global Audit Log is disabled"
-msgstr "Globaal auditlogboek is uitgeschakeld"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Contacts.xml
 msgid "Global contacts container"
-msgstr "Globale contactpersonencontainer"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:44
 msgid "Go to your instance"
-msgstr "Ga naar uw instantie"
+msgstr ""
 
 #: bika/lims/content/person.py:43
 msgid "Greeting title eg. Mr, Mrs, Dr"
-msgstr "Aanhef, bijv. Dhr., Mevr., Dr."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
-msgstr "Groepeer analysediensten per categorie in de LIMS-tabellen, handig wanneer de lijst lang is"
+msgstr ""
 
 #: bika/lims/content/arreport.py:134
 msgid "HTML"
-msgstr "HTML"
+msgstr ""
 
 #: bika/lims/content/referencesample.py:105
 #: bika/lims/content/sampletype.py:127
 msgid "Hazardous"
-msgstr "Gevaarlijk"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
 #: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
-msgstr "Verborgen"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:60
 msgid "Hidden Field"
-msgstr "Verborgen veld"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:114
 msgid "Hidden from report"
-msgstr "Verborgen in rapport"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
-msgstr "Aanvullende velden verbergen"
+msgstr ""
 
 # senaite.app.listing: Column config — bulk action button
 msgid "Hide all"
-msgstr "Alles verbergen"
+msgstr ""
 
 #: senaite/core/api/remarks.py:487
 msgid "Hide history"
-msgstr "Geschiedenis verbergen"
+msgstr ""
 
 # senaite.app.listing: Column config — eye-slash button tooltip / aria-label
 msgid "Hide this column"
-msgstr "Deze kolom verbergen"
+msgstr ""
 
 #: bika/lims/config.py:140
 msgid "High"
-msgstr "Hoog"
+msgstr ""
 
 #: bika/lims/config.py:139
 msgid "Highest"
-msgstr "Hoogst"
+msgstr ""
 
 #: bika/lims/browser/fields/durationfield.py:37
 msgid "Hours"
@@ -2690,7 +2690,7 @@ msgstr "Uur"
 
 #: bika/lims/content/supplier.py:75
 msgid "IBN"
-msgstr "IBN"
+msgstr ""
 
 #: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_view.pt:43
@@ -2699,474 +2699,474 @@ msgstr "ID"
 
 #: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
-msgstr "ID-server"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:17
 msgid "ID Server Settings"
-msgstr "ID-serverinstellingen"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
-msgstr "ID-serverwaarden"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:113
 msgid "ID Template <span class=\"sort-indicator\" />"
-msgstr "ID-sjabloon <span class=\"sort-indicator\" />"
+msgstr ""
 
 #: bika/lims/content/samplepoint.py:84
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
-msgstr "Als er periodiek een monster wordt genomen op dit monsterpunt, voer hier de frequentie in, bijv. wekelijks"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:317
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
-msgstr "Indien aangevinkt, wordt er een keuzelijst weergegeven naast het resultaatveld van de analyse in de resultaatinvoerweergaven. Met deze selector kan de analist de waarde instellen als detectielimiet (LDL of UDL) in plaats van een gewoon resultaat"
+msgstr ""
 
 #: bika/lims/content/instrument.py:187
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
-msgstr "Indien aangevinkt, is het instrument niet beschikbaar totdat de volgende geldige kalibratie is uitgevoerd. Dit selectievakje wordt automatisch uitgevinkt."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
-msgstr "Indien ingeschakeld, wordt er een vrijetekstveld weergegeven bij elke analyse in de resultaatinvoerweergave"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
-msgstr "Indien ingeschakeld, kan een gebruiker die een resultaat voor deze analyse heeft ingediend het ook verifiëren. Deze instelling geldt voor gebruikers met een toegewezen rol waarmee zij resultaten mogen verifiëren (standaard managers, labmanagers en verifiëerders). De hier ingestelde optie heeft voorrang op de optie die is ingesteld in Bika Setup"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-msgstr "Indien ingeschakeld, kan een gebruiker die een resultaat heeft ingediend het ook verifiëren. Deze instelling geldt alleen voor gebruikers met een toegewezen rol waarmee zij resultaten mogen verifiëren (standaard managers, labmanagers en verifiëerders). Deze instelling kan voor een bepaalde analyse worden overschreven in de bewerkweergave van de analysedienst. Standaard uitgeschakeld."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:96
 msgid "If enabled, the name of the analysis will be written in italics."
-msgstr "Indien ingeschakeld, wordt de naam van de analyse cursief weergegeven."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
-msgstr "Indien ingeschakeld, worden deze analyse en de resultaten ervan standaard niet weergegeven in rapporten. Deze instelling kan worden overschreven in het analyseprofiel en/of monster"
+msgstr ""
 
 #: bika/lims/content/batch.py:138
 msgid "If no Title value is entered, the Batch ID will be used."
-msgstr "Als er geen titelwaarde wordt ingevoerd, wordt de batch-ID gebruikt."
+msgstr ""
 
 #: bika/lims/content/batch.py:134
 msgid "If no value is entered, the Batch ID will be auto-generated."
-msgstr "Als er geen waarde wordt ingevoerd, wordt de batch-ID automatisch gegenereerd."
+msgstr ""
 
 #: bika/lims/content/method.py:128
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
-msgstr "Selecteer indien nodig een berekening voor de analysediensten die aan deze methode zijn gekoppeld. Berekeningen kunnen worden geconfigureerd onder het item berekeningen in de LIMS-instellingen"
+msgstr ""
 
 #: senaite/core/content/interpretationtemplate.py:72
 msgid "If set, this interpretation template will only be available for selection on samples from these types"
-msgstr "Indien ingesteld, is dit interpretatiesjabloon alleen selecteerbaar voor monsters van deze types"
+msgstr ""
 
 #: senaite/core/content/interpretationtemplate.py:60
 msgid "If set, this interpretation template will only be available for selection on samples that have assigned any of these analysis templates"
-msgstr "Indien ingesteld, is dit interpretatiesjabloon alleen selecteerbaar voor monsters waaraan een van deze analysesjablonen is toegewezen"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:69
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
-msgstr "Als hier tekst wordt ingevoerd, wordt deze in plaats van de titel gebruikt wanneer de dienst in kolomkoppen wordt vermeld. HTML-opmaak is toegestaan."
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:74
 msgid "If the system doesn't find any match (Sample, Reference Analysis or Duplicate), it will use the record's identifier to find matches for Reference Sample IDs. <br /> If a Reference Sample ID is found, the system will automatically create a Calibration Test (Reference Analysis) and will link it to the selected Instrument."
-msgstr "Als het systeem geen overeenkomst vindt (monster, referentieanalyse of duplicaat), gebruikt het de identificatie van het record om overeenkomsten voor referentiemonster-ID's te vinden. <br /> Als er een referentiemonster-ID wordt gevonden, maakt het systeem automatisch een kalibratietest (referentieanalyse) aan en koppelt het deze aan het geselecteerde instrument."
+msgstr ""
 
 #: bika/lims/content/worksheettemplate.py:141
 msgid "If unchecked, Lab Managers won't be able to assign the same Instrument more than one Analyses while creating a Worksheet."
-msgstr "Indien niet aangevinkt, kunnen labmanagers hetzelfde instrument niet aan meer dan één analyse toewijzen bij het aanmaken van een werkblad."
+msgstr ""
 
 #: bika/lims/content/calculation.py:112
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
-msgstr "Als uw formule een speciale functie uit een externe Python-bibliotheek nodig heeft, kunt u die hier importeren. Bijvoorbeeld als u de functie 'floor' uit de Python-module 'math' wilt gebruiken, voegt u 'math' toe aan het veld Module en 'floor' aan het functieveld. Het equivalent in Python zou 'from math import floor' zijn. In uw berekening zou u dan 'floor([Ca] + [Mg])' kunnen gebruiken. "
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
-msgstr "Directe invoer van resultaten"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:14
 #: senaite/core/profiles/default/actions.xml
 msgid "Import"
-msgstr "Importeren"
+msgstr ""
 
 #: bika/lims/content/instrument.py:235
 msgid "Import Data Interface"
-msgstr "Data-interface voor import"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:548
 msgid "Import finished successfully: {updated_ars} Samples and {updated_results} results updated"
-msgstr "Import succesvol voltooid: {updated_ars} Monsters en {updated_results} resultaten bijgewerkt"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:541
 msgid "Import finished successfully: {updated_ars} Samples, {updated_instruments} Instruments and {updated_results} results updated"
-msgstr "Import succesvol voltooid: {updated_ars} Monsters, {updated_instruments} Instrumenten en {updated_results} resultaten bijgewerkt"
+msgstr ""
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:59
 msgid "Imported File"
-msgstr "Geïmporteerd bestand"
+msgstr ""
 
 #: bika/lims/content/instrument.py:200
 msgid "In-lab calibration procedure"
-msgstr "Kalibratieprocedure in het lab"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
 #: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
-msgstr "Inactief"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
-msgstr "Prijsinformatie opnemen en weergeven"
+msgstr ""
 
 #: bika/lims/content/pricelist.py:75
 msgid "Include descriptions"
-msgstr "Beschrijvingen opnemen"
+msgstr ""
 
 #: senaite/core/content/supplier.py:170
 msgid "Incorrect IBAN number: %s"
-msgstr "Onjuist IBAN-nummer: %s"
+msgstr ""
 
 #: senaite/core/content/supplier.py:132
 msgid "Incorrect NIB number: %s"
-msgstr "Onjuist NIB-nummer: %s"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1404
 msgid "Indicates if the last SampleReport is printed,"
-msgstr "Geeft aan of het laatste SampleReport is afgedrukt,"
+msgstr ""
 
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:22
 msgid "Info"
-msgstr "Info"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Initialize"
-msgstr "Initialiseren"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:13
 msgid "Install SENAITE LIMS"
-msgstr "SENAITE LIMS installeren"
+msgstr ""
 
 #: bika/lims/content/instrument.py:356
 msgid "Installation Certificate"
-msgstr "Installatiecertificaat"
+msgstr ""
 
 #: bika/lims/content/instrument.py:357
 msgid "Installation certificate upload"
-msgstr "Installatiecertificaat uploaden"
+msgstr ""
 
 #: bika/lims/content/instrument.py:347
 msgid "InstallationDate"
-msgstr "InstallationDate"
+msgstr ""
 
 #: bika/lims/content/method.py:77
 msgid "Instructions"
-msgstr "Instructies"
+msgstr ""
 
 #: bika/lims/content/instrument.py:201
 msgid "Instructions for in-lab regular calibration routines intended for analysts"
-msgstr "Instructies voor reguliere kalibratieroutines in het lab, bedoeld voor analisten"
+msgstr ""
 
 #: bika/lims/content/instrument.py:213
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
-msgstr "Instructies voor reguliere preventieve en onderhoudsroutines, bedoeld voor analisten"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:78
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:107
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:64
 msgid "Instrument"
-msgstr "Instrument"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/method.py:74
 msgid "Instrument '{}' is used by service '{}'"
-msgstr "Instrument '{}' wordt gebruikt door dienst '{}'"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:193
 msgid "Instrument Calibrations"
-msgstr "Instrumentkalibraties"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:791
 msgid "Instrument Files"
-msgstr "Instrumentbestanden"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:37
 msgid "Instrument Import"
-msgstr "Instrumentimport"
+msgstr ""
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 msgid "Instrument Location"
-msgstr "Instrumentlocatie"
+msgstr ""
 
 #: senaite/core/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
-msgstr "Instrumentlocaties"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:65
 msgid "Instrument Maintenance"
-msgstr "Instrumentonderhoud"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:382
 msgid "Instrument Scheduled Tasks"
-msgstr "Geplande instrumenttaken"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:290
 msgid "Instrument Validations"
-msgstr "Instrumentvalidaties"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:392
 msgid "Instrument assignment is allowed"
-msgstr "Instrumenttoewijzing is toegestaan"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:35
 msgid "Instrument disabled until successful calibration:"
-msgstr "Instrument uitgeschakeld tot succesvolle kalibratie:"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:54
 msgid "Instrument disposed until new calibration tests being done:"
-msgstr "Instrument afgevoerd tot nieuwe kalibratietests zijn uitgevoerd:"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/export.py:53
 msgid "Instrument exporter not found"
-msgstr "Instrumentexporteur niet gevonden"
+msgstr ""
 
 #: bika/lims/browser/workflow/analysis.py:141
 msgid "Instrument failed reference test"
-msgstr "Instrument is niet geslaagd voor referentietest"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/export.py:40
 msgid "Instrument has no data interface selected"
-msgstr "Voor het instrument is geen data-interface geselecteerd"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/data_import.py:96
 msgid "Instrument import finished"
-msgstr "Instrumentimport voltooid"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:92
 msgid "Instrument in calibration progress:"
-msgstr "Instrument in kalibratieproces:"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:73
 msgid "Instrument in validation progress:"
-msgstr "Instrument in validatieproces:"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:402
 msgid "Instrument not found"
-msgstr "Instrument niet gevonden"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:16
 msgid "Instrument's calibration certificate expired:"
-msgstr "Kalibratiecertificaat van instrument verlopen:"
+msgstr ""
 
 #: senaite/core/profiles/default/types/InstrumentType.xml
 msgid "InstrumentType"
-msgstr "InstrumentType"
+msgstr ""
 
 #: senaite/core/profiles/default/types/InstrumentTypes.xml
 msgid "InstrumentTypes"
-msgstr "InstrumentTypes"
+msgstr ""
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 #: senaite/core/profiles/default/types/InstrumentType.xml
 #: senaite/core/profiles/default/types/Manufacturer.xml
 msgid "Instruments"
-msgstr "Instrumenten"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:162
 msgid "Instruments can be configured with one or multiple import data interfaces."
-msgstr "Instrumenten kunnen worden geconfigureerd met één of meerdere data-interfaces voor import."
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:39
 msgid "Instruments disabled until successful calibration:"
-msgstr "Instrumenten uitgeschakeld tot succesvolle kalibratie:"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:58
 msgid "Instruments disposed until new calibration tests being done:"
-msgstr "Instrumenten afgevoerd tot nieuwe kalibratietests zijn uitgevoerd:"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:96
 msgid "Instruments in calibration progress:"
-msgstr "Instrumenten in kalibratieproces:"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:77
 msgid "Instruments in validation progress:"
-msgstr "Instrumenten in validatieproces:"
+msgstr ""
 
 #: bika/lims/content/method.py:103
 msgid "Instruments supporting this method"
-msgstr "Instrumenten die deze methode ondersteunen"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:20
 msgid "Instruments' calibration certificates expired:"
-msgstr "Kalibratiecertificaten van instrumenten verlopen:"
+msgstr ""
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:55
 msgid "Interface"
-msgstr "Interface"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:494
 msgid "Internal Calibration Tests"
-msgstr "Interne kalibratietests"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:84
 msgid "Internal Certificate"
-msgstr "Intern certificaat"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
 #: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
-msgstr "Intern gebruik"
+msgstr ""
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:42
 #: bika/lims/browser/templates/referencesample_analyses.pt:40
 msgid "Interpolation"
-msgstr "Interpolatie"
+msgstr ""
 
 #: senaite/core/profiles/default/types/InterpretationTemplate.xml
 msgid "Interpretation Template"
-msgstr "Interpretatiesjabloon"
+msgstr ""
 
 #: senaite/core/profiles/default/types/InterpretationTemplates.xml
 msgid "Interpretation Templates"
-msgstr "Interpretatiesjablonen"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:110
 msgid "Interval"
-msgstr "Interval"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:168
 #: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
-msgstr "Ongeldig"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
-msgstr "Ongeldig ID-formaat op rij ${i} ('${pt}'): ${err}"
+msgstr ""
 
 #: senaite/core/content/person.py:236
 msgid "Invalid email address"
-msgstr "Ongeldig e-mailadres"
+msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:65
 msgid "Invalid specifications file detected. Please upload an Excel spreadsheet with at least the following columns defined: '{}', "
-msgstr "Ongeldig specificatiebestand gedetecteerd. Upload een Excel-spreadsheet waarin ten minste de volgende kolommen zijn gedefinieerd: '{}', "
+msgstr ""
 
 #: bika/lims/validators.py:1324
 msgid "Invalid value: Please enter a value without spaces."
-msgstr "Ongeldige waarde: Voer een waarde zonder spaties in."
+msgstr ""
 
 #: bika/lims/validators.py:528
 msgid "Invalid wildcards found: ${wildcards}"
-msgstr "Ongeldige jokertekens gevonden: ${wildcards}"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:152
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalidate"
-msgstr "Ongeldig maken"
+msgstr ""
 
 #: bika/lims/browser/workflow/analysisrequest.py:162
 msgid "Invalidated items: {}"
-msgstr "Ongeldig gemaakte items: {}"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:90
 msgid "Invalidation reason"
-msgstr "Reden voor ongeldigverklaring"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:18
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 #: bika/lims/profiles/default/types/Invoice.xml
 msgid "Invoice"
-msgstr "Factuur"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:55
 msgid "Invoice Date"
-msgstr "Factuurdatum"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:973
 msgid "Invoice Exclude"
-msgstr "Uitsluiten van facturatie"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:44
 msgid "Invoice ID"
-msgstr "Factuur-ID"
+msgstr ""
 
 #: bika/lims/content/invoice.py:41
 msgid "Invoice PDF"
-msgstr "Factuur-PDF"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:35
 msgid "Invoice To"
-msgstr "Factureren aan"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/invoice.py:187
 msgid "Invoice {} created"
-msgstr "Factuur {} aangemaakt"
+msgstr ""
 
 #: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
-msgstr "InvoiceBatch heeft geen einddatum"
+msgstr ""
 
 #: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
-msgstr "InvoiceBatch heeft geen startdatum"
+msgstr ""
 
 #: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
-msgstr "InvoiceBatch heeft geen titel"
+msgstr ""
 
 #: senaite/core/config/widgets.py:60
 msgid "Job Title"
-msgstr "Functietitel"
+msgstr ""
 
 #: bika/lims/content/person.py:141
 msgid "Job title"
-msgstr "Functietitel"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
-msgstr "Volgorde hierboven behouden"
+msgstr ""
 
 #: bika/lims/content/instrument.py:287
 msgid "Key"
-msgstr "Sleutel"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:98
 msgid "Key <span class=\"sort-indicator\" />"
-msgstr "Sleutel <span class=\"sort-indicator\" />"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
 msgid "Keyword"
-msgstr "Sleutelwoord"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:51
 msgid "Keyword is used in active analyses and can not be changed anymore"
-msgstr "Sleutelwoord wordt gebruikt in actieve analyses en kan niet meer worden gewijzigd"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:187
 msgid "Keyword required"
-msgstr "Sleutelwoord vereist"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
-msgstr "Sleutelwoorden"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:249
 msgid "Keywords of the analyses contained in the sample"
-msgstr "Sleutelwoorden van de analyses in het monster"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
 #: bika/lims/content/analysisspec.py:142
 msgid "Lab"
-msgstr "Lab"
+msgstr ""
 
 #: bika/lims/content/supplier.py:98
 msgid "Lab Account Number"
-msgstr "Lab-rekeningnummer"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/multi_results.pt:134
 msgid "Lab Analyses"
@@ -3174,7 +3174,7 @@ msgstr "Lab Analyses"
 
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
-msgstr "Labcontact"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_labcontacts.py:65
 #: bika/lims/profiles/default/types/LabContacts.xml
@@ -3187,11 +3187,11 @@ msgstr "Lab afdelingen"
 
 #: bika/lims/config.py:57
 msgid "Lab Preservation"
-msgstr "Labconservering"
+msgstr ""
 
 #: senaite/core/profiles/default/types/LabProduct.xml
 msgid "Lab Product"
-msgstr "Labproduct"
+msgstr ""
 
 #: senaite/core/profiles/default/types/LabProducts.xml
 msgid "Lab Products"
@@ -3205,29 +3205,29 @@ msgstr "Lab URL"
 #: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
-msgstr "Label"
+msgstr ""
 
 #: senaite/core/registry/schema.py:69
 msgid "Label configuration"
-msgstr "Labelconfiguratie"
+msgstr ""
 
 #: senaite/core/content/label.py:93
 msgid "Label names must be unique"
-msgstr "Labelnamen moeten uniek zijn"
+msgstr ""
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Label schema extender"
-msgstr "Labelschema-uitbreider"
+msgstr ""
 
 #: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
-msgstr "Gelabelde objecten"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/labels/view.py:52
 #: senaite/core/browser/label/labeled_objects.py:66
 #: senaite/core/browser/samples/view.py:875
 msgid "Labels"
-msgstr "Labels"
+msgstr ""
 
 #: senaite/core/content/laboratory.py:244
 #: senaite/core/profiles/default/types/Laboratory.xml
@@ -3240,27 +3240,27 @@ msgstr "Geaccrediteerd laboratorium"
 
 #: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
-msgstr "Werkdagen laboratorium"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:74
 msgid "Language"
-msgstr "Taal"
+msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Large Sticker"
-msgstr "Grote sticker"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
-msgstr "Sjabloon grote sticker"
+msgstr ""
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:42
 msgid "Last Auto-Import Logs"
-msgstr "Logboeken laatste automatische import"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:97
 msgid "Last Login Time"
-msgstr "Tijdstip laatste aanmelding"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:469
 msgid "Late"
@@ -3280,106 +3280,106 @@ msgstr "Latitude"
 
 #: senaite/core/schema/gpscoordinatesfield.py:103
 msgid "Latitude must be within -90 and 90 degrees"
-msgstr "Breedtegraad moet tussen -90 en 90 graden liggen"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:104
 msgid "Layout"
-msgstr "Lay-out"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/results.py:68
 msgid "Layout view '{}' not found. Set '{}' as layout view."
-msgstr "Lay-outweergave '{}' niet gevonden. Stel '{}' in als lay-outweergave."
+msgstr ""
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:63
 msgid "Legacy LIMS Setup"
-msgstr "Verouderde LIMS-instellingen"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:153
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:120
 msgid "Legend: Results in <em>italic</em> font are pending, results in <strong>bold</strong> font are verified."
-msgstr "Legenda: Resultaten in <em>cursief</em> zijn in behandeling, resultaten in <strong>vet</strong> zijn geverifieerd."
+msgstr ""
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:46
 #: bika/lims/browser/templates/referencesample_analyses.pt:44
 msgid "Linear"
-msgstr "Lineair"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:203
 msgid "Link User"
-msgstr "Gebruiker koppelen"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:144
 msgid "Link an existing User"
-msgstr "Een bestaande gebruiker koppelen"
+msgstr ""
 
 #: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
-msgstr "Alle objecten met labels weergeven"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
-msgstr "Lijst van mogelijke eindresultaten. Indien ingesteld, is geen aangepast resultaat toegestaan bij de resultaatinvoer en moet de gebruiker uit deze waarden kiezen"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
-msgstr "Lijst van vooraf gedefinieerde afwijzingsredenen. Voer één reden per regel in."
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:47
 msgid "Load Setup Data"
-msgstr "Instellingsgegevens laden"
+msgstr ""
 
 #: bika/lims/content/method.py:89
 msgid "Load documents describing the method here"
-msgstr "Laad hier documenten die de methode beschrijven"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:121
 msgid "Load from file"
-msgstr "Laden uit bestand"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:195
 msgid "Load the certificate document here"
-msgstr "Laad hier het certificaatdocument"
+msgstr ""
 
 # senaite.core: Sidebar loading state
 msgid "Loading navigation..."
-msgstr "Navigatie laden..."
+msgstr ""
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
-msgstr "Laden..."
+msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:79
 #: senaite/core/browser/controlpanel/contacts/view.py:70
 msgid "Location"
-msgstr "Locatie"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:58
 msgid "Location Code"
-msgstr "Locatiecode"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:63
 msgid "Location Description"
-msgstr "Locatiebeschrijving"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:53
 msgid "Location Title"
-msgstr "Locatietitel"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:68
 msgid "Location Type"
-msgstr "Locatietype"
+msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
-msgstr "Locatie waar de documentenset is opgeborgen"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Lock"
-msgstr "Vergrendelen"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Locked"
-msgstr "Vergrendeld"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3396,7 +3396,7 @@ msgstr "Lengtegraad"
 
 #: senaite/core/schema/gpscoordinatesfield.py:110
 msgid "Longitude must be within -180 and 180 degrees"
-msgstr "Lengtegraad moet tussen -180 en 180 graden liggen"
+msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:62
@@ -3406,11 +3406,11 @@ msgstr "Lotnummer"
 
 #: bika/lims/config.py:142
 msgid "Low"
-msgstr "Laag"
+msgstr ""
 
 #: bika/lims/config.py:143
 msgid "Lowest"
-msgstr "Laagste"
+msgstr ""
 
 #: bika/lims/config.py:82
 msgid "Mailing address"
@@ -3419,20 +3419,20 @@ msgstr "Mailing adres"
 #: bika/lims/browser/instrument.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:83
 msgid "Maintainer"
-msgstr "Beheerder"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Maintenance"
-msgstr "Onderhoud"
+msgstr ""
 
 #. Default: "Type"
 #: bika/lims/content/instrumentmaintenancetask.py:55
 msgid "Maintenance type"
-msgstr "Type"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:349
 msgid "Make attachments mandatory for verification"
-msgstr "Bijlagen verplicht maken voor verificatie"
+msgstr ""
 
 #: bika/lims/config.py:76
 msgid "Male"
@@ -3441,43 +3441,43 @@ msgstr "Mannetje"
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:14
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Manage Analyses"
-msgstr "Analyses beheren"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
-msgstr "Formuliervelden beheren"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:12
 msgid "Manage Number Generator"
-msgstr "Nummergenerator beheren"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:21
 msgid "Manage Partitions"
-msgstr "Partities beheren"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Manage Results"
-msgstr "Resultaten beheren"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:10
 msgid "Manage Sample Form Fields"
-msgstr "Monsterformuliervelden beheren"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:41
 msgid "Manage linked User"
-msgstr "Gekoppelde gebruiker beheren"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
-msgstr "Monstervelden beheren"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:38
 msgid "Manage the order and visibility of the fields displayed in analysis request add forms."
-msgstr "Beheer de volgorde en zichtbaarheid van de velden die worden weergegeven in de toevoegformulieren voor analyseaanvragen."
+msgstr ""
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:16
 msgid "Manage the order and visibility of the sample fields."
-msgstr "Beheer de volgorde en zichtbaarheid van de monstervelden."
+msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:75
 msgid "Manager"
@@ -3493,20 +3493,20 @@ msgstr "Manager telefoon"
 
 #: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
-msgstr "Handmatig"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:378
 #: bika/lims/content/method.py:148
 msgid "Manual entry of results"
-msgstr "Handmatige invoer van resultaten"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:161
 msgid "Manually publish all contained samples of the selected reports."
-msgstr "Publiceer handmatig alle monsters in de geselecteerde rapporten."
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:192
 msgid "Manually trigger auto import"
-msgstr "Automatische import handmatig starten"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Manufacturer.xml
 msgid "Manufacturer"
@@ -3514,11 +3514,11 @@ msgstr "Fabrikant"
 
 #: senaite/core/profiles/default/types/Manufacturers.xml
 msgid "Manufacturers"
-msgstr "Fabrikanten"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1417
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
-msgstr "Markeer het monster als uitsluitend voor intern gebruik. Dit betekent dat het alleen toegankelijk is voor labpersoneel en niet voor klanten."
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
@@ -3533,25 +3533,25 @@ msgstr "Max tijd"
 #: bika/lims/browser/fields/resultrangefield.py:36
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:121
 msgid "Max operator"
-msgstr "Max-operator"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
-msgstr "Max-waarschuwing"
+msgstr ""
 
 #: senaite/core/content/samplecontainer.py:79
 msgid "Maximum possible size or volume of samples"
-msgstr "Maximaal mogelijke grootte of volume van monsters"
+msgstr ""
 
 #: bika/lims/content/container.py:75
 msgid "Maximum possible size or volume of samples."
-msgstr "Maximaal mogelijke grootte of volume van monsters."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:443
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
-msgstr "Maximaal toegestane tijd voor het voltooien van de analyse. Er wordt een waarschuwing voor een te late analyse gegeven wanneer deze periode verstrijkt"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:442
 msgid "Maximum turn-around time"
@@ -3559,15 +3559,15 @@ msgstr "Maximale turn-around tijd"
 
 #: bika/lims/config.py:141
 msgid "Medium"
-msgstr "Gemiddeld"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:153
 msgid "Meet the community, browse the code and get support on"
-msgstr "Ontmoet de community, bekijk de code en krijg ondersteuning op"
+msgstr ""
 
 #: bika/lims/browser/clientfolder.py:94
 msgid "Member Discount"
-msgstr "Ledenkorting"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
 #: bika/lims/content/bikasetup.py:282
@@ -3580,15 +3580,15 @@ msgstr "Lid korting geldt"
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
-msgstr "Lid geregistreerd en gekoppeld aan het huidige contact."
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:146
 msgid "Message sent to {}, "
-msgstr "Bericht verzonden naar {}, "
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
-msgstr "Metadata"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:69
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:103
@@ -3601,3674 +3601,3671 @@ msgstr "Methode Document"
 
 #: bika/lims/content/method.py:56
 msgid "Method ID"
-msgstr "Methode-ID"
+msgstr ""
 
 #: bika/lims/browser/methodfolder.py:48
 #: bika/lims/browser/templates/analysisservice_info.pt:119
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:80
 msgid "Methods"
-msgstr "Methoden"
+msgstr ""
 
 #: bika/lims/content/person.py:59
 msgid "Middle initial"
-msgstr "Tweede voorletter"
+msgstr ""
 
 #: bika/lims/content/person.py:67
 msgid "Middle name"
-msgstr "Tweede naam"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
-msgstr "Min"
+msgstr ""
 
 #: bika/lims/browser/fields/resultrangefield.py:34
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:106
 msgid "Min operator"
-msgstr "Min-operator"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
-msgstr "Min-waarschuwing"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/folder.py:183
 msgid "Mine"
-msgstr "Van mij"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:245
 msgid "Minimum 5 characters."
-msgstr "Minimaal 5 tekens."
+msgstr ""
 
 #: bika/lims/content/sampletype.py:165
 msgid "Minimum Volume"
-msgstr "Minimumvolume"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
-msgstr "Minimumaantal resultaten voor QC-statistiekberekeningen"
+msgstr ""
 
 #: bika/lims/browser/fields/coordinatefield.py:37
 #: bika/lims/browser/fields/durationfield.py:38
 msgid "Minutes"
-msgstr "Minuten"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_labcontacts.py:92
 msgid "Mobile Phone"
-msgstr "Mobiele telefoon"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:80
 #: senaite/core/browser/controlpanel/contacts/view.py:68
 msgid "MobilePhone"
-msgstr "MobilePhone"
+msgstr ""
 
 #: bika/lims/content/instrument.py:137
 #: bika/lims/controlpanel/bika_instruments.py:84
 msgid "Model"
-msgstr "Model"
+msgstr ""
 
 #: bika/lims/content/calculation.py:100
 msgid "Module"
-msgstr "Module"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:156
 msgid "Monday"
-msgstr "Maandag"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:137
 msgid "Monthly"
-msgstr "Maandelijks"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
-msgstr "Meer dan één analyse gevonden voor {sid} en sleutelwoord '{keyword}'"
+msgstr ""
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Multi Catalog Behavior for Dexterity Contents"
-msgstr "Multi-catalogusgedrag voor Dexterity-inhoud"
+msgstr ""
 
 #: senaite/core/browser/samples/multi_results_transposed.py:66
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Multi Results"
-msgstr "Meerdere resultaten"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
-msgstr "Type multi-verificatie"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
-msgstr "Multi-verificatie vereist"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "Multifile"
-msgstr "Meerdere bestanden"
+msgstr ""
 
 #: senaite/core/config/vocabularies.py:60
 msgid "Multiple choices"
-msgstr "Meerdere keuzes"
+msgstr ""
 
 #: senaite/core/config/vocabularies.py:58
 msgid "Multiple selection"
-msgstr "Meervoudige selectie"
+msgstr ""
 
 #: senaite/core/config/vocabularies.py:59
 msgid "Multiple selection (with duplicates)"
-msgstr "Meervoudige selectie (met duplicaten)"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:108
 msgid "Multiple values"
-msgstr "Meerdere waarden"
+msgstr ""
 
 #: bika/lims/validators.py:469
 msgid "Multiple values control type is not supported for choices"
-msgstr "Het besturingstype met meerdere waarden wordt niet ondersteund voor keuzes"
+msgstr ""
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Organization"
-msgstr "Mijn organisatie"
+msgstr ""
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Profile"
-msgstr "Mijn profiel"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — default name when saving
 msgid "My filter"
-msgstr "Mijn filter"
+msgstr ""
 
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
-msgstr "NIB"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
 #: senaite/core/content/contact.py:146
 msgid "Name"
-msgstr "Naam"
+msgstr ""
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:67
 msgid "New LIMS Setup"
-msgstr "Nieuwe LIMS-instellingen"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
-msgstr "Nieuwe bereiken worden noch op nieuwe noch op huidige analyses toegepast. Wijs de specificatie opnieuw toe als u de laatste wijzigingen wilt toepassen."
+msgstr ""
 
 #: senaite/core/api/remarks.py:490
 msgid "Newest first"
-msgstr "Nieuwste eerst"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
-msgstr "Volgende ID <span class=\"sort-indicator\" />"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:168
 #: senaite/core/browser/widgets/services_widget.py:305
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:9
 msgid "No"
-msgstr "Nee"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/eltra/cs/cs2000.py:51
 msgid "No Analysis Services defined"
-msgstr "Geen analysediensten gedefinieerd"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:70
 msgid "No Email Address"
-msgstr "Geen e-mailadres"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:43
 msgid "No Method selected for this Service"
-msgstr "Geen methode geselecteerd voor deze dienst"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:415
 msgid "No Sample found for {sid}"
-msgstr "Geen monster gevonden voor {sid}"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:403
 msgid "No Sample with '{allowed_ar_states}' statesfound, and no QC analyses found for {sid}, "
-msgstr "Geen monster met status '{allowed_ar_states}' gevonden, en geen QC-analyses gevonden voor {sid}, "
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2189
 msgid "No Samples could be created."
-msgstr "Er konden geen monsters worden aangemaakt."
+msgstr ""
 
 #: bika/lims/browser/batch/batchbook.py:175
 msgid "No Subgroup"
-msgstr "Geen subgroep"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
-msgstr "Geen actie gedefinieerd."
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:131
 msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
-msgstr "Geen acties beschikbaar. Neem contact op met uw laboratoriummanager om rechten toegewezen te krijgen."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
-msgstr "Geen analyses gevonden voor {sid} en sleutelwoord '{keyword}'"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:434
 msgid "No analyses found for {sid} in the states '{allowed_sample_states}' , "
-msgstr "Geen analyses gevonden voor {sid} in de statussen '{allowed_sample_states}' , "
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:75
 msgid "No analyses were added"
-msgstr "Er zijn geen analyses toegevoegd"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:152
 msgid "No analyses were added to this worksheet."
-msgstr "Er zijn geen analyses aan dit werkblad toegevoegd."
+msgstr ""
 
 #: senaite/core/browser/attachment/attachment.py:219
 msgid "No analysis found for service '{}'"
-msgstr "Geen analyse gevonden voor dienst '{}'"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/biodrop/ulite/ulite.py:53
 #: senaite/core/exportimport/instruments/lifetechnologies/qubit/qubit.py:54
 msgid "No analysis selected"
-msgstr "Geen analyse geselecteerd"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/thermoscientific/multiskan/go.py:51
 msgid "No analysis service selected"
-msgstr "Geen analysedienst geselecteerd"
+msgstr ""
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:27
 msgid "No analysis services were selected."
-msgstr "Er zijn geen analysediensten geselecteerd."
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:135
 msgid "No changes"
-msgstr "Geen wijzigingen"
+msgstr ""
 
 #: senaite/core/browser/workflow/worksheet.py:50
 msgid "No changes made"
-msgstr "Geen wijzigingen aangebracht"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:166
 #: bika/lims/browser/workflow/analysisrequest.py:94
 msgid "No changes made."
-msgstr "Geen wijzigingen aangebracht."
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:130
 msgid "No data for the selected period"
-msgstr "Geen gegevens voor de geselecteerde periode"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
-msgstr "Geen datum ingesteld"
+msgstr ""
 
 #: bika/lims/browser/workflow/analysisrequest.py:435
 msgid "No duplicate created"
-msgstr "Geen duplicaat aangemaakt"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:135
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:138
 msgid "No email recipients available for this sample"
-msgstr "Geen e-mailontvangers beschikbaar voor dit monster"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:167
 msgid "No email recipients selected"
-msgstr "Geen e-mailontvangers geselecteerd"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:47
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:59
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:47
 msgid "No file selected"
-msgstr "Geen bestand geselecteerd"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/data_import.py:81
 msgid "No importer not found for interface '{}'"
-msgstr "Geen importeur gevonden voor interface '{}'"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/data_import.py:126
 msgid "No instrument import interfaces available for {}"
-msgstr "Geen instrumentimportinterfaces beschikbaar voor {}"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:120
 msgid "No items published"
-msgstr "Geen items gepubliceerd"
+msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:64
 #: senaite/core/browser/samples/rejection/reject_samples.py:78
 msgid "No items selected"
-msgstr "Geen items geselecteerd"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:129
 msgid "No items selected."
-msgstr "Geen items geselecteerd."
+msgstr ""
 
 # senaite.app.listing: Column config — empty state for hidden section with
 # search
 msgid "No matches in hidden columns."
-msgstr "Geen overeenkomsten in verborgen kolommen."
+msgstr ""
 
 # senaite.app.listing: Column config — empty state for visible section with
 # search
 msgid "No matches in visible columns."
-msgstr "Geen overeenkomsten in zichtbare kolommen."
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
-msgstr "Er zijn geen nieuwe items aangemaakt."
+msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
-msgstr "Er zijn geen partities aangemaakt"
+msgstr ""
 
 #: senaite/core/api/remarks.py:493
 msgid "No remarks yet"
-msgstr "Nog geen opmerkingen"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
-msgstr "Geen rapporten gevonden"
+msgstr ""
 
 #: senaite/core/browser/samples/invalidate_samples.py:110
 msgid "No samples were invalidated. Please ensure samples are selected and meet the criteria for invalidation."
-msgstr "Er zijn geen monsters ongeldig gemaakt. Zorg ervoor dat er monsters zijn geselecteerd die aan de criteria voor ongeldigverklaring voldoen."
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:112
 msgid "No samples were rejected"
-msgstr "Er zijn geen monsters afgewezen"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
-msgstr "Geen monsternameworkflow"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — empty state
 msgid "No saved filters yet."
-msgstr "Nog geen opgeslagen filters."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
-msgstr "Er konden geen diensten worden gevonden voor de verwerkte sleutelwoorden"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:133
 msgid "No user exists for ${contact_fullname} and they will not be able to log in. Fill in the form below to create one for them."
-msgstr "Er bestaat geen gebruiker voor ${contact_fullname} en deze zal niet kunnen aanmelden. Vul het onderstaande formulier in om er een voor hen aan te maken."
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:49
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
-msgstr "Er kon geen gebruikersprofiel worden gevonden voor de gekoppelde gebruiker. Neem contact op met de labbeheerder voor verdere ondersteuning of probeer de gebruiker opnieuw te koppelen."
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2057
 msgid "No valid contact"
-msgstr "Geen geldig contact"
+msgstr ""
 
 #: bika/lims/validators.py:448
 msgid "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
-msgstr "Geen geldig formaat in het keuzeveld. Ondersteund formaat is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/multi_results.pt:115
 msgid "No visible analyses for this sample"
-msgstr "Geen zichtbare analyses voor dit monster"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
 #: senaite/core/content/senaitesetup.py:1141
 msgid "None"
-msgstr "Geen"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:216
 msgid "Not all contacts are equal for the selected Reports. Please manually select recipients for this email."
-msgstr "Niet alle contacten zijn gelijk voor de geselecteerde rapporten. Selecteer de ontvangers voor deze e-mail handmatig."
+msgstr ""
 
 #: senaite/core/browser/modals/conditions.py:133
 msgid "Not allowed to update conditions: {}"
-msgstr "Niet toegestaan om voorwaarden bij te werken: {}"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:86
 msgid "Not defined"
-msgstr "Niet gedefinieerd"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
-msgstr "Niet afgedrukt"
+msgstr ""
 
 #: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
-msgstr "Niet ingesteld"
+msgstr ""
 
 #: bika/lims/content/worksheet.py:291
 msgid "Not specified"
-msgstr "Niet gespecificeerd"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:42
 msgid "Note: The settings apply to all Sample Add forms; Required fields can not be deselected."
-msgstr "Let op: De instellingen gelden voor alle formulieren voor het toevoegen van monsters; Verplichte velden kunnen niet worden gedeselecteerd."
+msgstr ""
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:19
 msgid "Note: The settings are global and apply to all sample views."
-msgstr "Let op: De instellingen zijn globaal en gelden voor alle monsterweergaven."
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:168
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
-msgstr "Let op: U kunt de bijlagerijen ook slepen en neerzetten om de volgorde waarin ze in het rapport verschijnen te wijzigen."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
-msgstr "Meldingen"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:126
 msgid "Num columns"
-msgstr "Aantal kolommen"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:259
 msgid "Number"
-msgstr "Nummer"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
-msgstr "Aantal analyses"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:82
 msgid "Number of Partitions to create"
-msgstr "Aantal aan te maken partities"
+msgstr ""
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:39
 msgid "Number of copies"
-msgstr "Aantal exemplaren"
+msgstr ""
 
 #: senaite/core/registry/schema.py:180
 msgid "Number of prominent columns"
-msgstr "Aantal prominente kolommen"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:839
 #: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
-msgstr "Aantal vereiste verificaties"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-msgstr "Aantal vereiste verificaties voordat een bepaald resultaat als 'geverifieerd' wordt beschouwd. Deze instelling kan voor elke analyse worden overschreven in de bewerkingsweergave van de analysedienst. Standaard 1"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
-msgstr "Aantal vereiste verificaties van verschillende gebruikers met voldoende rechten voordat een bepaald resultaat voor deze analyse als 'geverifieerd' wordt beschouwd. De hier ingestelde optie heeft voorrang op de optie die in Bika Setup is ingesteld"
+msgstr ""
 
 #: senaite/core/registry/schema.py:189
 msgid "Number of standard columns"
-msgstr "Aantal standaardkolommen"
+msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
-msgstr "Numeriek"
+msgstr ""
 
 #: senaite/core/api/remarks.py:491
 msgid "Oldest first"
-msgstr "Oudste eerst"
+msgstr ""
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
-msgstr "Na conservering moet het monster binnen deze periode worden afgevoerd. Indien niet gespecificeerd, wordt de bewaartermijn van het monstertype gebruikt."
+msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:51
 msgid "Only Excel files supported"
-msgstr "Alleen Excel-bestanden worden ondersteund"
+msgstr ""
 
 #: bika/lims/content/attachment.py:81
 msgid "Only images can be rendered in the report directly"
-msgstr "Alleen afbeeldingen kunnen direct in het rapport worden weergegeven"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:95
 msgid "Only instruments that have an import interface configured are displayed"
-msgstr "Alleen instrumenten waarvoor een importinterface is geconfigureerd, worden weergegeven"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
-msgstr "Alleen werkdagen van het laboratorium worden meegenomen bij de berekening van de doorlooptijd van de analyse."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
-msgstr "Alleen werkdagen van het laboratorium worden meegenomen bij de berekening van de doorlooptijd van de analyse. "
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:216
 msgid "Only to empty or zero fields"
-msgstr "Alleen op lege of nulvelden"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
-msgstr "Openen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
-msgstr "Open / Te verifiëren / Geverifieerd / Totaal"
+msgstr ""
 
 #: bika/lims/profiles.zcml:15
 msgid "Open Source Web based Laboratory Information Management System"
-msgstr "Open source webgebaseerd laboratoriuminformatiemanagementsysteem"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:97
 msgid "Open Worksheets"
-msgstr "Open werkbladen"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
-msgstr "Open het e-mailformulier om de geselecteerde rapporten naar de ontvangers te verzenden. Hiermee worden ook de in de rapporten opgenomen monsters gepubliceerd nadat de e-mail succesvol is verzonden."
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:522
 msgid "Open worksheets with analyses awaiting results"
-msgstr "Open werkbladen met analyses die op resultaten wachten"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
-msgstr "Volgorde"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:93
 msgid "Organization responsible of granting the calibration certificate"
-msgstr "Organisatie die verantwoordelijk is voor het verlenen van het kalibratiecertificaat"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisreport_info.pt:51
 msgid "Orientation"
-msgstr "Oriëntatie"
+msgstr ""
 
 #: senaite/core/z3cform/widgets/address.py:124
 msgid "Other address"
-msgstr "Ander adres"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:100
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:70
 msgid "Other reasons"
-msgstr "Andere redenen"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:22
 msgid "Other reasons:"
-msgstr "Andere redenen:"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
-msgstr "Andere status"
+msgstr ""
 
 #: senaite/core/browser/widgets/selectotherwidget.py:114
 #: senaite/core/z3cform/widgets/selectother/widget.py:138
 msgid "Other..."
-msgstr "Andere..."
+msgstr ""
 
 #: bika/lims/browser/instrument.py:733
 #: bika/lims/controlpanel/bika_instruments.py:170
 msgid "Out of date"
-msgstr "Verouderd"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:377
 msgid "Override non-empty analysis results"
-msgstr "Niet-lege analyseresultaten overschrijven"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:379
 msgid "Override non-empty analysis results, also with empty"
-msgstr "Niet-lege analyseresultaten overschrijven, ook met lege"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:198
 msgid "PDF"
-msgstr "PDF"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
-msgstr "PDF-bestand van het rapport"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisreport_info.pt:42
 msgid "Paperformat"
-msgstr "Papierformaat"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:130
 msgid "Partition"
-msgstr "Partitie"
+msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:120
 msgid "Partitioning canceled"
-msgstr "Partitionering geannuleerd"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:242
 msgid "Password"
-msgstr "Wachtwoord"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:50
 msgid "Path identifier"
-msgstr "Padidentificatie"
+msgstr ""
 
 #: bika/lims/browser/fields/referenceresultsfield.py:36
 #: bika/lims/browser/referencesample.py:228
 #: bika/lims/browser/widgets/referenceresultswidget.py:71
 msgid "Permitted Error %"
-msgstr "Toegestane fout %"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:23
 msgid "Persistent counters used by the ID Server. Adjust a counter to change the next ID that will be issued for the matching prefix. Setting a counter to 0 removes the entry from the storage."
-msgstr "Persistente tellers die door de ID-server worden gebruikt. Pas een teller aan om de volgende ID te wijzigen die voor de overeenkomende prefix wordt uitgegeven. Een teller op 0 zetten verwijdert de vermelding uit de opslag."
+msgstr ""
 
 #: bika/lims/browser/clientfolder.py:81
 #: bika/lims/browser/templates/batch_publish.pt:68
 #: bika/lims/content/organisation.py:59
 msgid "Phone"
-msgstr "Telefoon"
+msgstr ""
 
 #: bika/lims/content/person.py:110
 msgid "Phone (business)"
-msgstr "Telefoon (zakelijk)"
+msgstr ""
 
 #: bika/lims/content/person.py:126
 msgid "Phone (home)"
-msgstr "Telefoon (thuis)"
+msgstr ""
 
 #: bika/lims/content/person.py:134
 msgid "Phone (mobile)"
-msgstr "Telefoon (mobiel)"
+msgstr ""
 
 #: bika/lims/content/instrument.py:338
 msgid "Photo image file"
-msgstr "Foto-afbeeldingsbestand"
+msgstr ""
 
 #: bika/lims/content/instrument.py:339
 msgid "Photo of the instrument"
-msgstr "Foto van het instrument"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:87
 #: senaite/core/z3cform/widgets/address.py:120
 msgid "Physical address"
-msgstr "Fysiek adres"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:170
 msgid "Please add an email subject"
-msgstr "Voeg een e-mailonderwerp toe"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:173
 msgid "Please add an email text"
-msgstr "Voeg een e-mailtekst toe"
+msgstr ""
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:11
 msgid "Please check that the sample has been physically collected and the value for \"Sampled Date\" field has been set in accordance."
-msgstr "Controleer of het monster fysiek is verzameld en of de waarde voor het veld \"Monsternamedatum\" hierop is afgestemd."
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:165
 msgid "Please click the update button after your changes."
-msgstr "Klik op de bijwerkknop na uw wijzigingen."
+msgstr ""
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:11
 msgid "Please find attached the analysis result(s) for ${client_name}"
-msgstr "In de bijlage vindt u het analyseresultaat/de analyseresultaten voor ${client_name}"
+msgstr ""
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:44
 msgid "Please follow the link to the retest ${retest_id}."
-msgstr "Volg de link naar de hertest ${retest_id}."
+msgstr ""
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:95
 msgid "Please provide a comment explaining the reason for invalidating the sample. If the email notification option is selected, the sample contact will be informed, and this comment will be included in the email content."
-msgstr "Geef een opmerking met de reden voor het ongeldig verklaren van het monster. Als de optie voor e-mailmelding is geselecteerd, wordt het contact van het monster geïnformeerd en wordt deze opmerking in de e-mailinhoud opgenomen."
+msgstr ""
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:109
 msgid "Please provide the reason for invalidating the sample."
-msgstr "Geef de reden op voor het ongeldig verklaren van het monster."
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
-msgstr "Selecteer een gebruiker uit de lijst"
+msgstr ""
 
 #: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
-msgstr "Selecteer een stickersjabloon"
+msgstr ""
 
 #: senaite/core/browser/attachment/attachment.py:224
 msgid "Please select an analysis or service for the attachment"
-msgstr "Selecteer een analyse of dienst voor de bijlage"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:111
 msgid "Please select number of partitions to create and press the preview button"
-msgstr "Selecteer het aantal aan te maken partities en klik op de voorbeeldknop"
+msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
 #: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
-msgstr "Geef een reden op"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:183
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
-msgstr "Geef hier de conserveringen op die afwijken van de standaardconservering van de analysedienst per monstertype."
+msgstr ""
 
 #: bika/lims/content/laboratory.py:163
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
-msgstr "Upload het logo dat u van uw accreditatie-instantie op uw website en resultaatrapporten mag gebruiken. Maximale grootte is 175 x 175 pixels."
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:229
 msgid "Please use the following format for select options: key1:value1|key2:value2|...|keyN:valueN"
-msgstr "Gebruik het volgende formaat voor keuzeopties: key1:value1|key2:value2|...|keyN:valueN"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:71
 msgid "Please write a comment where the listed sample(s) are dispatched"
-msgstr "Schrijf een opmerking waar de vermelde monster(s) naartoe worden verzonden"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:73
 msgid "Please write a comment where the listed sample(s) are disposed"
-msgstr "Schrijf een opmerking waar de vermelde monster(s) worden afgevoerd"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
-msgstr "Verzamelpunt"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
-msgstr "Portaaltype"
+msgstr ""
 
 #: bika/lims/content/identifiertype.py:39
 msgid "Portal Types"
-msgstr "Portaaltypes"
+msgstr ""
 
 #: senaite/core/browser/samples/multi_results_transposed.py:97
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:75
 #: senaite/core/browser/worksheets/worksheet/analyses_transposed_listing.py:89
 msgid "Position"
-msgstr "Positie"
+msgstr ""
 
 #: senaite/core/z3cform/widgets/address.py:121
 msgid "Postal address"
-msgstr "Postadres"
+msgstr ""
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:125
 #: senaite/core/z3cform/widgets/address.py:226
 msgid "Postal code"
-msgstr "Postcode"
+msgstr ""
 
 #: senaite/core/content/samplecontainer.py:85
 msgid "Pre-preserved"
-msgstr "Voorgeconserveerd"
+msgstr ""
 
 #: senaite/core/content/samplecontainer.py:100
 msgid "Pre-preserved containers must have a preservation selected"
-msgstr "Voorgeconserveerde containers moeten een conservering geselecteerd hebben"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:176
 msgid "Precision as number of decimals"
-msgstr "Precisie als aantal decimalen"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:664
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
-msgstr "Precisie als het aantal significante cijfers volgens de onzekerheid. De decimale positie wordt bepaald door het eerste cijfer dat verschilt van nul in de onzekerheid; op die positie rondt het systeem de onzekerheid en resultaten af. Bij een resultaat van 5.243 en een onzekerheid van 0.22 toont het systeem bijvoorbeeld correct 5.2+-0.2. Als er geen onzekerheidsbereik voor het resultaat is ingesteld, gebruikt het systeem de ingestelde vaste precisie."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
-msgstr "Voorgedefinieerde resultaten"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
-msgstr "Voorkeursdecimaalteken voor rapporten."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
-msgstr "Voorkeursdecimaalteken voor resultaten"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-msgstr "Voorkeursindeling van de resultaatinvoertabel in de werkbladweergave. De klassieke indeling toont de monsters in rijen en de analyses in kolommen. De getransponeerde indeling toont de monsters in kolommen en de analyses in rijen."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
-msgstr "Voorkeursformaat voor wetenschappelijke notatie voor rapporten"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
-msgstr "Voorkeursformaat voor wetenschappelijke notatie voor resultaten"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
-msgstr "Prefix"
+msgstr ""
 
 #: bika/lims/content/sampletype.py:157
 msgid "Prefixes can not contain spaces."
-msgstr "Prefixen mogen geen spaties bevatten."
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Prepublish"
-msgstr "Voorpubliceren"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:195
 #: senaite/core/content/samplecontainer.py:114
 msgid "Preservation"
-msgstr "Conservering"
+msgstr ""
 
 #: bika/lims/content/preservation.py:45
 msgid "Preservation Category"
-msgstr "Conserveringscategorie"
+msgstr ""
 
 #: senaite/core/content/samplecontainer.py:117
 msgid "Preservation method of this container"
-msgstr "Conserveringsmethode van deze container"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:182
 msgid "Preservation per sample type"
-msgstr "Conservering per monstertype"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Preserve"
-msgstr "Conserveren"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
-msgstr "Conserveerder"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/toolbar.pt:44
 msgid "Press Ctrl+Space to trigger the Spotlight search"
-msgstr "Druk op Ctrl+Space om de Spotlight-zoekopdracht te starten"
+msgstr ""
 
 #: bika/lims/content/instrumentmaintenancetask.py:163
 #: bika/lims/content/instrumentscheduledtask.py:120
 msgid "Preventive"
-msgstr "Preventief"
+msgstr ""
 
 #: bika/lims/content/instrument.py:212
 msgid "Preventive maintenance procedure"
-msgstr "Preventieve onderhoudsprocedure"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
-msgstr "Voorbeeld"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
-msgstr "Prijs"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:551
 #: bika/lims/content/analysisprofile.py:112
 msgid "Price (excluding VAT)"
-msgstr "Prijs (exclusief btw)"
+msgstr ""
 
 #: bika/lims/content/labproduct.py:54
 msgid "Price excluding VAT"
-msgstr "Prijs exclusief btw"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Pricelist.xml
 msgid "Pricelist"
-msgstr "Prijslijst"
+msgstr ""
 
 #: bika/lims/content/pricelist.py:51
 msgid "Pricelist for"
-msgstr "Prijslijst voor"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:51
 #: bika/lims/profiles/default/types/PricelistFolder.xml
 msgid "Pricelists"
-msgstr "Prijslijsten"
+msgstr ""
 
 #: bika/lims/content/client.py:98
 msgid "Primary Contact"
-msgstr "Primair contact"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:73
 #: bika/lims/browser/templates/analysisreport_info.pt:60
 msgid "Primary Sample"
-msgstr "Primair monster"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
-msgstr "Afdrukken"
+msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Print Invoice"
-msgstr "Factuur afdrukken"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:135
 msgid "Print Worksheet"
-msgstr "Werkblad afdrukken"
+msgstr ""
 
 #: bika/lims/browser/templates/batch_publish.pt:124
 msgid "Print date:"
-msgstr "Afdrukdatum:"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Pricelist.xml
 msgid "Print pricelist"
-msgstr "Prijslijst afdrukken"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
-msgstr "Stickers afdrukken"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:259
 msgid "Printed"
-msgstr "Afgedrukt"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:53
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:53
 msgid "Printed on"
-msgstr "Afgedrukt op"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:925
 msgid "Priority"
-msgstr "Prioriteit"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:238
 msgid "Profile"
-msgstr "Profiel"
+msgstr ""
 
 #: bika/lims/content/analysisprofile.py:64
 msgid "Profile Analyses"
-msgstr "Profielanalyses"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:432
 msgid "Profile Key"
-msgstr "Profielsleutel"
+msgstr ""
 
 #: bika/lims/content/analysisprofile.py:51
 msgid "Profile Keyword"
-msgstr "Profielsleutelwoord"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:431
 msgid "Profile Name"
-msgstr "Profielnaam"
+msgstr ""
 
 #: senaite/core/content/analysisprofile.py:216
 msgid "Profile keyword must be unique"
-msgstr "Profielsleutelwoord moet uniek zijn"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:134
 msgid "Progress"
-msgstr "Voortgang"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:103
 #: senaite/core/registry/schema.py:198
 msgid "Prominent fields"
-msgstr "Prominente velden"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
-msgstr "Protocol-ID"
+msgstr ""
 
 #: bika/lims/browser/clientfolder.py:75
 msgid "Province"
-msgstr "Provincie"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
-msgstr "Publicatiemodi"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Publish"
-msgstr "Publiceren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:112
 msgid "Publish Reports"
-msgstr "Rapporten publiceren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:150
 #: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
-msgstr "Gepubliceerd"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:86
 msgid "Published By"
-msgstr "Gepubliceerd door"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:84
 msgid "Published Date"
-msgstr "Publicatiedatum"
+msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
-msgstr "Gepubliceerde resultaten"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:448
 msgid "Published samples whose reports have not been printed yet"
-msgstr "Gepubliceerde monsters waarvan de rapporten nog niet zijn afgedrukt"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
-msgstr "Gepubliceerd {}, "
+msgstr ""
 
 #: senaite/core/browser/viewlets/sampleanalyses.py:76
 msgid "QC Analyses"
-msgstr "QC-analyses"
+msgstr ""
 
 #: bika/lims/browser/referencesample.py:143
 msgid "QC Analysis ID"
-msgstr "QC-analyse-ID"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "QC Results"
-msgstr "QC-resultaten"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
-msgstr "QC-monster-ID"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:138
 msgid "Quarterly"
-msgstr "Per kwartaal"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:128
 msgid "Quick Actions"
-msgstr "Snelle acties"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
-msgstr "Bereik max"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:620
 msgid "Range min"
-msgstr "Bereik min"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:18
 msgid "Ranges for some analyses are different from the Specification"
-msgstr "Bereiken voor sommige analyses verschillen van de specificatie"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:29
 msgid "Re-assign the Specification if you want to restore analysis ranges."
-msgstr "Wijs de specificatie opnieuw toe als u de analysebereiken wilt herstellen."
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:256
 msgid "Re-enter the password. Make sure the passwords are identical."
-msgstr "Voer het wachtwoord opnieuw in. Zorg ervoor dat de wachtwoorden identiek zijn."
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:145
 msgid "Reasons for rejection"
-msgstr "Redenen voor afwijzing"
+msgstr ""
 
 #: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
-msgstr "Opnieuw toewijzen"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:445
 msgid "Reassignable Slot"
-msgstr "Opnieuw toewijsbaar slot"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr "Opnieuw koppelen"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
-msgstr "Herberekenen"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
-msgstr "Ontvangen"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
 #: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
-msgstr "Ontvangen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:420
 msgid "Received samples with analyses awaiting results"
-msgstr "Ontvangen monsters met analyses die op resultaten wachten"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
-msgstr "Ontvangst in behandeling"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
-msgstr "Ontvanger"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
-msgstr "Ontvangers"
+msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
 #: bika/lims/content/worksheettemplate.py:57
 msgid "Reference"
-msgstr "Referentie"
+msgstr ""
 
 #: bika/lims/browser/referencesample.py:83
 msgid "Reference Analyses"
-msgstr "Referentieanalyses"
+msgstr ""
 
 #: bika/lims/profiles/default/types/ReferenceAnalysis.xml
 msgid "Reference Analysis"
-msgstr "Referentieanalyse"
+msgstr ""
 
 #: bika/lims/browser/referencesample.py:353
 #: bika/lims/browser/templates/referencesample_view.pt:67
 #: bika/lims/profiles/default/types/ReferenceDefinition.xml
 msgid "Reference Definition"
-msgstr "Referentiedefinitie"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_referencedefinitions.py:63
 #: bika/lims/profiles/default/types/ReferenceDefinitions.xml
 msgid "Reference Definitions"
-msgstr "Referentiedefinities"
+msgstr ""
 
 #: bika/lims/content/referencesample.py:64
 msgid "Reference ID"
-msgstr "Referentie-ID"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:558
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:12
 #: bika/lims/browser/worksheet/views/referencesamples.py:72
 msgid "Reference Sample"
-msgstr "Referentiemonster"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Reference Samples"
-msgstr "Referentiemonsters"
+msgstr ""
 
 #: bika/lims/browser/referencesample.py:202
 #: bika/lims/profiles/default/types/ReferenceSample.xml
 msgid "Reference Values"
-msgstr "Referentiewaarden"
+msgstr ""
 
 #: bika/lims/content/referencesample.py:98
 msgid "Reference sample values are zero or 'blank'"
-msgstr "Referentiemonsterwaarden zijn nul of 'blanco'"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
-msgstr "Registreren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:105
 msgid "Register Samples"
-msgstr "Monsters registreren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
-msgstr "Geregistreerd"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_cancellable_type_workflow/definition.xml
 msgid "Reinstate"
-msgstr "Herstellen"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:149
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reject"
-msgstr "Afwijzen"
+msgstr ""
 
 #: bika/lims/profiles/default/types/RejectAnalysis.xml
 msgid "Reject Analysis"
-msgstr "Analyse afwijzen"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:17
 msgid "Reject samples"
-msgstr "Monsters afwijzen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
 #: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
-msgstr "Afgewezen"
+msgstr ""
 
 #: bika/lims/browser/workflow/analysisrequest.py:98
 msgid "Rejected items: {}"
-msgstr "Afgewezen items: {}"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:13
 msgid "Rejected sample"
-msgstr "Afgewezen monster"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:114
 msgid "Rejected {} samples: {}"
-msgstr "{} monsters afgewezen: {}"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
-msgstr "Afwijzingsredenen"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:121
 msgid "Rejection cancelled"
-msgstr "Afwijzing geannuleerd"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:84
 msgid "Rejection reasons"
-msgstr "Afwijzingsredenen"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:70
 msgid "Rejection workflow is not enabled"
-msgstr "Afwijzingsworkflow is niet ingeschakeld"
+msgstr ""
 
 # senaite.app.listing: Reload
 msgid "Reload"
-msgstr "Opnieuw laden"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:122
 #: senaite/core/browser/viewlets/remarks.py:31
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:242
 msgid "Remarks"
-msgstr "Opmerkingen"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1103
 msgid "Remarks and comments for this request"
-msgstr "Opmerkingen en commentaar voor deze aanvraag"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:672
 msgid "Remarks of {}"
-msgstr "Opmerkingen van {}"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:108
 msgid "Remarks to take into account before calibration"
-msgstr "Opmerkingen om rekening mee te houden vóór kalibratie"
+msgstr ""
 
 #: bika/lims/content/instrumentscheduledtask.py:87
 msgid "Remarks to take into account before performing the task"
-msgstr "Opmerkingen om rekening mee te houden voordat de taak wordt uitgevoerd"
+msgstr ""
 
 #: bika/lims/content/instrumentvalidation.py:90
 msgid "Remarks to take into account before validation"
-msgstr "Opmerkingen om rekening mee te houden vóór validatie"
+msgstr ""
 
 #: bika/lims/content/instrumentmaintenancetask.py:94
 msgid "Remarks to take into account for maintenance process"
-msgstr "Opmerkingen om rekening mee te houden voor het onderhoudsproces"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:90
 #: bika/lims/controlpanel/auditlog.py:92
 msgid "Remote IP"
-msgstr "Extern IP"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:72
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Remove"
-msgstr "Verwijderen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:597
 msgid "Remove this analysis from the filter"
-msgstr "Verwijder deze analyse uit de filter"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
-msgstr "{} sleutel(s) verwijderd: {}"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — row action tooltip
 msgid "Rename filter"
-msgstr "Filter hernoemen"
+msgstr ""
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
-msgstr "Bijlage weergeven in rapport"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:68
 msgid "Render in Report"
-msgstr "Weergeven in rapport"
+msgstr ""
 
 #: bika/lims/content/instrumentmaintenancetask.py:164
 #: bika/lims/content/instrumentscheduledtask.py:121
 msgid "Repair"
-msgstr "Repareren"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:59
 #: bika/lims/content/analysisservice.py:226
 msgid "Report"
-msgstr "Rapport"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:68
 #: bika/lims/content/instrumentvalidation.py:50
 msgid "Report Date"
-msgstr "Rapportdatum"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:150
 #: bika/lims/content/instrumentvalidation.py:132
 msgid "Report ID"
-msgstr "Rapport-ID"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:151
 #: bika/lims/content/instrumentvalidation.py:133
 msgid "Report identification number"
-msgstr "Rapportidentificatienummer"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
-msgstr "Rapportmetadata"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
-msgstr "Rapportontvangers"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:194
 msgid "Report upload"
-msgstr "Rapport uploaden"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Republish"
-msgstr "Opnieuw publiceren"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
-msgstr "Opnieuw gepubliceerd na laatste afdruk"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:71
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:70
 msgid "Request ID"
-msgstr "Aanvraag-ID"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
-msgstr "Nieuwe analyses aanvragen"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:227
 msgid "Required"
-msgstr "Vereist"
+msgstr ""
 
 #: bika/lims/browser/fields/partitionsetupfield.py:118
 msgid "Required Volume"
-msgstr "Vereist volume"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:198
 msgid "Reset"
-msgstr "Resetten"
+msgstr ""
 
 # senaite.app.listing: Reset-columns button tooltip
 msgid "Reset column visibility and order to the defaults"
-msgstr "Kolomzichtbaarheid en -volgorde terugzetten naar de standaardwaarden"
+msgstr ""
 
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
-msgstr "Kolommen resetten"
+msgstr ""
 
 # senaite.app.listing: Column config — reset link tooltip
 msgid "Reset to default columns and order"
-msgstr "Terugzetten naar standaardkolommen en -volgorde"
+msgstr ""
 
 # senaite.app.listing: Search box — undo / reset-view button tooltip
 msgid "Reset view"
-msgstr "Weergave resetten"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
-msgstr "Verantwoordelijken"
+msgstr ""
 
 #: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
-msgstr "Herstellen"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
-msgstr "Werkbladtoegang beperken tot toegewezen analisten"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
-msgstr "Werkbladbeheer beperken tot labmanagers"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:53
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:86
 msgid "Result"
-msgstr "Resultaat"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:130
 msgid "Result Capture Date"
-msgstr "Datum resultaatvastlegging"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:726
 msgid "Result Value"
-msgstr "Resultaatwaarde"
+msgstr ""
 
 #: bika/lims/validators.py:642
 msgid "Result Value must be a number"
-msgstr "Resultaatwaarde moet een getal zijn"
+msgstr ""
 
 #: bika/lims/validators.py:657
 msgid "Result Value must be unique"
-msgstr "Resultaatwaarde moet uniek zijn"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
-msgstr "Resultaat in schouderbereik"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
-msgstr "Resultaat buiten bereik"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
-msgstr "Resultaatbereik verschilt van specificatie: {}"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:711
 msgid "Result type"
-msgstr "Resultaattype"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
-msgstr "Resultaatwaarden met ten minste dit aantal significante cijfers worden weergegeven in wetenschappelijke notatie met de letter 'e' om de exponent aan te geven.  De precisie kan worden geconfigureerd in individuele analysediensten."
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:116
 msgid "Result variables"
-msgstr "Resultaatvariabelen"
+msgstr ""
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:63
 msgid "Results"
-msgstr "Resultaten"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1369
 msgid "Results Interpretation"
-msgstr "Resultaatinterpretatie"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:85
 msgid "Results Pending"
-msgstr "Resultaten in behandeling"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
-msgstr "Resultaatrapport"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
-msgstr "Resultaatrapporten"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
-msgstr "Resultaten zijn ingetrokken"
+msgstr ""
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:39
 msgid "Results interpretation"
-msgstr "Resultaatinterpretatie"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
-msgstr "Resultaten in behandeling"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:660
 #: bika/lims/content/preservation.py:52
 #: bika/lims/content/sampletype.py:116
 msgid "Retention Period"
-msgstr "Bewaartermijn"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Retest"
-msgstr "Hertest"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:96
 msgid "Retested"
-msgstr "Hertest"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Retract"
-msgstr "Intrekken"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
-msgstr "Ingetrokken"
+msgstr ""
 
 #: bika/lims/browser/templates/analyses_retractedlist.pt:11
 msgid "Retracted analyses"
-msgstr "Ingetrokken analyses"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:561
 msgid "Retractions"
-msgstr "Intrekkingen"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:78
 msgid "Review State"
-msgstr "Beoordelingsstatus"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:171
 msgid "Reviewed by"
-msgstr "Beoordeeld door"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:88
 #: bika/lims/controlpanel/auditlog.py:88
 msgid "Roles"
-msgstr "Rollen"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Rollback"
-msgstr "Terugdraaien"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/folder.py:110
 msgid "Routine Analyses"
-msgstr "Routineanalyses"
+msgstr ""
 
 #: bika/lims/api/snapshot.py:555
 msgid "Row ${num}"
-msgstr "Rij ${num}"
+msgstr ""
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
-msgstr "SENAITE CORE"
+msgstr ""
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE Add-on"
-msgstr "SENAITE CORE-add-on"
+msgstr ""
 
 #: bika/lims/profiles.zcml:15
 msgid "SENAITE Core 1.x (do not install)"
-msgstr "SENAITE Core 1.x (niet installeren)"
+msgstr ""
 
 #: senaite/core/browser/frontpage/templates/frontpage.pt:6
 msgid "SENAITE LIMS"
-msgstr "SENAITE LIMS"
+msgstr ""
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE LIMS front-page"
-msgstr "SENAITE LIMS-voorpagina"
+msgstr ""
 
 #: senaite/core/profiles/default/controlpanel.xml
 #: senaite/core/registry/controlpanel.py:81
 msgid "SENAITE Registry"
-msgstr "SENAITE Registry"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
-msgstr "SENAITE Instellingen"
+msgstr ""
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE front-page"
-msgstr "SENAITE-voorpagina"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
-msgstr "SMTP-server verbroken. Aanmaken van gebruiker afgebroken."
+msgstr ""
 
 #: bika/lims/content/supplier.py:87
 msgid "SWIFT code"
-msgstr "SWIFT-code"
+msgstr ""
 
 #: bika/lims/content/person.py:42
 msgid "Salutation"
-msgstr "Aanhef"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
 #: senaite/core/content/resultsreport.py:151
 msgid "Sample"
-msgstr "Monster"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2195
 msgid "Sample ${AR} was successfully created."
-msgstr "Monster ${AR} is succesvol aangemaakt."
+msgstr ""
 
 #: senaite/core/browser/samples/invalidate_samples.py:149
 msgid "Sample ${sample_id} has been successfully invalidated."
-msgstr "Monster ${sample_id} is succesvol ongeldig verklaard."
+msgstr ""
 
 #: senaite/core/browser/samples/invalidate_samples.py:139
 msgid "Sample ${sample_id} was successfully invalidated, and a notification email has been sent to the following recipients: ${recipients}."
-msgstr "Monster ${sample_id} is succesvol ongeldig verklaard en er is een meldingsmail verzonden naar de volgende ontvangers: ${recipients}."
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleCondition.xml
 msgid "Sample Condition"
-msgstr "Monsterconditie"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleConditions.xml
 msgid "Sample Conditions"
-msgstr "Monstercondities"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleContainer.xml
 msgid "Sample Container"
-msgstr "Monstercontainer"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleContainers.xml
 msgid "Sample Containers"
-msgstr "Monstercontainers"
+msgstr ""
 
 #: senaite/core/registry/schema.py:160
 msgid "Sample Header"
-msgstr "Monsterkop"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
 #: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
-msgstr "Monster-ID"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:17
 msgid "Sample Invalidation"
-msgstr "Ongeldigverklaring monster"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleMatrices.xml
 msgid "Sample Matrices"
-msgstr "Monstermatrices"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleMatrix.xml
 msgid "Sample Matrix"
-msgstr "Monstermatrix"
+msgstr ""
 
 #: bika/lims/content/artemplate.py:172
 msgid "Sample Partitions"
-msgstr "Monsterpartities"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
-msgstr "Monsterpunt"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SamplePoints.xml
 msgid "Sample Points"
-msgstr "Monsterpunten"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SamplePreservation.xml
 msgid "Sample Preservation"
-msgstr "Monsterconservering"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SamplePreservations.xml
 msgid "Sample Preservations"
-msgstr "Monsterconserveringen"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:671
 msgid "Sample Rejection"
-msgstr "Monsterafwijzing"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Sample Templates"
-msgstr "Monstersjablonen"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
 #: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
-msgstr "Monstertype"
+msgstr ""
 
 #: bika/lims/content/sampletype.py:156
 msgid "Sample Type Prefix"
-msgstr "Monstertypeprefix"
+msgstr ""
 
 #: senaite/core/registry/schema.py:124
 msgid "Sample View"
-msgstr "Monsterweergave"
+msgstr ""
 
 #: bika/lims/content/artemplate.py:118
 msgid "Sample collected by the laboratory"
-msgstr "Monster verzameld door het laboratorium"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:1992
 msgid "Sample creation cancelled"
-msgstr "Aanmaken van monster geannuleerd"
+msgstr ""
 
 #: bika/lims/browser/workflow/analysisrequest.py:248
 msgid "Sample date required for sample %s"
-msgstr "Monsterdatum vereist voor monster %s"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Sample due"
-msgstr "Monster verwacht"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:111
 msgid "Sample type"
-msgstr "Monstertype"
+msgstr ""
 
 #: senaite/core/content/interpretationtemplate.py:71
 msgid "Sample types"
-msgstr "Monstertypes"
+msgstr ""
 
 #: senaite/core/registry/schema.py:125
 msgid "Sample view configuration"
-msgstr "Configuratie monsterweergave"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:15
 msgid "Sample with partitions"
-msgstr "Monster met partities"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleTemplate.xml
 msgid "SampleTemplate"
-msgstr "MonsterSjabloon"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleTemplates.xml
 msgid "SampleTemplates"
-msgstr "MonsterSjablonen"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleType.xml
 msgid "SampleType"
-msgstr "MonsterType"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SampleTypes.xml
 msgid "SampleTypes"
-msgstr "MonsterTypes"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
-msgstr "Monsternemer"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:497
 msgid "Sampler for scheduled sampling"
-msgstr "Monsternemer voor geplande monstername"
+msgstr ""
 
 #: bika/lims/browser/workflow/analysisrequest.py:241
 msgid "Sampler required for sample %s"
-msgstr "Monsternemer vereist voor monster %s"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:457
 #: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
-msgstr "Monsters"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2192
 msgid "Samples ${ARs} were successfully created."
-msgstr "Monsters ${ARs} zijn succesvol aangemaakt."
+msgstr ""
 
 #: senaite/core/browser/samples/invalidate_samples.py:155
 msgid "Samples ${sample_ids} were successfully invalidated, with notification emails sent for the following: ${notified_ids}."
-msgstr "Monsters ${sample_ids} zijn succesvol ongeldig verklaard, met meldingsmails verzonden voor de volgende: ${notified_ids}."
+msgstr ""
 
 #: senaite/core/browser/samples/invalidate_samples.py:164
 msgid "Samples ${sample_ids} were successfully invalidated."
-msgstr "Monsters ${sample_ids} zijn succesvol ongeldig verklaard."
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:400
 msgid "Samples awaiting collection of the sample"
-msgstr "Monsters die wachten op verzameling van het monster"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:404
 msgid "Samples awaiting preservation"
-msgstr "Monsters die wachten op conservering"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:416
 msgid "Samples awaiting reception at the laboratory"
-msgstr "Monsters die wachten op ontvangst bij het laboratorium"
+msgstr ""
 
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
-msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:67
 msgid "Samples rejection reporting form"
-msgstr "Formulier voor rapportage van monsterafwijzing"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:81
 msgid "Samples to Receive"
-msgstr "Te ontvangen monsters"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:432
 msgid "Samples whose reports have been published"
-msgstr "Monsters waarvan de rapporten zijn gepubliceerd"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:424
 msgid "Samples whose results are awaiting verification"
-msgstr "Monsters waarvan de resultaten op verificatie wachten"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:409
 msgid "Samples with a scheduled sampling date"
-msgstr "Monsters met een geplande monsternamedatum"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
-msgstr "Monstername"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:106
 msgid "Sampling Date"
-msgstr "Monsternamedatum"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
-msgstr "Monsternameafwijking"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SamplingDeviations.xml
 msgid "Sampling Deviations"
-msgstr "Monsternameafwijkingen"
+msgstr ""
 
 #: bika/lims/content/samplepoint.py:83
 msgid "Sampling Frequency"
-msgstr "Monsternamefrequentie"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
-msgstr "Monstername gepland"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:161
 msgid "Saturday"
-msgstr "Zaterdag"
+msgstr ""
 
 #: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
 msgid "Save"
-msgstr "Opslaan"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
-msgstr "Opslaan en kopiëren"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — footer button to save the
 # current view
 msgid "Save current view"
-msgstr "Huidige weergave opslaan"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — toggle title + menu header
 msgid "Saved filters"
-msgstr "Opgeslagen filters"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
-msgstr "Opgeslagen items: {}"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Schedule"
-msgstr "Plannen"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Schedule sampling"
-msgstr "Monstername plannen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
-msgstr "Geplande monstername"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:400
 msgid "Scheduled task"
-msgstr "Geplande taak"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:95
 msgid "Scientific name"
-msgstr "Wetenschappelijke naam"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:154
 msgid "Search"
-msgstr "Zoeken"
+msgstr ""
 
 # senaite.app.listing: Column config — search input placeholder
 msgid "Search columns…"
-msgstr "Kolommen zoeken…"
+msgstr ""
 
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
-msgstr "Zoeken..."
+msgstr ""
 
 #: bika/lims/browser/fields/coordinatefield.py:38
 msgid "Seconds"
-msgstr "Seconden"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
-msgstr "Beveiliging"
+msgstr ""
 
 #: bika/lims/content/container.py:118
 msgid "Security Seal Intact Y/N"
-msgstr "Verzegeling intact J/N"
+msgstr ""
 
 #: senaite/core/content/samplecontainer.py:122
 msgid "Security seal intact"
-msgstr "Verzegeling intact"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:261
 msgid "Select"
-msgstr "Selecteren"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:100
 msgid "Select Import Interface"
-msgstr "Import-interface selecteren"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:215
 msgid "Select Partition Analyses"
-msgstr "Partitie-analyses selecteren"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:146
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
-msgstr "Selecteer een standaardconservering voor deze analysedienst. Als de conservering afhangt van de combinatie met het monstertype, geef dan per monstertype een conservering op in de onderstaande tabel"
+msgstr ""
 
 # senaite.core.browser.modals.templates.create_worksheet.pt
 msgid "Select all"
-msgstr "Alles selecteren"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:168
 msgid "Select all:"
-msgstr "Alles selecteren:"
+msgstr ""
 
 #: bika/lims/content/instrument.py:223
 msgid "Select an Export interface for this instrument."
-msgstr "Selecteer een export-interface voor dit instrument."
+msgstr ""
 
 #: bika/lims/content/instrument.py:236
 msgid "Select an Import interface for this instrument."
-msgstr "Selecteer een import-interface voor dit instrument."
+msgstr ""
 
 #: bika/lims/content/artemplate.py:288
 msgid "Select analyses to include in this template"
-msgstr "Selecteer analyses om op te nemen in dit sjabloon"
+msgstr ""
 
 #: senaite/core/browser/worksheets/templates/view.pt:36
 msgid "Select analyst"
-msgstr "Analist selecteren"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:203
 msgid "Select any add-ons you want to activate immediately. You can also activate add-ons after the site has been created using the Add-ons control panel."
-msgstr "Selecteer de add-ons die u direct wilt activeren. U kunt add-ons ook activeren nadat de site is aangemaakt via het configuratiescherm voor add-ons."
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:135
 msgid "Select existing file"
-msgstr "Bestaand bestand selecteren"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:85
 msgid "Select if is an in-house calibration certificate"
-msgstr "Selecteer of het een intern kalibratiecertificaat betreft"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:88
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
-msgstr "Selecteer of de te gebruiken berekening de standaardberekening van de standaardmethode is. Als deze niet is geselecteerd, kan de berekening handmatig worden gekozen"
+msgstr ""
 
 #: bika/lims/content/pricelist.py:76
 msgid "Select if the descriptions should be included"
-msgstr "Selecteer of de beschrijvingen moeten worden opgenomen"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:393
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
-msgstr "Selecteer of de resultaten voor tests van dit type analyse met behulp van een instrument kunnen worden ingesteld. Indien uitgeschakeld, zullen er geen instrumenten beschikbaar zijn voor tests van dit type analyse in de weergave voor resultaatbeheer, ook al zijn er instrumenten toegewezen aan de voor de test geselecteerde methode."
+msgstr ""
 
 #: senaite/core/browser/worksheets/templates/view.pt:66
 msgid "Select instrument"
-msgstr "Instrument selecteren"
+msgstr ""
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:50
 msgid "Select reasons"
-msgstr "Redenen selecteren"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:76
 #: senaite/core/browser/worksheets/templates/view.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:33
 msgid "Select template"
-msgstr "Sjabloon selecteren"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
-msgstr "Selecteer het land dat de site standaard zal tonen"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
-msgstr "Selecteer de valuta die de site gebruikt om prijzen weer te geven."
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:166
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
-msgstr "Selecteer de standaardcontainer voor deze analysedienst. Als de te gebruiken container afhangt van de combinatie van monstertype en conservering, geef de container dan op in de monstertypetabel hieronder"
+msgstr ""
 
 #: bika/lims/profiles/default/registry.xml
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
-msgstr "Selecteer de standaardstartpagina. Deze wordt gebruikt wanneer een klantgebruiker zich aanmeldt bij het systeem, of wanneer een klant wordt geselecteerd uit de lijst met klantmappen."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
-msgstr "Selecteer het standaardstickersjabloon voor automatisch afdrukken."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
-msgstr "Selecteer het standaardstickersjabloon voor automatisch afdrukken.<br/>"
+msgstr ""
 
 #: bika/lims/content/identifiertype.py:40
 msgid "Select the types that this ID is used to identify."
-msgstr "Selecteer de typen die met deze ID worden geïdentificeerd."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
-msgstr "Selecteer dit om automatische e-mailmeldingen aan de klant te activeren wanneer een monster wordt afgewezen."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
-msgstr "Selecteer dit om het dashboard te activeren als standaardvoorpagina."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
-msgstr "Selecteer dit om de workflowstappen voor monsterverzameling te activeren."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
-msgstr "Selecteer dit om een monsternamecoördinator toe te staan een monstername te plannen. Deze functionaliteit is alleen van kracht wanneer de 'Monstername-workflow' actief is"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1001
 msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
-msgstr "Selecteer dit om het verzenden van monsters via de overgang 'verzenden' toe te staan en de aanvullende status 'verzonden' in te schakelen. De analyses van een verzonden monster worden alleen-lezen en worden teruggezet naar hun vorige status wanneer het monster wordt hersteld. Standaard uitgeschakeld."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:991
 msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
-msgstr "Selecteer dit om het afvoeren van monsters via de overgang 'afvoeren' toe te staan en de aanvullende status 'afgevoerd' in te schakelen. Standaard uitgeschakeld."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
-msgstr "Selecteer dit om de gebruiker toe te staan een aanvullende status 'Afgedrukt' toe te kennen aan die analyseaanvragen die zijn gepubliceerd. Standaard uitgeschakeld."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
-msgstr "Selecteer dit om monsters automatisch te ontvangen wanneer ze door laboratoriumpersoneel worden aangemaakt en de monstername-workflow is uitgeschakeld. Monsters die door contactpersonen van klanten worden aangemaakt, worden niet automatisch ontvangen"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-msgstr "Selecteer dit om monsterpartities te tonen aan contactpersonen van klanten. Indien gedeactiveerd, worden partities niet opgenomen in lijsten en wordt er geen infobericht met links naar het primaire monster getoond aan contactpersonen van klanten."
+msgstr ""
 
 #: bika/lims/content/worksheettemplate.py:82
 msgid "Select which Analyses should be included on the Worksheet"
-msgstr "Selecteer welke analyses op het werkblad moeten worden opgenomen"
+msgstr ""
 
 #: senaite/core/config/vocabularies.py:57
 msgid "Selection list"
-msgstr "Selectielijst"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
-msgstr "Zelfverificatie van resultaten"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:208
 msgid "Send"
-msgstr "Verzenden"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:23
 msgid "Send Analysis Reports via Email"
-msgstr "Analyserapporten via e-mail verzenden"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
-msgstr "Verzendlogboek"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
-msgstr "Verzendlogboekregel"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:132
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:135
 msgid "Send an email notification to ${recipients}"
-msgstr "Een e-mailmelding verzenden naar ${recipients}"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisreport_info.pt:132
 msgid "Sender"
-msgstr "Afzender"
+msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:91
 msgid "Sent to"
-msgstr "Verzonden naar"
+msgstr ""
 
 #: bika/lims/browser/fields/partitionsetupfield.py:115
 #: bika/lims/content/analysisservice.py:129
 msgid "Separate Container"
-msgstr "Aparte container"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
-msgstr "Seq-type"
+msgstr ""
 
 #: bika/lims/content/instrument.py:145
 msgid "Serial No"
-msgstr "Serienr."
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:74
 #: bika/lims/browser/templates/analysisservice_info.pt:209
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:73
 msgid "Service"
-msgstr "Dienst"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
-msgstr "Dienst kan niet worden gedeselecteerd. Klik op de infoknop voor meer details"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:315
 msgid "Service keyword {analysis_keyword} not found"
-msgstr "Dienstsleutelwoord {analysis_keyword} niet gevonden"
+msgstr ""
 
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:119
 msgid "Set Conditions"
-msgstr "Voorwaarden instellen"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:167
 msgid "Set remarks"
-msgstr "Opmerkingen instellen"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:171
 msgid "Set remarks for selected analyses"
-msgstr "Opmerkingen instellen voor geselecteerde analyses"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:672
 msgid "Set the Sample Rejection workflow and the reasons"
-msgstr "Stel de workflow voor monsterafwijzing en de redenen in"
+msgstr ""
 
 #: bika/lims/content/instrumentmaintenancetask.py:128
 msgid "Set the maintenance task as closed."
-msgstr "Stel de onderhoudstaak in als gesloten."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
-msgstr "Stel de tekst in voor de hoofdtekst van de e-mail die naar de contactpersoon van de klant van het monster wordt verzonden als de optie 'E-mailmelding bij monsterafwijzing' is ingeschakeld. U kunt gereserveerde sleutelwoorden gebruiken: $sample_id, $sample_link, $reasons, $lab_address"
+msgstr ""
 
 #: senaite/core/registry/schema.py:40
 msgid "Settings for Clients"
-msgstr "Instellingen voor klanten"
+msgstr ""
 
 #: bika/lims/profiles/default/types/BikaSetup.xml
 msgid "Setup"
-msgstr "Instellingen"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
-msgstr "Legplankcode"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:83
 msgid "Shelf Description"
-msgstr "Legplankbeschrijving"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:73
 msgid "Shelf Title"
-msgstr "Legplanktitel"
+msgstr ""
 
 #: bika/lims/config.py:84
 msgid "Shipping address"
-msgstr "Verzendadres"
+msgstr ""
 
 #: bika/lims/content/client.py:61
 msgid "Short and unique identifier of this client. Besides fast searches by client in Samples listings, the purposes of this field depend on the laboratory needs. For instance, the Client ID can be included as part of the Sample identifier, so the lab can easily know the client a given sample belongs to by just looking to its ID."
-msgstr "Korte en unieke identificatie van deze klant. Naast snel zoeken op klant in monsterlijsten hangen de doeleinden van dit veld af van de behoeften van het laboratorium. De klant-ID kan bijvoorbeeld worden opgenomen als onderdeel van de monsteridentificatie, zodat het lab eenvoudig kan weten tot welke klant een bepaald monster behoort door alleen naar de ID te kijken."
+msgstr ""
 
 #: bika/lims/content/method.py:160
 msgid "Short method description"
-msgstr "Korte methodebeschrijving"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:68
 msgid "Short title"
-msgstr "Korte titel"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:974
 msgid "Should the analyses be excluded from the invoice?"
-msgstr "Moeten de analyses worden uitgesloten van de factuur?"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:127
 msgid "Should the default example content be added to the site?"
-msgstr "Moet de standaard voorbeeldinhoud aan de site worden toegevoegd?"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
-msgstr "Aanvullende velden tonen"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
-msgstr "Alles tonen"
+msgstr ""
 
 #: senaite/core/api/remarks.py:486
 msgid "Show history"
-msgstr "Geschiedenis tonen"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
-msgstr "Laatste logboeken voor automatische import tonen"
+msgstr ""
 
 #: senaite/core/api/remarks.py:489
 msgid "Show less"
-msgstr "Minder tonen"
+msgstr ""
 
 #: senaite/core/api/remarks.py:488
 msgid "Show more"
-msgstr "Meer tonen"
+msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
-msgstr "Standaardvelden tonen"
+msgstr ""
 
 # senaite.app.listing: Column config — plus button tooltip / aria-label
 msgid "Show this column"
-msgstr "Deze kolom tonen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:129
 msgid "Show/hide timeline"
-msgstr "Tijdlijn tonen/verbergen"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
-msgstr "Handtekening"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "Simple File"
-msgstr "Eenvoudig bestand"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "Simple Image"
-msgstr "Eenvoudige afbeelding"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:43
 msgid "Site Code"
-msgstr "Sitecode"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:48
 msgid "Site Description"
-msgstr "Sitebeschrijving"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
-msgstr "Sitelogo"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
-msgstr "Sitelogo-CSS"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:38
 msgid "Site Title"
-msgstr "Sitetitel"
+msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:67
 #: senaite/core/browser/viewlets/templates/attachments.pt:65
 msgid "Size"
-msgstr "Grootte"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:648
 msgid "Skipping result for analysis '{keyword}' of sample '{sid}' with calculation '{calculation}'"
-msgstr "Resultaat voor analyse '{keyword}' van monster '{sid}' met berekening '{calculation}' wordt overgeslagen"
+msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Small Sticker"
-msgstr "Kleine sticker"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
-msgstr "Klein stickersjabloon"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:98
 msgid "Snapshot"
-msgstr "Momentopname"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/results.py:190
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
-msgstr "Sommige analyses gebruiken verouderde of niet-gekalibreerde instrumenten. Bewerken van resultaten niet toegestaan"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:82
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
-msgstr "Sorteersleutel"
+msgstr ""
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort ascending"
-msgstr "Oplopend sorteren"
+msgstr ""
 
 # senaite.app.listing: Column header — sort arrow tooltip / aria-label
 msgid "Sort descending"
-msgstr "Aflopend sorteren"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
-msgstr "Bron"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:93
 msgid "Specification"
-msgstr "Specificatie"
+msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:50
 msgid "Specification File"
-msgstr "Specificatiebestand"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:707
 msgid "Specification Name"
-msgstr "Specificatienaam"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:18
 msgid "Specification ranges have changed since they were assigned"
-msgstr "De specificatiebereiken zijn gewijzigd sinds ze werden toegewezen"
+msgstr ""
 
 #: bika/lims/content/analysisspec.py:90
 msgid "Specifications"
-msgstr "Specificaties"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
-msgstr "Geef aan hoeveel exemplaren van elke sticker standaard moeten worden afgedrukt."
+msgstr ""
 
 #: bika/lims/content/worksheettemplate.py:63
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
-msgstr "Geef de grootte van het werkblad op, bijvoorbeeld overeenkomend met de trayafmeting van een specifiek instrument. Selecteer vervolgens een analyse-'type' per werkbladpositie. Waar QC-monsters worden geselecteerd, selecteer ook welk referentiemonster moet worden gebruikt. Als een duplicaatanalyse wordt geselecteerd, geef dan aan van welke monsterpositie het een duplicaat moet zijn"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
-msgstr "Splitslengte"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:149
 #: senaite/core/registry/schema.py:205
 msgid "Standard fields"
-msgstr "Standaardvelden"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:64
 msgid "Start Date"
-msgstr "Startdatum"
+msgstr ""
 
 #: bika/lims/validators.py:237
 msgid "Start date must be before End Date"
-msgstr "Startdatum moet vóór einddatum liggen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
-msgstr "Status"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
-msgstr "Status"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
-msgstr "Sticker"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Stickers preview"
-msgstr "Voorbeeld van stickers"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — star action tooltip when active
 msgid "Stop auto-applying"
-msgstr "Automatisch toepassen stoppen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
-msgstr "Opslaglocatie"
+msgstr ""
 
 #: senaite/core/profiles/default/types/StorageLocations.xml
 msgid "Storage Locations"
-msgstr "Opslaglocaties"
+msgstr ""
 
 #: senaite/core/config/vocabularies.py:55
 msgid "String"
-msgstr "Tekenreeks"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SubGroup.xml
 msgid "SubGroup"
-msgstr "Subgroep"
+msgstr ""
 
 #: senaite/core/profiles/default/types/SubGroups.xml
 msgid "SubGroups"
-msgstr "Subgroepen"
+msgstr ""
 
 #: bika/lims/content/subgroup.py:39
 msgid "Subgroups are sorted with this key in group views"
-msgstr "Subgroepen worden met deze sleutel gesorteerd in groepsweergaven"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:115
 #: bika/lims/browser/templates/analysisreport_info.pt:165
 msgid "Subject"
-msgstr "Onderwerp"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:124
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Submit"
-msgstr "Indienen"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:114
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
-msgstr "Dien een geldig Open XML-bestand (.XLSX) in met instellingsrecords om door te gaan."
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:490
 msgid "Submitted analyses awaiting verification"
-msgstr "Ingediende analyses in afwachting van verificatie"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
-msgstr "Ingediend en geverifieerd door dezelfde gebruiker: {}"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:181
 msgid "Submitter"
-msgstr "Indiener"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
-msgstr "Subtotaal"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:162
 msgid "Sunday"
-msgstr "Zondag"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:600
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Supplier"
-msgstr "Leverancier"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Suppliers.xml
 msgid "Suppliers"
-msgstr "Leveranciers"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/referencesamples.py:75
 msgid "Supported Services"
-msgstr "Ondersteunde diensten"
+msgstr ""
 
 #: bika/lims/content/method.py:116
 msgid "Supported calculations of this method"
-msgstr "Ondersteunde berekeningen van deze methode"
+msgstr ""
 
 #: bika/lims/content/person.py:75
 msgid "Surname"
-msgstr "Achternaam"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/multi_results.pt:33
 msgid "Switch to classic view"
-msgstr "Overschakelen naar klassieke weergave"
+msgstr ""
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:6
 msgid "Switch to dashboard"
-msgstr "Overschakelen naar dashboard"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/multi_results.pt:25
 msgid "Switch to transposed view"
-msgstr "Overschakelen naar getransponeerde weergave"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
-msgstr "Systeemstandaard"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:84
 msgid "Task"
-msgstr "Taak"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:57
 msgid "Task ID"
-msgstr "Taak-ID"
+msgstr ""
 
 #. Default: "Type"
 #: bika/lims/browser/instrument.py:86
 #: bika/lims/content/instrumentscheduledtask.py:66
 msgid "Task type"
-msgstr "Type"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:217
 msgid "Taxes"
-msgstr "Belastingen"
+msgstr ""
 
 #: bika/lims/content/method.py:78
 msgid "Technical description and instructions intended for analysts"
-msgstr "Technische beschrijving en instructies bedoeld voor analisten"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
-msgstr "Sjabloon"
+msgstr ""
 
 #: bika/lims/content/calculation.py:156
 msgid "Test Parameters"
-msgstr "Testparameters"
+msgstr ""
 
 #: bika/lims/content/calculation.py:170
 msgid "Test Result"
-msgstr "Testresultaat"
+msgstr ""
 
 #: senaite/core/config/vocabularies.py:56
 msgid "Text"
-msgstr "Tekst"
+msgstr ""
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:5
 msgid "Thank you for your analysis request."
-msgstr "Bedankt voor uw analyseaanvraag."
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:54
 msgid "The ID of the site. This ends up as part of the URL. No special characters or spaces are allowed."
-msgstr "De ID van de site. Deze wordt onderdeel van de URL. Speciale tekens of spaties zijn niet toegestaan."
+msgstr ""
 
 #: bika/lims/content/laboratory.py:65
 msgid "The Laboratory's web address"
-msgstr "Het webadres van het laboratorium"
+msgstr ""
 
 #: senaite/core/browser/form/adapters/referencesample.py:46
 msgid "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
-msgstr "De referentiemonster-ID kan niet worden gewijzigd omdat deze al is gekoppeld aan andere objecten, zoals QC-analyses."
+msgstr ""
 
 #: bika/lims/content/laboratory.py:142
 msgid "The accreditation standard that applies, e.g. ISO 17025"
-msgstr "De van toepassing zijnde accreditatienorm, bijv. ISO 17025"
+msgstr ""
 
 #: bika/lims/content/analysisprofile.py:65
 msgid "The analyses included in this profile, grouped per category"
-msgstr "De analyses die in dit profiel zijn opgenomen, gegroepeerd per categorie"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:97
 msgid "The analyst or agent responsible of the calibration"
-msgstr "De analist of medewerker die verantwoordelijk is voor de kalibratie"
+msgstr ""
 
 #: bika/lims/content/instrumentmaintenancetask.py:84
 msgid "The analyst or agent responsible of the maintenance"
-msgstr "De analist of medewerker die verantwoordelijk is voor het onderhoud"
+msgstr ""
 
 #: bika/lims/content/instrumentvalidation.py:79
 msgid "The analyst responsible of the validation"
-msgstr "De analist die verantwoordelijk is voor de validatie"
+msgstr ""
 
 #: bika/lims/browser/batch/batchbook.py:38
 msgid "The batch book allows to introduce analysis results for all samples in this batch. Please note that submitting the results for verification is only possible within samples or worksheets, because additional information like e.g. the instrument or the method need to be set additionally."
-msgstr "Met het batchboek kunt u analyseresultaten invoeren voor alle monsters in deze batch. Houd er rekening mee dat het indienen van de resultaten voor verificatie alleen mogelijk is binnen monsters of werkbladen, omdat aanvullende informatie zoals bijvoorbeeld het instrument of de methode aanvullend moet worden ingesteld."
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:852
 msgid "The client side identifier of the sample"
-msgstr "De identificatie van het monster aan de klantzijde"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:818
 msgid "The client side order number for this request"
-msgstr "Het ordernummer aan de klantzijde voor deze aanvraag"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:835
 msgid "The client side reference for this request"
-msgstr "De referentie aan de klantzijde voor deze aanvraag"
+msgstr ""
 
 #: bika/lims/content/instrument.py:348
 msgid "The date the instrument was installed"
-msgstr "De datum waarop het instrument is geïnstalleerd"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:623
 msgid "The date when the sample was preserved"
-msgstr "De datum waarop het monster is geconserveerd"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1077
 msgid "The date when the sample was received"
-msgstr "De datum waarop het monster is ontvangen"
+msgstr ""
 
 #: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
-msgstr "Het decimaalteken dat is geselecteerd in Bika Setup wordt gebruikt."
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:113
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
-msgstr "De standaardinstelling voor de tijdzone van het portaal. Gebruikers kunnen hun eigen tijdzone instellen, mits er beschikbare tijdzones zijn gedefinieerd in de datum- en tijdinstellingen."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-msgstr "Het hier ingevoerde kortingspercentage wordt toegepast op de prijzen voor klanten die zijn gemarkeerd als 'leden', doorgaans coöperatieve leden of partners die deze korting verdienen"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:179
 msgid "The email 'From' address is invalid. Please verify the \"Publication 'From' address\" in Setup > Notifications and/or the \"Site 'From' address\" in Site Setup > Mail."
-msgstr "Het 'Van'-e-mailadres is ongeldig. Controleer het \"Publicatie-'Van'-adres\" in Instellingen > Meldingen en/of het \"Site-'Van'-adres\" in Site-instellingen > E-mail."
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:940
 msgid "The environmental condition during sampling"
-msgstr "De omgevingsconditie tijdens de monstername"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:104
 msgid "The fields are always listed on top and can not be faded out. You can drag and drop any fields to the lower list to change thier visibility."
-msgstr "De velden worden altijd bovenaan weergegeven en kunnen niet worden verborgen. U kunt velden naar de onderste lijst slepen om hun zichtbaarheid te wijzigen."
+msgstr ""
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:150
 msgid "The fields are listed below the promient fields and can be faded out. You can drag and drop any fields to the upper list to change their visibility."
-msgstr "De velden worden onder de prominente velden weergegeven en kunnen worden verborgen. U kunt velden naar de bovenste lijst slepen om hun zichtbaarheid te wijzigen."
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:20
 msgid "The following partitions have been created from this Sample:"
-msgstr "De volgende partities zijn aangemaakt op basis van dit monster:"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:47
 msgid "The following sample(s) will be dispatched"
-msgstr "De volgende monster(s) worden verzonden"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/dispose_samples.pt:47
 msgid "The following sample(s) will be disposed"
-msgstr "De volgende monster(s) worden afgevoerd"
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
-msgstr "Het globale auditlogboek toont alle wijzigingen van het systeem. Indien ingeschakeld, worden alle entiteiten geïndexeerd in een aparte catalogus. Dit verlengt de tijd bij het aanmaken of wijzigen van objecten."
+msgstr ""
 
 #: bika/lims/content/samplepoint.py:75
 msgid "The height or depth at which the sample has to be taken"
-msgstr "De hoogte of diepte waarop het monster moet worden genomen"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
-msgstr "De houdbaarheidstijd voor dit monster en deze analyse is verstreken. Doorgaan met de analyse kan de betrouwbaarheid van de resultaten in gevaar brengen."
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
-msgstr "De houdbaarheidstijd voor dit monster en deze analyse verloopt binnenkort. Voltooi de analyse zo snel mogelijk om de nauwkeurigheid en betrouwbaarheid van de gegevens te waarborgen."
+msgstr ""
 
 #: bika/lims/content/instrument.py:309
 #: bika/lims/content/instrumentcertification.py:58
 msgid "The instrument's ID in the lab's asset register"
-msgstr "De ID van het instrument in het inventarisregister van het lab"
+msgstr ""
 
 #: bika/lims/content/instrument.py:138
 msgid "The instrument's model number"
-msgstr "Het modelnummer van het instrument"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:111
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
-msgstr "Het interval wordt berekend vanaf het veld 'Van' en bepaalt na hoeveel dagen het certificaat verloopt. Het instellen van dit interval overschrijft het veld 'Tot' bij opslaan."
+msgstr ""
 
 #: senaite/core/browser/samples/invalidate_samples.py:121
 msgid "The invalidation process has been successfully cancelled."
-msgstr "Het ongeldigverklaringsproces is met succes geannuleerd."
+msgstr ""
 
 #: bika/lims/browser/accreditation.py:71
 msgid "The lab is not accredited, or accreditation has not been configured. "
-msgstr "Het lab is niet geaccrediteerd, of de accreditatie is niet geconfigureerd. "
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:90
 msgid "The main language of the site."
-msgstr "De hoofdtaal van de site."
+msgstr ""
 
 #: bika/lims/content/sampletype.py:166
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
-msgstr "Het minimale monstervolume dat nodig is voor analyse, bijv. '10 ml' of '1 kg'."
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:40
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
-msgstr "De opslag van de nummergenerator is leeg. Tellers worden geïnitialiseerd bij de eerste ID-generatie voor elk voorvoegsel."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
-msgstr "Het aantal dagen voordat een monster verloopt en niet meer kan worden geanalyseerd. Deze instelling kan per afzonderlijk monstertype worden overschreven in de instellingen voor monstertypen"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-msgstr "Het aantal minuten voordat een gebruiker automatisch wordt afgemeld. 0 schakelt automatisch afmelden uit"
+msgstr ""
 
 #: bika/lims/content/sampletype.py:117
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
-msgstr "De periode gedurende welke niet-geconserveerde monsters van dit type kunnen worden bewaard voordat ze verlopen en niet verder kunnen worden geanalyseerd"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:644
 msgid "The person who preserved the sample"
-msgstr "De persoon die het monster heeft geconserveerd"
+msgstr ""
 
 #: bika/lims/content/analysisrequest.py:477
 msgid "The person who took the sample"
-msgstr "De persoon die het monster heeft genomen"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:562
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
-msgstr "De prijs die per analyse in rekening wordt gebracht voor klanten die in aanmerking komen voor volumekortingen"
+msgstr ""
 
 #: bika/lims/content/analysisprofile.py:92
 msgid "The profile's commercial ID for accounting purposes."
-msgstr "De commerciële ID van het profiel voor boekhoudkundige doeleinden."
+msgstr ""
 
 #: bika/lims/content/analysisprofile.py:52
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
-msgstr "Het sleutelwoord van het profiel wordt gebruikt om het uniek te identificeren in importbestanden. Het moet uniek zijn en mag niet hetzelfde zijn als een ID van een tussentijds berekeningsveld."
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:23
 msgid "The ranges for the following analyses have been manually changed and they are no longer compliant with the ranges of the Specification:"
-msgstr "De bereiken voor de volgende analyses zijn handmatig gewijzigd en voldoen niet langer aan de bereiken van de specificatie:"
+msgstr ""
 
 #: bika/lims/content/laboratory.py:153
 msgid "The reference code issued to the lab by the accreditation body"
-msgstr "De referentiecode die door de accreditatie-instantie aan het lab is toegekend"
+msgstr ""
 
 #: bika/lims/content/calculation.py:171
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
-msgstr "Het resultaat nadat de berekening met testwaarden heeft plaatsgevonden. U moet de berekening opslaan voordat deze waarde wordt berekend."
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
-msgstr "Het resultaat is vastgelegd na de houdbaarheidstijdlimiet."
+msgstr ""
 
 #: bika/lims/content/method.py:149
 msgid "The results for the Analysis Services that use this method can be set manually"
-msgstr "De resultaten voor de analysediensten die deze methode gebruiken, kunnen handmatig worden ingesteld"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:514
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
-msgstr "De resultaten van veldanalyses worden vastgelegd tijdens de monstername op het monsterpunt, bijv. de temperatuur van een watermonster in de rivier waar het wordt genomen. Labanalyses worden in het laboratorium uitgevoerd"
+msgstr ""
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:8
 msgid "The sample cannot be received"
-msgstr "Het monster kan niet worden ontvangen"
+msgstr ""
 
 #: bika/lims/content/artemplate.py:110
 msgid "The sample is a mix of sub samples"
-msgstr "Het monster is een mengsel van submonsters"
+msgstr ""
 
 #: bika/lims/content/instrument.py:146
 msgid "The serial number that uniquely identifies the instrument"
-msgstr "Het serienummer dat het instrument uniek identificeert"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
-msgstr "De ID van het analytische protocol van de dienst"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
-msgstr "De commerciële ID van de dienst voor boekhoudkundige doeleinden"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:14
 msgid "The specification has a Dynamic Specification assigned"
-msgstr "Aan de specificatie is een dynamische specificatie toegewezen"
+msgstr ""
 
 #: senaite/core/schema/emailfield.py:12
 msgid "The specified email is not valid."
-msgstr "Het opgegeven e-mailadres is niet geldig."
+msgstr ""
 
 #: bika/lims/content/referencesample.py:65
 msgid "The unique identifier for this reference sample. If specified, the system will use this value as the sample's ID instead of automatically generating one based on the formatting rules defined in the setup's ID server."
-msgstr "De unieke identificatie voor dit referentiemonster. Indien opgegeven, gebruikt het systeem deze waarde als de ID van het monster in plaats van er automatisch een te genereren op basis van de opmaakregels die zijn gedefinieerd in de ID-server van de instellingen."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:363
 msgid "The unique keyword used to identify the analysis service in import files of bulk Sample requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
-msgstr "Het unieke sleutelwoord dat wordt gebruikt om de analysedienst te identificeren in importbestanden van bulk-monsteraanvragen en resultaatimports van instrumenten. Het wordt ook gebruikt om afhankelijke analysediensten te identificeren in door de gebruiker gedefinieerde resultaatberekeningen"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:1461
 msgid "The value of field '%s' was emptied. Please select a new value."
-msgstr "De waarde van veld '%s' is leeggemaakt. Selecteer een nieuwe waarde."
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:126
 msgid "The variable ${recipients} will be automatically replaced with the names and emails of the final selected recipients."
-msgstr "De variabele ${recipients} wordt automatisch vervangen door de namen en e-mailadressen van de uiteindelijk geselecteerde ontvangers."
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:93
 msgid "There are no pre-defined conditions set"
-msgstr "Er zijn geen vooraf gedefinieerde voorwaarden ingesteld"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:14
 msgid "This Analysis Specification has a Dynamic Specification assigned"
-msgstr "Aan deze analysespecificatie is een dynamische specificatie toegewezen"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:15
 msgid "This Sample has been rejected due to the following reasons:"
-msgstr "Dit monster is afgewezen om de volgende redenen:"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/partition_ar_viewlet.pt:14
 msgid "This is a Partition from Sample"
-msgstr "Dit is een partitie van monster"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/secondary_ar_viewlet.pt:15
 msgid "This is a Secondary Sample of"
-msgstr "Dit is een secundair monster van"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/detached_partition_viewlet.pt:15
 msgid "This is a detached partition from Sample"
-msgstr "Dit is een losgekoppelde partitie van monster"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
-msgstr "Dit is de standaard maximale tijd die is toegestaan voor het uitvoeren van analyses. Deze wordt alleen gebruikt voor analyses waarbij de analysedienst geen doorlooptijd opgeeft. Alleen laboratoriumwerkdagen worden in aanmerking genomen."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
-msgstr "Dit is de standaard maximale tijd die is toegestaan voor het uitvoeren van analyses. Deze wordt alleen gebruikt voor analyses waarbij de analysedienst geen doorlooptijd opgeeft. Alleen laboratoriumwerkdagen worden in aanmerking genomen."
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:134
 msgid "This operation can not be undone. Are you sure you want to reject the selected analyses?"
-msgstr "Deze bewerking kan niet ongedaan worden gemaakt. Weet u zeker dat u de geselecteerde analyses wilt afwijzen?"
+msgstr ""
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:14
 msgid "This report was sent to the following contacts:"
-msgstr "Dit rapport is verzonden naar de volgende contactpersonen:"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/retest_ar_viewlet.pt:19
 msgid "This sample is a retest, automatically generated following the invalidation of sample ${invalidated_id}."
-msgstr "Dit monster is een hertest, automatisch gegenereerd na de ongeldigverklaring van monster ${invalidated_id}."
+msgstr ""
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:28
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date} for the following reason(s): ${reason}."
-msgstr "Dit monster is ongeldig verklaard door ${actor_fullname} (${actor_id}) op ${date} om de volgende reden(en): ${reason}."
+msgstr ""
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:38
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
-msgstr "Dit monster is ongeldig verklaard door ${actor_fullname} (${actor_id}) op ${date}."
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
-msgstr "Deze dienst kan niet worden geselecteerd om te voorkomen dat de analyse wordt uitgevoerd na de analytische houdbaarheidstijd."
+msgstr ""
 
 #: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
-msgstr "Dit toont een aangepast logo op uw SENAITE-site."
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:57
 msgid "This site configuration is outdated and needs to be upgraded:"
-msgstr "Deze siteconfiguratie is verouderd en moet worden bijgewerkt:"
+msgstr ""
 
 #: bika/lims/content/laboratory.py:100
 msgid "This value is reported at the bottom of all published results"
-msgstr "Deze waarde wordt onderaan alle gepubliceerde resultaten vermeld"
+msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:84
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
-msgstr "Dit werkblad is aangemaakt ter vervanging van het afgewezen werkblad bij ${ws_id}"
+msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:77
 msgid "This worksheet has been rejected.  The replacement worksheet is ${ws_id}"
-msgstr "Dit werkblad is afgewezen. Het vervangende werkblad is ${ws_id}"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:159
 msgid "Thursday"
-msgstr "Donderdag"
+msgstr ""
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:47
 msgid "Time"
-msgstr "Tijd"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:129
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
-msgstr "Tip. Bijgevoegde documenten worden niet geladen tenzij ze aanwezig zijn in de instantie."
+msgstr ""
 
 #: senaite/core/browser/controlpanel/labels/view.py:60
 #: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
-msgstr "Titel"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:54
 msgid "Title of location"
-msgstr "Titel van locatie"
+msgstr ""
 
 #: bika/lims/controlpanel/dynamic_analysisspecs.py:35
 msgid "Title of the Folder"
-msgstr "Titel van de map"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:74
 msgid "Title of the shelf"
-msgstr "Titel van de legplank"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:39
 msgid "Title of the site"
-msgstr "Titel van de site"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:88
 #: bika/lims/content/instrumentmaintenancetask.py:75
 #: bika/lims/content/instrumentvalidation.py:70
 msgid "To"
-msgstr "Tot"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
-msgstr "Te conserveren"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
-msgstr "Te bemonsteren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:93
 msgid "To be Published"
-msgstr "Te publiceren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:89
 msgid "To be Verified"
-msgstr "Te verifiëren"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
-msgstr "Om onder elke analysecategoriesectie op resultaatrapporten te worden weergegeven."
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
-msgstr "Te conserveren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
-msgstr "Af te drukken"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
-msgstr "Te bemonsteren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:148
 #: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
-msgstr "Te verifiëren"
+msgstr ""
 
 #: bika/lims/content/calculation.py:157
 msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
-msgstr "Voer hier waarden in voor alle berekeningsparameters om de berekening te testen. Dit omvat hierboven gedefinieerde tussentijdse velden, evenals eventuele diensten waarvan deze berekening afhankelijk is om resultaten te berekenen."
+msgstr ""
 
 #: senaite/core/registry/schema.py:174
 msgid "Toggle visibility of standard sample header fields"
-msgstr "Zichtbaarheid van standaard monsterkopvelden in-/uitschakelen"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:650
 msgid "Total"
-msgstr "Totaal"
+msgstr ""
 
 #: bika/lims/content/analysisprofile.py:142
 #: bika/lims/content/labproduct.py:67
 msgid "Total price"
-msgstr "Totaalprijs"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:202
 msgid "Total size of email exceeded {:.1f} MB ({:.2f} MB)"
-msgstr "Totale grootte van de e-mail overschreed {:.1f} MB ({:.2f} MB)"
+msgstr ""
 
 #: bika/lims/config.py:126
 msgid "Transposed"
-msgstr "Getransponeerd"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:157
 msgid "Tuesday"
-msgstr "Dinsdag"
+msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
 #: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
-msgstr "Type"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:64
 msgid "Type of control to be displayed on value entry when choices are set"
-msgstr "Type besturingselement dat bij waarde-invoer wordt weergegeven wanneer keuzes zijn ingesteld"
+msgstr ""
 
 #: bika/lims/content/multifile.py:74
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
-msgstr "Type document (bijv. gebruikershandleiding, instrumentspecificaties, afbeelding, ...)"
+msgstr ""
 
 #: bika/lims/content/storagelocation.py:69
 msgid "Type of location"
-msgstr "Type locatie"
+msgstr ""
 
 #: senaite/core/content/samplecontainer.py:73
 msgid "Type of the container"
-msgstr "Type van de container"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/templates/setupview.pt:27
 msgid "Type to filter ..."
-msgstr "Typ om te filteren ..."
+msgstr ""
 
 # senaite.app.listing: Column-filter row — searchable-select placeholder
 msgid "Type to filter..."
-msgstr "Typ om te filteren..."
+msgstr ""
 
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
-msgstr "Typen die labels rechtstreeks ondersteunen.<br/>OPMERKING: In clusteropstellingen moeten andere instanties handmatig opnieuw worden gestart om de wijzigingen door te voeren!"
+msgstr ""
 
 #: senaite/core/registry/schema.py:77
 msgid "Types with labels"
-msgstr "Typen met labels"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:100
 msgid "UID"
-msgstr "UID"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/printview.py:151
 msgid "Unable to load the template"
-msgstr "Kan het sjabloon niet laden"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassign"
-msgstr "Toewijzing opheffen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
-msgstr "Niet toegewezen"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:61
 msgid "Uncertainty"
-msgstr "Onzekerheid"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:622
 msgid "Uncertainty value"
-msgstr "Onzekerheidswaarde"
+msgstr ""
 
 #: bika/lims/content/department.py:45
 msgid "Unique Department ID that identifies the department"
-msgstr "Unieke afdelings-ID die de afdeling identificeert"
+msgstr ""
 
 #: senaite/core/browser/modals/analysis/schema.py:96
 msgid "Unit"
-msgstr "Eenheid"
+msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:125
 msgid "Unknown"
-msgstr "Onbekend"
+msgstr ""
 
 #: senaite/core/content/supplier.py:156
 msgid "Unknown IBAN country %s"
-msgstr "Onbekend IBAN-land %s"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:108
 msgid "Unlink User"
-msgstr "Gebruiker ontkoppelen"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
-msgstr "Ontkoppelde gebruiker"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unlock"
-msgstr "Ontgrendelen"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
-msgstr "Niet-herkend bestandsformaat ${file_format}"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:51
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:63
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:51
 msgid "Unrecognized file format ${fileformat}"
-msgstr "Niet-herkend bestandsformaat ${fileformat}"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/horiba/jobinyvon/icp.py:57
 msgid "Unrecognized file format ${format}"
-msgstr "Niet-herkend bestandsformaat ${format}"
+msgstr ""
 
 #: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
-msgstr "Niet toegewezen"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
-msgstr "Bijlagen bijwerken"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — Update preset action tooltip
 msgid "Update preset with current view"
-msgstr "Voorinstelling bijwerken met huidige weergave"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
-msgstr "{} sleutel(s) bijgewerkt: {}"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:47
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
-msgstr "Upload een gescande handtekening voor gebruik op afgedrukte analyseresultaatrapporten. De ideale grootte is 250 pixels breed bij 150 pixels hoog"
+msgstr ""
 
 #: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
-msgstr "Upload bestanden en afbeeldingen voor deze klant. Bestanden worden opgeslagen in de klantmap en kunnen later worden gedownload."
+msgstr ""
 
 #: bika/lims/content/analysisprofile.py:101
 msgid "Use Analysis Profile Price"
-msgstr "Analyseprofielprijs gebruiken"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
-msgstr "Dashboard als standaard startpagina gebruiken"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:84
 msgid "Use Template"
-msgstr "Sjabloon gebruiken"
+msgstr ""
 
 #: bika/lims/content/analysisservice.py:87
 msgid "Use the Default Calculation of Method"
-msgstr "De standaardberekening van de methode gebruiken"
+msgstr ""
 
 #: bika/lims/content/instrument.py:292
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
-msgstr "Gebruik dit veld om willekeurige parameters door te geven aan de export-/importmodules."
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:71
 #: senaite/core/browser/clients/client/contacts/view.py:74
 #: senaite/core/browser/controlpanel/contacts/view.py:62
 msgid "User Name"
-msgstr "Gebruikersnaam"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_labcontacts.py:101
 msgid "User groups"
-msgstr "Gebruikersgroepen"
+msgstr ""
 
 #: senaite/core/browser/user/userdatapanel.py:181
 msgid "User is linked to lab contact '${fullname}'"
-msgstr "Gebruiker is gekoppeld aan labcontactpersoon '${fullname}'"
+msgstr ""
 
 #: senaite/core/browser/user/userdatapanel.py:192
 msgid "User is linked to the contact '${fullname}'"
-msgstr "Gebruiker is gekoppeld aan contactpersoon '${fullname}'"
+msgstr ""
 
 #: senaite/core/browser/user/userdatapanel.py:189
 msgid "User is linked to the global contact '${fullname}'"
-msgstr "Gebruiker is gekoppeld aan de globale contactpersoon '${fullname}'"
+msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
-msgstr "Gebruiker gekoppeld aan deze contactpersoon"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_labcontacts.py:98
 msgid "User name"
-msgstr "Gebruikersnaam"
+msgstr ""
 
 #: senaite/core/content/resultsreport.py:105
 msgid "Username"
-msgstr "Gebruikersnaam"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-msgstr "Te weinig datapunten gebruiken is statistisch niet zinvol. Stel een aanvaardbaar minimumaantal resultaten in voordat QC-statistieken worden berekend en uitgezet"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
-msgstr "Btw"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
 #: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
-msgstr "Btw %"
+msgstr ""
 
 #: bika/lims/content/organisation.py:52
 msgid "VAT number"
-msgstr "Btw-nummer"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:223
 msgid "Valid"
-msgstr "Geldig"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:662
 #: bika/lims/content/instrumentcertification.py:126
 msgid "Valid from"
-msgstr "Geldig vanaf"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:663
 #: bika/lims/content/instrumentcertification.py:136
 msgid "Valid to"
-msgstr "Geldig tot"
+msgstr ""
 
 #: bika/lims/content/instrumentscheduledtask.py:122
 msgid "Validation"
-msgstr "Validatie"
+msgstr ""
 
 #: senaite/core/z3cform/error.py:32
 msgid "Validation failed."
-msgstr "Validatie mislukt."
+msgstr ""
 
 #: bika/lims/validators.py:346
 msgid "Validation failed: '${keyword}': duplicate keyword"
-msgstr "Validatie mislukt: '${keyword}': dubbel sleutelwoord"
+msgstr ""
 
 #: bika/lims/validators.py:365
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
-msgstr "Validatie mislukt: '${title}': Dit sleutelwoord is al in gebruik door dienst '${used_by}'"
+msgstr ""
 
 #: bika/lims/validators.py:354
 msgid "Validation failed: '${title}': duplicate title"
-msgstr "Validatie mislukt: '${title}': dubbele titel"
+msgstr ""
 
 #: bika/lims/validators.py:206
 msgid "Validation failed: '${value}' is not unique"
-msgstr "Validatie mislukt: '${value}' is niet uniek"
+msgstr ""
 
 #: bika/lims/validators.py:1465
 msgid "Validation failed: '{}' is not numeric"
-msgstr "Validatie mislukt: '{}' is niet numeriek"
+msgstr ""
 
 #: bika/lims/validators.py:624
 msgid "Validation failed: Bearing must be E/W"
-msgstr "Validatie mislukt: Peiling moet O/W zijn"
+msgstr ""
 
 #: bika/lims/validators.py:605
 msgid "Validation failed: Bearing must be N/S"
-msgstr "Validatie mislukt: Peiling moet N/Z zijn"
+msgstr ""
 
 #: bika/lims/validators.py:1350
 msgid "Validation failed: Could not import module '%s'"
-msgstr "Validatie mislukt: Kon module '%s' niet importeren"
+msgstr ""
 
 #: bika/lims/validators.py:966
 msgid "Validation failed: Error percentage must be between 0 and 100"
-msgstr "Validatie mislukt: Foutpercentage moet tussen 0 en 100 liggen"
+msgstr ""
 
 #: bika/lims/validators.py:982
 msgid "Validation failed: Error value must be 0 or greater"
-msgstr "Validatie mislukt: Foutwaarde moet 0 of groter zijn"
+msgstr ""
 
 #: bika/lims/validators.py:959
 msgid "Validation failed: Error values must be numeric"
-msgstr "Validatie mislukt: Foutwaarden moeten numeriek zijn"
+msgstr ""
 
 #: bika/lims/validators.py:499
 msgid "Validation failed: Keyword '${keyword}' is invalid"
-msgstr "Validatie mislukt: Sleutelwoord '${keyword}' is ongeldig"
+msgstr ""
 
 #: bika/lims/validators.py:974
 msgid "Validation failed: Max values must be greater than Min values"
-msgstr "Validatie mislukt: Max-waarden moeten groter zijn dan Min-waarden"
+msgstr ""
 
 #: bika/lims/validators.py:944
 msgid "Validation failed: Max values must be numeric"
-msgstr "Validatie mislukt: Max-waarden moeten numeriek zijn"
+msgstr ""
 
 #: bika/lims/validators.py:937
 msgid "Validation failed: Min values must be numeric"
-msgstr "Validatie mislukt: Min-waarden moeten numeriek zijn"
+msgstr ""
 
 #: bika/lims/validators.py:1451
 msgid "Validation failed: Please set a default value when defining a required checkbox condition."
-msgstr "Validatie mislukt: Stel een standaardwaarde in bij het definiëren van een verplichte selectievakjevoorwaarde."
+msgstr ""
 
 #: bika/lims/validators.py:1445
 msgid "Validation failed: Please use the character '|' to separate the available options in 'Choices' subfield"
-msgstr "Validatie mislukt: Gebruik het teken '|' om de beschikbare opties in het subveld 'Keuzes' te scheiden"
+msgstr ""
 
 #: bika/lims/validators.py:770
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
-msgstr "Validatie mislukt: Voorgeconserveerde containers moeten een conservering geselecteerd hebben."
+msgstr ""
 
 #: bika/lims/validators.py:728
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
-msgstr "Validatie mislukt: De selectie vereist dat de volgende categorieën worden geselecteerd: ${categories}"
+msgstr ""
 
 #: bika/lims/validators.py:1014
 msgid "Validation failed: Values must be numbers"
-msgstr "Validatie mislukt: Waarden moeten getallen zijn"
+msgstr ""
 
 #: bika/lims/validators.py:393
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
-msgstr "Validatie mislukt: kolomtitel '${title}' moet sleutelwoord '${keyword}' hebben"
+msgstr ""
 
 #: bika/lims/validators.py:615
 msgid "Validation failed: degrees is 180; minutes must be zero"
-msgstr "Validatie mislukt: graden is 180; minuten moeten nul zijn"
+msgstr ""
 
 #: bika/lims/validators.py:620
 msgid "Validation failed: degrees is 180; seconds must be zero"
-msgstr "Validatie mislukt: graden is 180; seconden moeten nul zijn"
+msgstr ""
 
 #: bika/lims/validators.py:596
 msgid "Validation failed: degrees is 90; minutes must be zero"
-msgstr "Validatie mislukt: graden is 90; minuten moeten nul zijn"
+msgstr ""
 
 #: bika/lims/validators.py:601
 msgid "Validation failed: degrees is 90; seconds must be zero"
-msgstr "Validatie mislukt: graden is 90; seconden moeten nul zijn"
+msgstr ""
 
 #: bika/lims/validators.py:610
 msgid "Validation failed: degrees must be 0 - 180"
-msgstr "Validatie mislukt: graden moeten 0 - 180 zijn"
+msgstr ""
 
 #: bika/lims/validators.py:591
 msgid "Validation failed: degrees must be 0 - 90"
-msgstr "Validatie mislukt: graden moeten 0 - 90 zijn"
+msgstr ""
 
 #: bika/lims/validators.py:564
 msgid "Validation failed: degrees must be numeric"
-msgstr "Validatie mislukt: graden moeten numeriek zijn"
+msgstr ""
 
 #: bika/lims/validators.py:405
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
-msgstr "Validatie mislukt: sleutelwoord '${keyword}' moet kolomtitel '${title}' hebben"
+msgstr ""
 
 #: senaite/core/api/analysisservice.py:172
 msgid "Validation failed: keyword contains invalid characters"
-msgstr "Validatie mislukt: sleutelwoord bevat ongeldige tekens"
+msgstr ""
 
 #: senaite/core/api/analysisservice.py:177
 msgid "Validation failed: keyword is already in use"
-msgstr "Validatie mislukt: sleutelwoord is al in gebruik"
+msgstr ""
 
 #: senaite/core/api/analysisservice.py:187
 msgid "Validation failed: keyword is already in use by calculation '{}'"
-msgstr "Validatie mislukt: sleutelwoord is al in gebruik door berekening '{}'"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:95
 #: bika/lims/validators.py:324
 msgid "Validation failed: keyword is required"
-msgstr "Validatie mislukt: sleutelwoord is verplicht"
+msgstr ""
 
 #: bika/lims/validators.py:580
 msgid "Validation failed: minutes must be 0 - 59"
-msgstr "Validatie mislukt: minuten moeten 0 - 59 zijn"
+msgstr ""
 
 #: bika/lims/validators.py:570
 msgid "Validation failed: minutes must be numeric"
-msgstr "Validatie mislukt: minuten moeten numeriek zijn"
+msgstr ""
 
 #: bika/lims/validators.py:1042
 msgid "Validation failed: percent values must be between 0 and 100"
-msgstr "Validatie mislukt: procentwaarden moeten tussen 0 en 100 liggen"
+msgstr ""
 
 #: bika/lims/validators.py:1038
 msgid "Validation failed: percent values must be numbers"
-msgstr "Validatie mislukt: procentwaarden moeten getallen zijn"
+msgstr ""
 
 #: bika/lims/validators.py:584
 msgid "Validation failed: seconds must be 0 - 59"
-msgstr "Validatie mislukt: seconden moeten 0 - 59 zijn"
+msgstr ""
 
 #: bika/lims/validators.py:576
 msgid "Validation failed: seconds must be numeric"
-msgstr "Validatie mislukt: seconden moeten numeriek zijn"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:88
 #: bika/lims/validators.py:320
 msgid "Validation failed: title is required"
-msgstr "Validatie mislukt: titel is verplicht"
+msgstr ""
 
 #: bika/lims/validators.py:1456
 msgid "Validation failed: value for Choices subfield is only required for when the control type of choice is 'Select'"
-msgstr "Validatie mislukt: waarde voor subveld Keuzes is alleen vereist wanneer het besturingstype van de keuze 'Select' is"
+msgstr ""
 
 #: bika/lims/validators.py:1438
 msgid "Validation failed: value for Choices subfield is required when the control type of choice is 'Select'"
-msgstr "Validatie mislukt: waarde voor subveld Keuzes is vereist wanneer het besturingstype van de keuze 'Select' is"
+msgstr ""
 
 #: senaite/core/content/analysiscategory.py:122
 #: senaite/core/content/subgroup.py:82
 msgid "Validation failed: value must be between 0 and 1000"
-msgstr "Validatie mislukt: waarde moet tussen 0 en 1000 liggen"
+msgstr ""
 
 #: senaite/core/content/analysiscategory.py:118
 #: senaite/core/content/subgroup.py:78
 msgid "Validation failed: value must be float"
-msgstr "Validatie mislukt: waarde moet een decimaal getal zijn"
+msgstr ""
 
 #: bika/lims/content/instrumentvalidation.py:51
 msgid "Validation report date"
-msgstr "Datum validatierapport"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Validations"
-msgstr "Validaties"
+msgstr ""
 
 #: bika/lims/browser/instrument.py:318
 #: bika/lims/content/instrumentvalidation.py:78
 msgid "Validator"
-msgstr "Validator"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:206
 msgid "Value"
-msgstr "Waarde"
+msgstr ""
 
 #: senaite/core/schema/coordinatefield.py:109
 msgid "Value for degrees must be within 0 and 180"
-msgstr "Waarde voor graden moet tussen 0 en 180 liggen"
+msgstr ""
 
 #: senaite/core/schema/coordinatefield.py:93
 msgid "Value for degrees must be within 0 and 90"
-msgstr "Waarde voor graden moet tussen 0 en 90 liggen"
+msgstr ""
 
 #: senaite/core/schema/coordinatefield.py:68
 msgid "Value for minutes must be within 0 and 59"
-msgstr "Waarde voor minuten moet tussen 0 en 59 liggen"
+msgstr ""
 
 #: senaite/core/schema/coordinatefield.py:77
 msgid "Value for seconds must be within 0 and 59.9999"
-msgstr "Waarde voor seconden moet tussen 0 en 59.9999 liggen"
+msgstr ""
 
 #: bika/lims/content/abstractanalysis.py:183
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
-msgstr "Hier kunnen waarden worden ingevoerd die de standaardwaarden overschrijven die zijn opgegeven in de tussenvelden van de berekening."
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:149
 #: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
-msgstr "Geverifieerd"
+msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:133
 msgid "Verified By"
-msgstr "Geverifieerd door"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:428
 msgid "Verified samples ready to be published"
-msgstr "Geverifieerde monsters klaar om te publiceren"
+msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
-msgstr "Verifiëren"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:109
 msgid "Verify Results"
-msgstr "Resultaten verifiëren"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
 #: bika/lims/controlpanel/auditlog.py:72
 msgid "Version"
-msgstr "Versie"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "View"
-msgstr "Weergeven"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
-msgstr "Bekijk uw SENAITE-site"
+msgstr ""
 
 # senaite.app.listing: Column config — visible-section header
 msgid "Visible"
-msgstr "Zichtbaar"
+msgstr ""
 
 # senaite.app.listing: Column config — counter title attribute
 msgid "Visible / total columns"
-msgstr "Zichtbare / totale kolommen"
+msgstr ""
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
-msgstr "Zichtbare velden"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:24
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:24
 msgid "Visit the Dynamic Specification for additional information:"
-msgstr "Bezoek de dynamische specificatie voor aanvullende informatie:"
+msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:28
 msgid "Visit the Specification's changes history for additional information:"
-msgstr "Bezoek de wijzigingsgeschiedenis van de specificatie voor aanvullende informatie:"
+msgstr ""
 
 #: bika/lims/content/labproduct.py:36
 msgid "Volume"
-msgstr "Volume"
+msgstr ""
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:17
 msgid "Warning"
-msgstr "Waarschuwing"
+msgstr ""
 
 #: bika/lims/content/laboratory.py:132
 msgid "Web address for the accreditation body"
-msgstr "Webadres van de accreditatie-instantie"
+msgstr ""
 
 #: bika/lims/content/supplier.py:52
 msgid "Website"
-msgstr "Website"
+msgstr ""
 
 #: senaite/core/vocabularies/setup.py:158
 msgid "Wednesday"
-msgstr "Woensdag"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:136
 msgid "Weekly"
-msgstr "Wekelijks"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
-msgstr "Weken tot vervaldatum"
+msgstr ""
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:7
 msgid "Welcome"
-msgstr "Welkom"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:14
 msgid "Welcome to SENAITE"
-msgstr "Welkom bij SENAITE"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-msgstr "Indien ingeschakeld hebben analisten alleen toegang tot werkbladen waaraan ze zijn toegewezen. Indien uitgeschakeld hebben analisten toegang tot alle werkbladen."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-msgstr "Indien ingeschakeld kunnen alleen labmanagers werkbladen aanmaken en beheren. Indien uitgeschakeld kunnen ook analisten en labmedewerkers werkbladen beheren. Let op: Deze instelling wordt automatisch ingeschakeld en vergrendeld wanneer de toegang tot werkbladen is beperkt tot toegewezen analisten."
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-msgstr "Indien ingeschakeld wordt het monster automatisch geverifieerd zodra alle resultaten zijn geverifieerd. Anders moeten gebruikers met voldoende rechten het monster daarna handmatig verifiëren. Standaard: ingeschakeld"
+msgstr ""
 
 #: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-msgstr "Indien ingeschakeld kunnen gebruikers resultaten indienen voor analyses die niet aan hen zijn toegewezen of voor niet-toegewezen analyses. Indien uitgeschakeld kunnen gebruikers alleen resultaten indienen voor analyses die aan henzelf zijn toegewezen. Deze instelling geldt niet voor gebruikers met de rol Labmanager."
+msgstr ""
 
 #: bika/lims/content/analysisprofile.py:102
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
-msgstr "Wanneer dit is ingesteld, gebruikt het systeem de prijs van het analyseprofiel voor de offerte en wordt de btw van het systeem overschreven door de specifieke btw van het analyseprofiel"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:480
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
-msgstr "Wanneer de resultaten van duplicaatanalyses op werkbladen, uitgevoerd op hetzelfde monster, meer dan dit percentage verschillen, wordt een waarschuwing gegeven"
+msgstr ""
 
 #: bika/lims/validators.py:518
 msgid "Wildcards for interims are not allowed: ${wildcards}"
-msgstr "Jokertekens voor tussenvelden zijn niet toegestaan: ${wildcards}"
+msgstr ""
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:20
 msgid "With best regards"
-msgstr "Met vriendelijke groet"
+msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:118
 #: bika/lims/content/instrumentmaintenancetask.py:103
 #: bika/lims/content/instrumentvalidation.py:100
 msgid "Work Performed"
-msgstr "Uitgevoerd werk"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:94
 #: bika/lims/controlpanel/auditlog.py:99
 msgid "Workflow State"
-msgstr "Workflowstatus"
+msgstr ""
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Worksheet"
-msgstr "Werkblad"
+msgstr ""
 
 #: bika/lims/content/worksheettemplate.py:62
 msgid "Worksheet Layout"
-msgstr "Werkbladindeling"
+msgstr ""
 
 #: senaite/core/profiles/default/types/WorksheetTemplate.xml
 msgid "Worksheet Template"
-msgstr "Werkbladsjabloon"
+msgstr ""
 
 #: senaite/core/profiles/default/types/WorksheetTemplates.xml
 msgid "Worksheet Templates"
-msgstr "Werkbladsjablonen"
+msgstr ""
 
 #: senaite/core/registry/schema.py:109
 msgid "Worksheet printing templates order"
-msgstr "Volgorde van werkbladafdruksjablonen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
-msgstr "Werkbladen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:531
 msgid "Worksheets that have been verified"
-msgstr "Werkbladen die zijn geverifieerd"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:526
 msgid "Worksheets whose results are awaiting verification"
-msgstr "Werkbladen waarvan de resultaten op verificatie wachten"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
-msgstr "Verkeerde IBAN-lengte met %s: %s"
+msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
-msgstr "Verkeerde IBAN-lengte met %s: %ste kort met %i"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:140
 msgid "Yearly"
-msgstr "Jaarlijks"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
 msgid "Yes"
-msgstr "Ja"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:124
 msgid "You can add another SENAITE site:"
-msgstr "U kunt nog een SENAITE-site toevoegen:"
+msgstr ""
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:109
 msgid "You can change the visibility of a field by selecting or unselecting the checkbox."
-msgstr "U kunt de zichtbaarheid van een veld wijzigen door het selectievakje aan of uit te vinken."
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:17
 msgid "You can enable the global Audit Log again in the <a href=\"${DYNAMIC_CONTENT}\">Setup</a>"
-msgstr "U kunt het globale auditlogboek opnieuw inschakelen in de <a href=\"${DYNAMIC_CONTENT}\">Instellingen</a>"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:294
 msgid "You can use the browse button to select and upload a new attachment."
-msgstr "U kunt de bladerknop gebruiken om een nieuwe bijlage te selecteren en te uploaden."
+msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:42
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
-msgstr "U hebt onvoldoende rechten om het werkblad ${worksheet_title} te bekijken."
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:78
 msgid "You have multiple SENAITE sites:"
-msgstr "U hebt meerdere SENAITE-sites:"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/export.py:33
 msgid "You must select an instrument"
-msgstr "U moet een instrument selecteren"
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:159
 msgid "You normally don't need to change anything here unless you have specific reasons and know what you are doing."
-msgstr "Normaal gesproken hoeft u hier niets te wijzigen, tenzij u specifieke redenen hebt en weet wat u doet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/sysmex/xs/i500.py:77
 msgid "You should introduce a default result key."
-msgstr "U moet een standaard resultaatsleutel invoeren."
+msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:121
 msgid "Your SENAITE site has not been added yet:"
-msgstr "Uw SENAITE-site is nog niet toegevoegd:"
+msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:134
 msgid "activate"
-msgstr "activeren"
+msgstr ""
 
 #. Default: "Classic"
 #: senaite/core/config/worksheet.py:25
 msgid "analyses_classic_view_name"
-msgstr "Klassiek"
+msgstr ""
 
 #. Default: "Transposed"
 #: senaite/core/config/worksheet.py:29
 msgid "analyses_transposed_view_name"
-msgstr "Getransponeerd"
+msgstr ""
 
 #. Default: "Analysis"
 #: senaite/core/config/vocabularies.py:35
 msgid "analysis_type_analysis"
-msgstr "Analyse"
+msgstr ""
 
 #. Default: "Blank"
 #: senaite/core/config/vocabularies.py:39
 msgid "analysis_type_blank"
-msgstr "Blanco"
+msgstr ""
 
 #. Default: "Control"
 #: senaite/core/config/vocabularies.py:43
 msgid "analysis_type_control"
-msgstr "Controle"
+msgstr ""
 
 #. Default: "Duplicate"
 #: senaite/core/config/vocabularies.py:47
 msgid "analysis_type_duplicate"
-msgstr "Duplicaat"
+msgstr ""
 
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
-msgstr "Analist moet worden opgegeven."
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — micro-tag on the default preset
 msgid "auto"
-msgstr "auto"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
-msgstr "halfjaarlijks"
+msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:48
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:48
 msgid "by"
-msgstr "door"
+msgstr ""
 
 #. in '${calc}')"
 #. Default: "keyword '${keyword}' must have column title '${title}' (defined in '${calc}')"
 #: senaite/core/validators/interimfields.py:151
-#, fuzzy
 msgid "calcs_interims_validator_dup_keyword_error"
-msgstr "sleutelwoord '${keyword}' moet kolomtitel '${title}' hebben (gedefinieerd in '${calc}')"
+msgstr ""
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:57
 msgid "change_worksheet_result_layout_message"
-msgstr "Wijzigingen opgeslagen."
+msgstr ""
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:168
 msgid "changes_saved"
-msgstr "Wijzigingen opgeslagen."
+msgstr ""
 
 #. Results edition not allowed: ${inv}"
 #. Default: "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed: ${inv}"
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:214
-#, fuzzy
 msgid "check_instrument_validity_message"
-msgstr "Sommige analyses gebruiken verouderde of niet-gekalibreerde instrumenten. Bewerken van resultaten niet toegestaan: ${inv}"
+msgstr ""
 
 #. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #. Default: "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #: senaite/core/validators/interimfields.py:211
-#, fuzzy
 msgid "choice_syntax_validation_error"
-msgstr "Geen geldig formaat in het keuzeveld. Ondersteund formaat is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
+msgstr ""
 
 #. Default: "Control type is not supported for empty choices"
 #: senaite/core/validators/interimfields.py:111
 msgid "choices_and_restype_validator_no_choices_error"
-msgstr "Besturingstype wordt niet ondersteund voor lege keuzes"
+msgstr ""
 
 #. Default: "Chosen control type not supporting choices"
 #: senaite/core/validators/interimfields.py:117
 msgid "choices_and_restype_validator_not_supported_choices_error"
-msgstr "Gekozen besturingstype ondersteunt geen keuzes"
+msgstr ""
 
 #. Default: "Empty keys are not supported"
 #: senaite/core/validators/interimfields.py:169
 msgid "choices_empty_keys_validator_error"
-msgstr "Lege sleutels worden niet ondersteund"
+msgstr ""
 
 #. Default: "At least, two options for choices field are required"
 #: senaite/core/validators/interimfields.py:195
 msgid "choices_min_items_validator_error"
-msgstr "Ten minste twee opties voor het keuzeveld zijn vereist"
+msgstr ""
 
 #. Default: "Duplicate keys in choices field"
 #: senaite/core/validators/interimfields.py:183
 msgid "choices_unique_keys_validator_error"
-msgstr "Dubbele sleutels in het keuzeveld"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:250
 msgid "daily"
-msgstr "dagelijks"
+msgstr ""
 
 #. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -7279,7 +7276,7 @@ msgstr "dagelijks"
 #. ${b} ${d}, ${Y} ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "date_format_long"
-msgstr "${d}-${m}-${Y} ${H}:${M}"
+msgstr ""
 
 #. Default: "${Y}-${m}-${d}"
 #. The variables used here are the same as used in the strftime formating.
@@ -7290,83 +7287,80 @@ msgstr "${d}-${m}-${Y} ${H}:${M}"
 #. ${b} ${d}, ${Y}
 #: ./TranslationServiceTool.py
 msgid "date_format_short"
-msgstr "${d}-${m}-${Y}"
+msgstr ""
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "yy-mm-dd"
-#, fuzzy
+#. Default: "mm/dd/yy"
 msgid "date_format_short_datepicker"
-msgstr "dd-mm-jj"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "days"
-msgstr "dagen"
+msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:127
 msgid "deactivate"
-msgstr "deactiveren"
+msgstr ""
 
 #. Default: "Sample disposed after the retention period."
 #: senaite/core/browser/samples/templates/dispose_samples.pt:66
 msgid "default_dispose_reason"
-msgstr "Monster afgevoerd na de bewaartermijn."
+msgstr ""
 
 #: senaite/core/api/remarks.py:485
 msgid "deleted by {user} at {time}"
-msgstr "verwijderd door {user} op {time}"
+msgstr ""
 
 #. Default: "Attached labels"
 #: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
-msgstr "Toegevoegde labels"
+msgstr ""
 
 #. Default: "The accreditation standard that applies, e.g. ISO 17025"
 #: senaite/core/content/laboratory.py:174
 msgid "description_accreditation"
-msgstr "De van toepassing zijnde accreditatienorm, bijv. ISO 17025"
+msgstr ""
 
 #. Default: "E.g. SANAS, APLAC, etc."
 #: senaite/core/content/laboratory.py:153
 msgid "description_accreditation_body"
-msgstr "Bijv. SANAS, APLAC, enz."
+msgstr ""
 
 #. and results reports by your accreditation body. Maximum size is 175 x 175
 #. pixels."
 #. Default: "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 #: senaite/core/content/laboratory.py:198
-#, fuzzy
 msgid "description_accreditation_body_logo"
-msgstr "Upload het logo dat u door uw accreditatie-instantie gemachtigd bent te gebruiken op uw website en resultaatrapporten. Maximale grootte is 175 x 175 pixels."
+msgstr ""
 
 #. Default: "Web address for the accreditation body"
 #: senaite/core/content/laboratory.py:163
 msgid "description_accreditation_body_url"
-msgstr "Webadres van de accreditatie-instantie"
+msgstr ""
 
 #. following fields are available: lab_is_accredited, lab_name, lab_country,
 #. confidence, accreditation_body_name, accreditation_standard,
 #. accreditation_reference"
 #. Default: "Enter the details of your lab's service accreditations here. The following fields are available: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 #: senaite/core/content/laboratory.py:220
-#, fuzzy
 msgid "description_accreditation_page_header"
-msgstr "Voer hier de gegevens van de dienstaccreditaties van uw lab in. De volgende velden zijn beschikbaar: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
+msgstr ""
 
 #. Default: "The reference code issued to the lab by the accreditation body"
 #: senaite/core/content/laboratory.py:186
 msgid "description_accreditation_reference"
-msgstr "De referentiecode die door de accreditatie-instantie aan het lab is toegekend"
+msgstr ""
 
 #. Default: "The category the analysis service belongs to"
 #: bika/lims/content/abstractbaseanalysis.py:533
 msgid "description_analysis_category"
-msgstr "De categorie waartoe de analysedienst behoort"
+msgstr ""
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/abstractbaseanalysis.py:591
 msgid "description_analysis_department"
-msgstr "Selecteer de verantwoordelijke afdeling"
+msgstr ""
 
 #. registration form if the elapsed time since sample collection exceeds the
 #. holding time limit. Exceeding this time limit may result in unreliable or
@@ -7377,18 +7371,16 @@ msgstr "Selecteer de verantwoordelijke afdeling"
 #. view."
 #. Default: "This service will not appear for selection on the sample registration form if the elapsed time since sample collection exceeds the holding time limit. Exceeding this time limit may result in unreliable or compromised data, as the integrity of the sample can degrade over time. Consequently, any results obtained after this period may not accurately reflect the sample's true composition, impacting data validity. Note: This setting does not affect the test's availability in the 'Manage Analyses' view."
 #: bika/lims/content/abstractbaseanalysis.py:457
-#, fuzzy
 msgid "description_analysis_maxholdingtime"
-msgstr "Deze dienst verschijnt niet ter selectie op het monsterregistratieformulier als de verstreken tijd sinds de monstername de bewaartijdlimiet overschrijdt. Overschrijding van deze tijdslimiet kan leiden tot onbetrouwbare of gecompromitteerde gegevens, aangezien de integriteit van het monster in de loop van de tijd kan afnemen. Bijgevolg weerspiegelen resultaten die na deze periode worden verkregen mogelijk niet de werkelijke samenstelling van het monster, wat de geldigheid van de gegevens beïnvloedt. Let op: Deze instelling heeft geen invloed op de beschikbaarheid van de test in de weergave 'Analyses beheren'."
+msgstr ""
 
 #. in results entry listings. Note this only applies to the options displayed
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
 #: bika/lims/content/abstractbaseanalysis.py:773
-#, fuzzy
 msgid "description_analysis_results_options_sorting"
-msgstr "Criteria die worden gebruikt wanneer resultaatopties ter selectie worden weergegeven in lijsten voor resultaatinvoer. Let op: dit geldt alleen voor de opties die in de selectielijst worden weergegeven. Het heeft geen effect op de volgorde waarin resultaten worden weergegeven nadat ze zijn ingediend"
+msgstr ""
 
 #. in a range with minimum of 0 and maximum of 10, where the uncertainty value
 #. is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also
@@ -7402,64 +7394,58 @@ msgstr "Criteria die worden gebruikt wanneer resultaatopties ter selectie worden
 #. 20.00, 20.01 - 30.00 etc."
 #. Default: "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2%, a result of 100 will be reported as 100 ± 2.<br/>If you don't want uncertainty to be displayed for a given range, set 0 (or a value below 0) as the Uncertainty value.<br/>Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30.00 etc."
 #: bika/lims/content/abstractbaseanalysis.py:630
-#, fuzzy
 msgid "description_analysis_uncertainty"
-msgstr "Geef de onzekerheidswaarde op voor een bepaald bereik, bijv. voor resultaten in een bereik met een minimum van 0 en een maximum van 10, waar de onzekerheidswaarde 0,5 is - een resultaat van 6,67 wordt gerapporteerd als 6,67 ± 0,5.<br/>U kunt de onzekerheidswaarde ook opgeven als een percentage van de resultaatwaarde, door een '%' toe te voegen aan de waarde die is ingevoerd in de kolom 'Onzekerheidswaarde', bijv. voor resultaten in een bereik met een minimum van 10,01 en een maximum van 100, waar de onzekerheidswaarde 2% is, wordt een resultaat van 100 gerapporteerd als 100 ± 2.<br/>Als u niet wilt dat de onzekerheid voor een bepaald bereik wordt weergegeven, stel dan 0 (of een waarde onder 0) in als onzekerheidswaarde.<br/>Zorg ervoor dat opeenvolgende bereiken continu zijn, bijv. 0,00 - 10,00 wordt gevolgd door 10,01 - 20,00, 20,01 - 30,00 enz."
+msgstr ""
 
 #. mg/l, ppm, dB, mV, etc."
 #. Default: "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 #: bika/lims/content/abstractbaseanalysis.py:112
-#, fuzzy
 msgid "description_analysis_unit"
-msgstr "De meeteenheden voor de resultaten van deze analysedienst, bijv. mg/l, ppm, dB, mV, enz."
+msgstr ""
 
 #. Ensure to include the default unit in this list"
 #. Default: "Provide a list of units that are suitable for the analysis. Ensure to include the default unit in this list"
 #: bika/lims/content/abstractbaseanalysis.py:162
-#, fuzzy
 msgid "description_analysis_unitchoices"
-msgstr "Geef een lijst met eenheden op die geschikt zijn voor de analyse. Zorg ervoor dat u de standaardeenheid in deze lijst opneemt"
+msgstr ""
 
 #. reports."
 #. Default: "To be displayed below each Analysis Category section on results reports."
 #: senaite/core/content/analysiscategory.py:64
-#, fuzzy
 msgid "description_analysiscategory_comments"
-msgstr "Weer te geven onder elke sectie Analysecategorie op resultaatrapporten."
+msgstr ""
 
 #. Default: "Select the responsible department"
 #: senaite/core/content/analysiscategory.py:85
 msgid "description_analysiscategory_department"
-msgstr "Selecteer de verantwoordelijke afdeling"
+msgstr ""
 
 #. Duplicate values are ordered alphabetically."
 #. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 #: senaite/core/content/analysiscategory.py:99
-#, fuzzy
 msgid "description_analysiscategory_sort_key"
-msgstr "Decimale waarde van 0,0 - 1000,0 die de sorteervolgorde aangeeft. Dubbele waarden worden alfabetisch geordend."
+msgstr ""
 
 #. Default: "Commercial ID used for accounting"
 #: senaite/core/content/analysisprofile.py:125
 msgid "description_analysisprofile_commercial_id"
-msgstr "Commerciële ID gebruikt voor boekhouding"
+msgstr ""
 
 #. Default: "Please provide a unique profile keyword"
 #: senaite/core/content/analysisprofile.py:94
 msgid "description_analysisprofile_profile_key"
-msgstr "Geef een uniek profielsleutelwoord op"
+msgstr ""
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/analysisprofile.py:149
 msgid "description_analysisprofile_profile_price"
-msgstr "Geef de prijs exclusief btw op"
+msgstr ""
 
 #. price"
 #. Default: "Please provide the VAT in percent that is added to the profile price"
 #: senaite/core/content/analysisprofile.py:161
-#, fuzzy
 msgid "description_analysisprofile_profile_vat"
-msgstr "Geef de btw in procenten op die aan de profielprijs wordt toegevoegd"
+msgstr ""
 
 #. profile won't be available for selection in sample creation and edit forms
 #. unless the selected sample type is one of these. If no sample type is set
@@ -7467,29 +7453,28 @@ msgstr "Geef de btw in procenten op die aan de profielprijs wordt toegevoegd"
 #. the sample type of the sample."
 #. Default: "Sample types for which this analysis profile is supported. This profile won't be available for selection in sample creation and edit forms unless the selected sample type is one of these. If no sample type is set here, this profile will always be available for selection, regardless of the sample type of the sample."
 #: senaite/core/content/analysisprofile.py:184
-#, fuzzy
 msgid "description_analysisprofile_sampletypes"
-msgstr "Monstertypes waarvoor dit analyseprofiel wordt ondersteund. Dit profiel is niet beschikbaar ter selectie in formulieren voor het aanmaken en bewerken van monsters tenzij het geselecteerde monstertype een van deze is. Als hier geen monstertype is ingesteld, is dit profiel altijd beschikbaar ter selectie, ongeacht het monstertype van het monster."
+msgstr ""
 
 #. Default: "Select the included analyses for this profile"
 #: senaite/core/content/analysisprofile.py:110
 msgid "description_analysisprofile_services"
-msgstr "Selecteer de opgenomen analyses voor dit profiel"
+msgstr ""
 
 #. Default: "Use profile price instead of single analyses prices"
 #: senaite/core/content/analysisprofile.py:137
 msgid "description_analysisprofile_use_profile_price"
-msgstr "Profielprijs gebruiken in plaats van prijzen van afzonderlijke analyses"
+msgstr ""
 
 #. Default: "Number of samples to create with the information provided"
 #: bika/lims/content/analysisrequest.py:1441
 msgid "description_analysisrequest_numsamples"
-msgstr "Aantal aan te maken monsters met de opgegeven informatie"
+msgstr ""
 
 #. Default: "Link dynamic analysis specification"
 #: bika/lims/content/analysisspec.py:72
 msgid "description_analysisspec_dynamicspec"
-msgstr "Koppel dynamische analysespecificatie"
+msgstr ""
 
 #. outside this results range will raise an alert.<br/>'Min warn' and 'Max
 #. warn' values indicate a shoulder range. Any result outside the results
@@ -7500,115 +7485,108 @@ msgstr "Koppel dynamische analysespecificatie"
 #. results report as well"
 #. Default: "'Min' and 'Max' values indicate a valid results range. Any result outside this results range will raise an alert.<br/>'Min warn' and 'Max warn' values indicate a shoulder range. Any result outside the results range but within the shoulder range will raise a less severe alert.<br/>If the result is out of range, the value set for '&lt; Min' or '&gt; Max' will be displayed in lists and results reports instead of the real result. In such case, the value set for 'Out of range comment' will be displayed in results report as well"
 #: bika/lims/content/analysisspec.py:91
-#, fuzzy
 msgid "description_analysisspec_resultsrange"
-msgstr "'Min'- en 'Max'-waarden geven een geldig resultaatbereik aan. Elk resultaat buiten dit resultaatbereik geeft een waarschuwing.<br/>'Min waarsch'- en 'Max waarsch'-waarden geven een schouderbereik aan. Elk resultaat buiten het resultaatbereik maar binnen het schouderbereik geeft een minder ernstige waarschuwing.<br/>Als het resultaat buiten het bereik ligt, wordt de waarde die is ingesteld voor '&lt; Min' of '&gt; Max' weergegeven in lijsten en resultaatrapporten in plaats van het werkelijke resultaat. In dat geval wordt de waarde die is ingesteld voor 'Opmerking buiten bereik' ook weergegeven in het resultaatrapport"
+msgstr ""
 
 #. Default: "Select the sample type for this specification"
 #: bika/lims/content/analysisspec.py:52
 msgid "description_analysisspec_sampletype"
-msgstr "Selecteer het monstertype voor deze specificatie"
+msgstr ""
 
 #. Default: "Contained samples in the PDF"
 #: bika/lims/content/arreport.py:82
 msgid "description_arreport_contained_samples"
-msgstr "Opgenomen monsters in de PDF"
+msgstr ""
 
 #. Default: "The primary sample of the PDF"
 #: bika/lims/content/arreport.py:52
 msgid "description_arreport_sample"
-msgstr "Het primaire monster van de PDF"
+msgstr ""
 
 #. Default: "Select the analysis profile for this template"
 #: bika/lims/content/artemplate.py:257
 msgid "description_artemplate_profile"
-msgstr "Selecteer het analyseprofiel voor dit sjabloon"
+msgstr ""
 
 #. Default: "Select the sample point for this template"
 #: bika/lims/content/artemplate.py:58
 msgid "description_artemplate_samplepoint"
-msgstr "Selecteer het monsterpunt voor dit sjabloon"
+msgstr ""
 
 #. Default: "Select the sample type for this template"
 #: bika/lims/content/artemplate.py:89
 msgid "description_artemplate_sampletype"
-msgstr "Selecteer het monstertype voor dit sjabloon"
+msgstr ""
 
 #. Default: "Select the type of the attachment"
 #: bika/lims/content/attachment.py:64
 msgid "description_attachment_type"
-msgstr "Selecteer het type van de bijlage"
+msgstr ""
 
 #. Default: "Assign the instrument for this log"
 #: bika/lims/content/autoimportlog.py:53
 msgid "description_autoimportlog_instrument"
-msgstr "Wijs het instrument toe voor dit logboek"
+msgstr ""
 
 #. Default: "The date and time when the log was created"
 #: bika/lims/content/autoimportlog.py:90
 msgid "description_autoimportlog_logtime"
-msgstr "De datum en tijd waarop het logboek is aangemaakt"
+msgstr ""
 
 #. Default: "The logged results"
 #: bika/lims/content/autoimportlog.py:77
 msgid "description_autoimportlog_results"
-msgstr "De gelogde resultaten"
+msgstr ""
 
 #. Default: "Select the client of this batch"
 #: bika/lims/content/batch.py:81
 msgid "description_batch_client"
-msgstr "Selecteer de klant van deze batch"
+msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
 #: bika/lims/content/bikasetup.py:397
-#, fuzzy
 msgid "description_bikasetup_allow_manual_result_capture_date"
-msgstr "Als deze optie is geactiveerd, kan de vastlegdatum van het resultaat handmatig worden ingevoerd voor analyses"
+msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
 #: bika/lims/content/bikasetup.py:854
-#, fuzzy
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
-msgstr "Indien geselecteerd ontvangen de verantwoordelijke personen van alle betrokken labafdelingen publicatie-e-mails."
+msgstr ""
 
 #. Default: "Group analyses by category for samples"
 #: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
-msgstr "Analyses groeperen per categorie voor monsters"
+msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
 #: bika/lims/content/bikasetup.py:690
-#, fuzzy
 msgid "description_bikasetup_date_sampled_required"
-msgstr "Selecteer dit om het veld Datum bemonsterd verplicht te maken bij het aanmaken van monsters. Deze functionaliteit is alleen van kracht wanneer 'Monsternameworkflow' niet actief is"
+msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
 #: bika/lims/content/bikasetup.py:830
-#, fuzzy
 msgid "description_bikasetup_email_body_sample_publication"
-msgstr "Stel de standaard e-mailtekst in die wordt gebruikt bij het verzenden van resultaatrapporten naar de geselecteerde ontvangers. U kunt gereserveerde sleutelwoorden gebruiken: $client_name, $recipients, $lab_name, $lab_address"
+msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
 #: bika/lims/content/bikasetup.py:806
-#, fuzzy
 msgid "description_bikasetup_email_from_sample_publication"
-msgstr "E-mail die als 'Van'-adres wordt gebruikt voor uitgaande e-mails bij het publiceren van resultaatrapporten. Dit adres overschrijft de waarde die is ingesteld bij de 'Mailinstellingen' van het portaal."
+msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
 #: bika/lims/content/bikasetup.py:444
-#, fuzzy
 msgid "description_bikasetup_immediateresultsentry"
-msgstr "Sta de gebruiker toe om direct resultaten in te voeren na het aanmaken van monsters, bijv. om veldresultaten onmiddellijk in te voeren, of labresultaten, wanneer de automatische monsterontvangst is geactiveerd."
+msgstr ""
 
 #. sent to primary contacts and laboratory managers when a sample is
 #. invalidated. The following placeholders are supported: <code title='The ID
@@ -7619,27 +7597,25 @@ msgstr "Sta de gebruiker toe om direct resultaten in te voeren na het aanmaken v
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
 #: bika/lims/content/bikasetup.py:947
-#, fuzzy
 msgid "description_bikasetup_invalidation_email_body"
-msgstr "Definieer het sjabloon voor de e-mailtekst die automatisch wordt verzonden naar primaire contactpersonen en laboratoriummanagers wanneer een monster ongeldig wordt verklaard. De volgende plaatshouders worden ondersteund: <code title='De ID van het monster'>$sample_id</code>, <code title='De ID van de hertest van het monster'>$retest_id</code>, <code title='De link naar de hertest'>$retest_link</code>, <code title='De reden(en) voor ongeldigverklaring'>$reason</code>, <code title='Het adres van het lab'>$lab_address</code>."
+msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
 #: bika/lims/content/bikasetup.py:914
-#, fuzzy
 msgid "description_bikasetup_invalidation_reason_required"
-msgstr "Geef aan of het opgeven van een reden verplicht is bij het ongeldig verklaren van een monster. Indien ingeschakeld wordt de plaatshouder '$reason' in de e-mailtekst van de meldingsmail voor ongeldigverklaring vervangen door de ingevoerde reden."
+msgstr ""
 
 #. Default: "Analyses are required for sample registration"
 #: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
-msgstr "Analyses zijn vereist voor monsterregistratie"
+msgstr ""
 
 #. Default: "Dependent services of this calculation"
 #: bika/lims/content/calculation.py:84
 msgid "description_calculation_dependentservices"
-msgstr "Afhankelijke diensten van deze berekening"
+msgstr ""
 
 #. dynamically calculated when an analysis using this calculation is
 #. displayed.</p><p>To enter a Calculation, use standard maths operators, + -
@@ -7650,9 +7626,8 @@ msgstr "Afhankelijke diensten van deze berekening"
 #. where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #. Default: "<p>The formula you type here will be dynamically calculated be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators, + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #: senaite/core/content/calculation.py:291
-#, fuzzy
 msgid "description_calculation_formula"
-msgstr "<p>De formule die u hier typt, wordt dynamisch berekend wanneer een analyse die deze berekening gebruikt wordt weergegeven.</p><p>Om een berekening in te voeren, gebruikt u standaard wiskundige operatoren, + - * / ( ), en alle beschikbare sleutelwoorden, zowel van andere analysediensten als de hier opgegeven tussenvelden, als variabelen. Zet ze tussen vierkante haken [ ].</p><p>Bijv. de berekening voor Totale hardheid, het totaal van calcium- (ppm) en magnesiumionen (ppm) in water, wordt ingevoerd als [Ca] + [Mg], waarbij Ca en Mg de sleutelwoorden zijn voor die twee analysediensten.</p>"
+msgstr ""
 
 #. library, you can import it here. E.g. if you want to use the 'floor'
 #. function from the Python 'math' module, you add 'math' to the Module field
@@ -7661,9 +7636,8 @@ msgstr "<p>De formule die u hier typt, wordt dynamisch berekend wanneer een anal
 #. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
-#, fuzzy
 msgid "description_calculation_imports"
-msgstr "Als uw formule een speciale functie uit een externe Python-bibliotheek nodig heeft, kunt u deze hier importeren. Bijv. als u de functie 'floor' uit de Python-module 'math' wilt gebruiken, voegt u 'math' toe aan het veld Module en 'floor' aan het veld functie. Het equivalent in Python zou 'from math import floor' zijn. In uw berekening zou u dan 'floor([Ca] + [Mg])' kunnen gebruiken."
+msgstr ""
 
 #. should your calculation require them. The field title specified here will
 #. be used as column headers and field descriptors where the interim fields
@@ -7672,104 +7646,99 @@ msgstr "Als uw formule een speciale functie uit een externe Python-bibliotheek n
 #. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
-#, fuzzy
 msgid "description_calculation_interims"
-msgstr "Definieer tussenvelden zoals vatmassa, verdunningsfactoren, mocht uw berekening deze nodig hebben. De hier opgegeven veldtitel wordt gebruikt als kolomkoppen en veldbeschrijvingen waar de tussenvelden worden weergegeven. Als 'Breed toepassen' is ingeschakeld, wordt het veld weergegeven in een selectievak bovenaan het werkblad, waardoor een specifieke waarde op alle bijbehorende velden op het blad kan worden toegepast."
+msgstr ""
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
 #. Default: "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
 #: senaite/core/content/calculation.py:321
-#, fuzzy
 msgid "description_calculation_test_params"
-msgstr "Om de berekening te testen, voert u hier waarden in voor alle berekeningsparameters. Dit omvat de hierboven gedefinieerde tussenvelden, evenals alle diensten waarvan deze berekening afhankelijk is om resultaten te berekenen."
+msgstr ""
 
 #. values."
 #. Default: "The result after the calculation has taken place with test values."
 #: senaite/core/content/calculation.py:345
-#, fuzzy
 msgid "description_calculation_test_result"
-msgstr "Het resultaat nadat de berekening met testwaarden heeft plaatsgevonden."
+msgstr ""
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/analysiscategory.py:62
 msgid "description_category_department"
-msgstr "Selecteer de verantwoordelijke afdeling"
+msgstr ""
 
 #. Default: "Always expand the selected categories"
 #: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
-msgstr "De geselecteerde categorieën altijd uitvouwen"
+msgstr ""
 
 #. Default: "Show only selected categories"
 #: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
-msgstr "Alleen geselecteerde categorieën tonen"
+msgstr ""
 
 #. Default: "This value is reported at the bottom of all published results"
 #: senaite/core/content/laboratory.py:127
 msgid "description_confidence_level"
-msgstr "Deze waarde wordt gerapporteerd onderaan alle gepubliceerde resultaten"
+msgstr ""
 
 #. Default: "Contacts in CC for new samples"
 #: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
-msgstr "Contactpersonen in CC voor nieuwe monsters"
+msgstr ""
 
 #. could be selected here."
 #. Default: "If this container is pre-preserved, then the preservation method could be selected here."
 #: bika/lims/content/container.py:100
-#, fuzzy
 msgid "description_container_preservation"
-msgstr "Als deze container voorgeconserveerd is, kan hier de conserveringsmethode worden geselecteerd."
+msgstr ""
 
 #. Default: "Select the type of this container"
 #: bika/lims/content/container.py:57
 msgid "description_container_type"
-msgstr "Selecteer het type van deze container"
+msgstr ""
 
 #. Default: "${copyright} 2017-${current_year} ${senaitelims}"
 #: senaite/core/browser/viewlets/templates/footer.pt:13
 msgid "description_copyright"
-msgstr "${copyright} 2017-${current_year} ${senaitelims}"
+msgstr ""
 
 #. Default: "Please provide a unique department identifier"
 #: senaite/core/content/department.py:80
 msgid "description_department_id"
-msgstr "Geef een unieke afdelingsidentificatie op"
+msgstr ""
 
 #. the 'lab contacts' setup item. Departmental managers are referenced on
 #. analysis results reports containing analyses by their department."
 #. Default: "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 #: senaite/core/content/department.py:106
-#, fuzzy
 msgid "description_department_manager"
-msgstr "Selecteer een manager uit het beschikbare personeel dat is geconfigureerd onder het instellingenitem 'labcontactpersonen'. Afdelingsmanagers worden vermeld op analyseresultaatrapporten die analyses van hun afdeling bevatten."
+msgstr ""
 
 #. Default: "Name of the department"
 #: senaite/core/content/department.py:52
 msgid "description_department_title"
-msgstr "Naam van de afdeling"
+msgstr ""
 
 #. Default: "Location where the instrument is installed"
 #: bika/lims/content/instrument.py:322
 msgid "description_instrument_instrumentlocation"
-msgstr "Locatie waar het instrument is geïnstalleerd"
+msgstr ""
 
 #. Default: "Select the type of this instrument"
 #: bika/lims/content/instrument.py:82
 msgid "description_instrument_instrumenttype"
-msgstr "Selecteer het type van dit instrument"
+msgstr ""
 
 #. Default: "Select the manufacturer of this instrument"
 #: bika/lims/content/instrument.py:102
 msgid "description_instrument_manufacturer"
-msgstr "Selecteer de fabrikant van dit instrument"
+msgstr ""
 
 #. Default: "Methods that are supported by this analytical instrument"
 #: bika/lims/content/instrument.py:174
 msgid "description_instrument_methods"
-msgstr "Methoden die door dit analytische instrument worden ondersteund"
+msgstr ""
 
 #. where the system should look for the results files while automatically
 #. importing results. Having a folder for each Instrument and inside that
@@ -7778,140 +7747,132 @@ msgstr "Methoden die door dit analytische instrument worden ondersteund"
 #. unique."
 #. Default: "For each interface of this instrument, you can define a folder where the system should look for the results files while automatically importing results. Having a folder for each Instrument and inside that folder creating different folders for each of its Interfaces can be a good approach. You can use Interface codes to be sure that folder names are unique."
 #: bika/lims/content/instrument.py:267
-#, fuzzy
 msgid "description_instrument_result_file_folder"
-msgstr "Voor elke interface van dit instrument kunt u een map definiëren waar het systeem naar de resultaatbestanden moet zoeken tijdens het automatisch importeren van resultaten. Een map voor elk instrument hebben en binnen die map verschillende mappen aanmaken voor elk van de interfaces kan een goede aanpak zijn. U kunt interfacecodes gebruiken om ervoor te zorgen dat mapnamen uniek zijn."
+msgstr ""
 
 #. Default: "Select the supplier of this instrument"
 #: bika/lims/content/instrument.py:122
 msgid "description_instrument_supplier"
-msgstr "Selecteer de leverancier van dit instrument"
+msgstr ""
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentcalibration.py:130
 msgid "description_instrumentcalibration_worker"
-msgstr "De persoon die de taak heeft uitgevoerd"
+msgstr ""
 
 #. Default: "The person at the supplier who prepared the certificat"
 #: bika/lims/content/instrumentcertification.py:149
 msgid "description_instrumentcertification_preparator"
-msgstr "De persoon bij de leverancier die het certificaat heeft opgesteld"
+msgstr ""
 
 #. Default: "The person at the supplier who approved the certificate"
 #: bika/lims/content/instrumentcertification.py:173
 msgid "description_instrumentcertification_validator"
-msgstr "De persoon bij de leverancier die het certificaat heeft goedgekeurd"
+msgstr ""
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentvalidation.py:112
 msgid "description_instrumentvalidation_worker"
-msgstr "De persoon die de taak heeft uitgevoerd"
+msgstr ""
 
 #. selected departments."
 #. Default: "Select a default department for this contact from one of the selected departments."
 #: bika/lims/content/labcontact.py:89
-#, fuzzy
 msgid "description_labcontact_default_department"
-msgstr "Selecteer een standaardafdeling voor deze contactpersoon uit een van de geselecteerde afdelingen."
+msgstr ""
 
 #. Default: "Assigned laboratory departments"
 #: bika/lims/content/labcontact.py:62
 msgid "description_labcontact_departments"
-msgstr "Toegewezen laboratoriumafdelingen"
+msgstr ""
 
 #. the default style."
 #. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
 #: senaite/core/content/label.py:72
-#, fuzzy
 msgid "description_label_color"
-msgstr "Hexkleurcode gebruikt voor de chip (bijv. #0d6efd). Laat leeg voor de standaardstijl."
+msgstr ""
 
 #. labeled content. The cascade runs in the same transaction as the save and
 #. may take a moment on large datasets."
 #. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
 #: senaite/core/content/label.py:45
-#, fuzzy
 msgid "description_label_title"
-msgstr "Het hernoemen van dit label herschrijft de opgeslagen naam op elke inhoud die momenteel is gelabeld. De cascade wordt uitgevoerd in dezelfde transactie als het opslaan en kan bij grote datasets even duren."
+msgstr ""
 
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
-msgstr "Vink dit vakje aan als uw laboratorium geaccrediteerd is"
+msgstr ""
 
 #. Default: "The Laboratory's web address"
 #: senaite/core/content/laboratory.py:101
 msgid "description_laboratory_lab_url"
-msgstr "Het webadres van het laboratorium"
+msgstr ""
 
 #. Default: "Supervisor of the Lab"
 #: bika/lims/content/laboratory.py:78
 msgid "description_laboratory_suervisor"
-msgstr "Supervisor van het lab"
+msgstr ""
 
 #. Default: "Supervisor of the Lab"
 #: senaite/core/content/laboratory.py:77
 msgid "description_laboratory_supervisor"
-msgstr "Supervisor van het lab"
+msgstr ""
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/labproduct.py:89
 msgid "description_labproduct_price"
-msgstr "Geef de prijs exclusief btw op"
+msgstr ""
 
 #. price"
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
-#, fuzzy
 msgid "description_labproduct_vat"
-msgstr "Geef de btw in procenten op die aan de labproductprijs wordt toegevoegd"
+msgstr ""
 
 #. nested and positioned as they appear on the site. Use the controls to hide,
 #. show or reorder each viewlet."
 #. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
-#, fuzzy
 msgid "description_manage_viewlets"
-msgstr "De viewletmanagers en hun viewlets worden ter plaatse getoond, genest en gepositioneerd zoals ze op de site verschijnen. Gebruik de bediening om elke viewlet te verbergen, tonen of herordenen."
+msgstr ""
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
 msgid "description_multifile_document_location"
-msgstr "Locatie waar de documentenset is opgeborgen"
+msgstr ""
 
 #. image, ...)"
 #. Default: "Type of document (e.g. user manual, instrument specifications, image, ...)"
 #: senaite/core/content/multifile.py:83
-#, fuzzy
 msgid "description_multifile_document_type"
-msgstr "Type document (bijv. gebruikershandleiding, instrumentspecificaties, afbeelding, ...)"
+msgstr ""
 
 #. Default: "File upload"
 #: senaite/core/content/multifile.py:51
 msgid "description_multifile_file"
-msgstr "Bestand uploaden"
+msgstr ""
 
 #. Default: "Greeting title eg. Mr, Mrs, Dr"
 #: senaite/core/content/person.py:71
 msgid "description_person_salutation"
-msgstr "Aanhef bijv. Dhr., Mevr., Dr."
+msgstr ""
 
 #. Default: "Reference sample values are zero or 'blank'"
 #: bika/lims/content/referencedefinition.py:77
 msgid "description_referencedefinition_blank"
-msgstr "Referentiemonsterwaarden zijn nul of 'blanco'"
+msgstr ""
 
 #. definition."
 #. Default: "Hazard categories that apply to samples of this reference definition."
 #: bika/lims/content/referencedefinition.py:106
-#, fuzzy
 msgid "description_referencedefinition_hazard_categories"
-msgstr "Gevarencategorieën die van toepassing zijn op monsters van deze referentiedefinitie."
+msgstr ""
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: bika/lims/content/referencedefinition.py:91
 msgid "description_referencedefinition_hazardous"
-msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
+msgstr ""
 
 #. category. Enter minimum and maximum values to indicate a valid results
 #. range. Any result outside this range will raise an alert. The % Error field
@@ -7921,67 +7882,61 @@ msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
 #. alert."
 #. Default: "Click on Analysis Categories to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 #: bika/lims/content/referencedefinition.py:55
-#, fuzzy
 msgid "description_referencedefinition_referencevalues"
-msgstr "Klik op Analysecategorieën om analysediensten in elke categorie te zien. Voer minimum- en maximumwaarden in om een geldig resultaatbereik aan te geven. Elk resultaat buiten dit bereik geeft een waarschuwing. Het veld % Fout maakt het mogelijk om een % onzekerheid in aanmerking te nemen bij het evalueren van resultaten ten opzichte van minimum- en maximumwaarden. Een resultaat buiten het bereik maar toch binnen het bereik als de % fout in aanmerking wordt genomen, geeft een minder ernstige waarschuwing."
+msgstr ""
 
 #. inherit from the reference definition."
 #. Default: "Hazard categories for this reference sample. Leave empty to inherit from the reference definition."
 #: bika/lims/content/referencesample.py:118
-#, fuzzy
 msgid "description_referencesample_hazard_categories"
-msgstr "Gevarencategorieën voor dit referentiemonster. Laat leeg om over te nemen van de referentiedefinitie."
+msgstr ""
 
 #. Default: "Select the manufacturer for this sample"
 #: bika/lims/content/referencesample.py:136
 msgid "description_referencesample_manufacturer"
-msgstr "Selecteer de fabrikant voor dit monster"
+msgstr ""
 
 #. Default: "Select the reference definition for this sample"
 #: bika/lims/content/referencesample.py:82
 msgid "description_referencesample_referencedefinition"
-msgstr "Selecteer de referentiedefinitie voor dit monster"
+msgstr ""
 
 #. the paste popup in the sample add form. Please note that the paste button
 #. will only show for the fields listed here."
 #. Default: "Add all field names that support to enter multiple values using the paste popup in the sample add form. Please note that the paste button will only show for the fields listed here."
 #: senaite/core/registry/schema.py:375
-#, fuzzy
 msgid "description_registry_allow_multi_paste"
-msgstr "Voeg alle veldnamen toe die het invoeren van meerdere waarden ondersteunen via de plakpop-up in het formulier voor het toevoegen van monsters. Let op: de plakknop wordt alleen weergegeven voor de hier vermelde velden."
+msgstr ""
 
 #. catalogs in which these portal types should be indexed, beyond the default
 #. catalogs. A restart is required for these changes to take effect."
 #. Default: "Define the relationship between portal types and the additional catalogs in which these portal types should be indexed, beyond the default catalogs. A restart is required for these changes to take effect."
 #: senaite/core/registry/schema.py:278
-#, fuzzy
 msgid "description_registry_catalog_mappings"
-msgstr "Definieer de relatie tussen portaaltypes en de aanvullende catalogi waarin deze portaaltypes moeten worden geïndexeerd, naast de standaardcatalogi. Een herstart is vereist om deze wijzigingen van kracht te laten worden."
+msgstr ""
 
 #. logs into the system, or when a client is selected from the client folder
 #. listing"
 #. Default: "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing"
 #: senaite/core/registry/schema.py:51
-#, fuzzy
 msgid "description_registry_client_landing_page"
-msgstr "Selecteer de standaard bestemmingspagina. Deze wordt gebruikt wanneer een klantgebruiker inlogt op het systeem, of wanneer een klant wordt geselecteerd uit de klantmaplijst"
+msgstr ""
 
 #. structure of the site via Generic Setup"
 #. Default: "List of portal types to be skipped when exporting the content structure of the site via Generic Setup"
 #: senaite/core/registry/schema.py:238
-#, fuzzy
 msgid "description_registry_generic_setup_skip_export_types"
-msgstr "Lijst van portaaltypes die moeten worden overgeslagen bij het exporteren van de inhoudsstructuur van de site via Generic Setup"
+msgstr ""
 
 #. Default: "Attach import file to all Worksheet assigned analyses"
 #: senaite/core/registry/schema.py:443
 msgid "description_registry_import_analysis_attach_attachment"
-msgstr "Importbestand koppelen aan alle aan het werkblad toegewezen analyses"
+msgstr ""
 
 #. Default: "Automatically submit analyses upon import"
 #: senaite/core/registry/schema.py:456
 msgid "description_registry_import_analysis_submit"
-msgstr "Analyses automatisch indienen bij import"
+msgstr ""
 
 #. in its own ZODB transaction with a per-sample retry on conflict. This
 #. reduces the chance that ID-counter or container contention aborts the whole
@@ -7989,200 +7944,192 @@ msgstr "Analyses automatisch indienen bij import"
 #. batch is created in a single transaction (legacy behaviour)."
 #. Default: "When enabled, each sample created from the add form is committed in its own ZODB transaction with a per-sample retry on conflict. This reduces the chance that ID-counter or container contention aborts the whole batch on instances with many concurrent users. When disabled, the whole batch is created in a single transaction (legacy behaviour)."
 #: senaite/core/registry/schema.py:391
-#, fuzzy
 msgid "description_registry_sample_add_commit_per_sample"
-msgstr "Indien ingeschakeld wordt elk monster dat via het toevoegformulier wordt aangemaakt vastgelegd in zijn eigen ZODB-transactie met een nieuwe poging per monster bij een conflict. Dit vermindert de kans dat conflicten om de ID-teller of container de hele batch afbreken op instanties met veel gelijktijdige gebruikers. Indien uitgeschakeld wordt de hele batch in één transactie aangemaakt (verouderd gedrag)."
+msgstr ""
 
 #. matching the source sample structure. Each partition will be created with
 #. the same configuration (sample type, container, preservation) and analyses
 #. as the source partition."
 #. Default: "When enabled, copying a sample will also create partitions matching the source sample structure. Each partition will be created with the same configuration (sample type, container, preservation) and analyses as the source partition."
 #: senaite/core/registry/schema.py:328
-#, fuzzy
 msgid "description_registry_sample_add_copy_partitions"
-msgstr "Indien ingeschakeld worden bij het kopiëren van een monster ook partities aangemaakt die overeenkomen met de structuur van het bronmonster. Elke partitie wordt aangemaakt met dezelfde configuratie (monstertype, container, conservering) en analyses als de bronpartitie."
+msgstr ""
 
 #. copying analyses to a new sample in the sample add form."
 #. Default: "Add all analyses workflow states that should be skipped when copying analyses to a new sample in the sample add form."
 #: senaite/core/registry/schema.py:359
-#, fuzzy
 msgid "description_registry_sample_add_skip_analyses_in_states"
-msgstr "Voeg alle analyseworkflowstatussen toe die moeten worden overgeslagen bij het kopiëren van analyses naar een nieuw monster in het formulier voor het toevoegen van monsters."
+msgstr ""
 
 #. copying a sample. Only analyses that directly belong to the source sample
 #. will be copied to the new sample."
 #. Default: "When enabled, analyses from partitions will be excluded when copying a sample. Only analyses that directly belong to the source sample will be copied to the new sample."
 #: senaite/core/registry/schema.py:344
-#, fuzzy
 msgid "description_registry_sample_add_skip_partition_analyses"
-msgstr "Indien ingeschakeld worden analyses van partities uitgesloten bij het kopiëren van een monster. Alleen analyses die rechtstreeks tot het bronmonster behoren, worden naar het nieuwe monster gekopieerd."
+msgstr ""
 
 #. upon sample creation. This option is disabled by default, but certain add-
 #. ons may depend on it to operate correctly."
 #. Default: "When enabled, triggers “before” and “after” transition events upon sample creation. This option is disabled by default, but certain add-ons may depend on it to operate correctly."
 #: senaite/core/registry/schema.py:410
-#, fuzzy
 msgid "description_registry_trigger_events_on_sample_creation"
-msgstr "Indien ingeschakeld activeert dit “voor”- en “na”-overgangsgebeurtenissen bij het aanmaken van monsters. Deze optie is standaard uitgeschakeld, maar bepaalde add-ons kunnen ervan afhankelijk zijn om correct te werken."
+msgstr ""
 
 #. Default: "Worksheet view configuration"
 #: senaite/core/registry/schema.py:99
 msgid "description_registry_worksheet_settings"
-msgstr "Configuratie van werkbladweergave"
+msgstr ""
 
 #. Default: "Contained samples in the PDF"
 #: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
-msgstr "Opgenomen monsters in de PDF"
+msgstr ""
 
 #. Default: "The primary sample of the PDF"
 #: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
-msgstr "Het primaire monster van de PDF"
+msgstr ""
 
 #. Default: "Assign sample to a batch"
 #: bika/lims/content/analysisrequest.py:331
 msgid "description_sample_batch"
-msgstr "Monster toewijzen aan een batch"
+msgstr ""
 
 #. Default: "The contacts used in CC for email notifications"
 #: bika/lims/content/analysisrequest.py:200
 msgid "description_sample_cccontact"
-msgstr "De contactpersonen die in CC worden gebruikt voor e-mailmeldingen"
+msgstr ""
 
 #. Default: "Select the client for this sample"
 #: bika/lims/content/analysisrequest.py:258
 msgid "description_sample_client"
-msgstr "Selecteer de klant voor dit monster"
+msgstr ""
 
 #. Default: "Select the primary contact for this sample"
 #: bika/lims/content/analysisrequest.py:159
 msgid "description_sample_contact"
-msgstr "Selecteer de primaire contactpersoon voor dit monster"
+msgstr ""
 
 #. Default: "Select a container for this sample"
 #: bika/lims/content/analysisrequest.py:569
 msgid "description_sample_container"
-msgstr "Selecteer een container voor dit monster"
+msgstr ""
 
 #. Default: "The date when the sample was taken"
 #: bika/lims/content/analysisrequest.py:453
 msgid "description_sample_datesampled"
-msgstr "De datum waarop het monster is genomen"
+msgstr ""
 
 #. Default: "Reference to detached sample"
 #: bika/lims/content/analysisrequest.py:1311
 msgid "description_sample_detached_from"
-msgstr "Verwijzing naar losgekoppeld monster"
+msgstr ""
 
 #. Default: "Reference to the source sample this sample was duplicated from"
 #: bika/lims/content/analysisrequest.py:1283
 msgid "description_sample_duplicated_from"
-msgstr "Verwijzing naar het bronmonster waarvan dit monster is gedupliceerd"
+msgstr ""
 
 #. Default: "Generated invoice for this sample"
 #: bika/lims/content/analysisrequest.py:1049
 msgid "description_sample_invoice"
-msgstr "Gegenereerde factuur voor dit monster"
+msgstr ""
 
 #. Default: "Reference to parent sample"
 #: bika/lims/content/analysisrequest.py:1255
 msgid "description_sample_parent_sample"
-msgstr "Verwijzing naar bovenliggend monster"
+msgstr ""
 
 #. Default: "Select the needed preservation for this sample"
 #: bika/lims/content/analysisrequest.py:600
 msgid "description_sample_preservation"
-msgstr "Selecteer de benodigde conservering voor dit monster"
+msgstr ""
 
 #. Default: "Select a sample to create a secondary Sample"
 #: bika/lims/content/analysisrequest.py:295
 msgid "description_sample_primary"
-msgstr "Selecteer een monster om een secundair monster aan te maken"
+msgstr ""
 
 #. Default: "Select an analysis profile for this sample"
 #: bika/lims/content/analysisrequest.py:421
 msgid "description_sample_profiles"
-msgstr "Selecteer een analyseprofiel voor dit monster"
+msgstr ""
 
 #. sample publication report"
 #. Default: "Select an analysis specification that should be used in the sample publication report"
 #: bika/lims/content/analysisrequest.py:737
-#, fuzzy
 msgid "description_sample_publicationspecification"
-msgstr "Selecteer een analysespecificatie die moet worden gebruikt in het publicatierapport van het monster"
+msgstr ""
 
 #. Default: "Reference to retracted sample"
 #: bika/lims/content/analysisrequest.py:1339
 msgid "description_sample_retracted"
-msgstr "Verwijzing naar ingetrokken monster"
+msgstr ""
 
 #. Default: "The condition of the sample"
 #: bika/lims/content/analysisrequest.py:900
 msgid "description_sample_samplecondition"
-msgstr "De conditie van het monster"
+msgstr ""
 
 #. Default: "Location where the sample was taken"
 #: bika/lims/content/analysisrequest.py:770
 msgid "description_sample_samplepoint"
-msgstr "Locatie waar het monster is genomen"
+msgstr ""
 
 #. Default: "Select the sample type of this sample"
 #: bika/lims/content/analysisrequest.py:541
 msgid "description_sample_sampletype"
-msgstr "Selecteer het monstertype van dit monster"
+msgstr ""
 
 #. Default: "The date when the sample will be taken"
 #: bika/lims/content/analysisrequest.py:516
 msgid "description_sample_samplingdate"
-msgstr "De datum waarop het monster zal worden genomen"
+msgstr ""
 
 #. Default: "Deviation between the sample and how it was sampled"
 #: bika/lims/content/analysisrequest.py:872
 msgid "description_sample_samplingdeviation"
-msgstr "Afwijking tussen het monster en hoe het is bemonsterd"
+msgstr ""
 
 #. Default: "Select an analysis specification for this sample"
 #: bika/lims/content/analysisrequest.py:693
 msgid "description_sample_specification"
-msgstr "Selecteer een analysespecificatie voor dit monster"
+msgstr ""
 
 #. Default: "Location where the sample is kept"
 #: bika/lims/content/analysisrequest.py:794
 msgid "description_sample_storagelocation"
-msgstr "Locatie waar het monster wordt bewaard"
+msgstr ""
 
 #. Default: "The assigned batch sub group of this request"
 #: bika/lims/content/analysisrequest.py:366
 msgid "description_sample_subgroup"
-msgstr "De toegewezen batchsubgroep van deze aanvraag"
+msgstr ""
 
 #. Default: "Select an analysis template for this sample"
 #: bika/lims/content/analysisrequest.py:393
 msgid "description_sample_template"
-msgstr "Selecteer een analysesjabloon voor dit monster"
+msgstr ""
 
 #. and put together from more than one sub sample, e.g. several surface
 #. samples from a dam mixed together to be a representative sample for the
 #. dam. The default, unchecked, indicates 'grab' samples"
 #. Default: "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 #: senaite/core/content/samplepoint.py:147
-#, fuzzy
 msgid "description_samplepoint_composite"
-msgstr "Vink dit vakje aan als de monsters die op dit punt worden genomen 'samengesteld' zijn en zijn samengevoegd uit meer dan één submonster, bijv. verschillende oppervlaktemonsters uit een dam die samen zijn gemengd tot een representatief monster voor de dam. De standaardinstelling, niet aangevinkt, geeft 'grab'-monsters aan"
+msgstr ""
 
 #. Default: "The height or depth at which the sample has to be taken"
 #: senaite/core/content/samplepoint.py:91
 msgid "description_samplepoint_elevation"
-msgstr "De hoogte of diepte waarop het monster moet worden genomen"
+msgstr ""
 
 #. further analysis. It plays a pivotal role in research as it can
 #. significantly influence the results and conclusions drawn from the study."
 #. Default: "The geographical point or area from which samples are taken for further analysis. It plays a pivotal role in research as it can significantly influence the results and conclusions drawn from the study."
 #: senaite/core/content/samplepoint.py:76
-#, fuzzy
 msgid "description_samplepoint_location"
-msgstr "Het geografische punt of gebied waaruit monsters worden genomen voor verdere analyse. Het speelt een cruciale rol in het onderzoek, aangezien het de resultaten en conclusies van de studie aanzienlijk kan beïnvloeden."
+msgstr ""
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
@@ -8190,16 +8137,14 @@ msgstr "Het geografische punt of gebied waaruit monsters worden genomen voor ver
 #. regardless of the type."
 #. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
 #: bika/lims/content/samplepoint.py:98
-#, fuzzy
 msgid "description_samplepoint_sampletypes"
-msgstr "De lijst met monstertypes die op dit monsterpunt kunnen worden verzameld. Het veld voor de selectie van een monsterpunt in de aanmaak- en bewerkingsformulieren voor monsters wordt dienovereenkomstig gefilterd. Monsterpunten waaraan geen monstertype is toegewezen, blijven echter altijd beschikbaar voor selectie, ongeacht het type."
+msgstr ""
 
 #. frequency here, e.g. weekly"
 #. Default: "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 #: senaite/core/content/samplepoint.py:103
-#, fuzzy
 msgid "description_samplepoint_sampling_frequency"
-msgstr "Als op dit monsterpunt periodiek een monster wordt genomen, voer hier dan de frequentie in, bijv. wekelijks"
+msgstr ""
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
@@ -8207,340 +8152,308 @@ msgstr "Als op dit monsterpunt periodiek een monster wordt genomen, voer hier da
 #. regardless of the type."
 #. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
 #: senaite/core/content/samplepoint.py:126
-#, fuzzy
 msgid "description_samplepoint_sampling_sample_types"
-msgstr "De lijst met monstertypes die op dit monsterpunt kunnen worden verzameld. Het veld voor de selectie van een monsterpunt in de aanmaak- en bewerkingsformulieren voor monsters wordt dienovereenkomstig gefilterd. Monsterpunten waaraan geen monstertype is toegewezen, blijven echter altijd beschikbaar voor selectie, ongeacht het type."
+msgstr ""
 
 #. sample is received"
 #. Default: "Automatically redirect the user to the partitions view when the sample is received"
 #: senaite/core/content/sampletemplate.py:258
-#, fuzzy
 msgid "description_sampletemplate_auto_partition"
-msgstr "De gebruiker automatisch doorverwijzen naar de partitieweergave wanneer het monster wordt ontvangen"
+msgstr ""
 
 #. Default: "Select if the sample is a mix of sub samples"
 #: senaite/core/content/sampletemplate.py:219
 msgid "description_sampletemplate_composite"
-msgstr "Selecteer of het monster een mengsel van deelmonsters is"
+msgstr ""
 
 #. ID'"
 #. Default: "Each line defines a new partition identified by the 'Partition ID'"
 #: senaite/core/content/sampletemplate.py:245
-#, fuzzy
 msgid "description_sampletemplate_partitions"
-msgstr "Elke regel definieert een nieuwe partitie die wordt geïdentificeerd door de 'Partitie-ID'"
+msgstr ""
 
 #. Default: "Select the sample point for this template"
 #: senaite/core/content/sampletemplate.py:187
 msgid "description_sampletemplate_samplepoint"
-msgstr "Selecteer het monsterpunt voor dit sjabloon"
+msgstr ""
 
 #. Default: "Select the sample type for this template"
 #: senaite/core/content/sampletemplate.py:209
 msgid "description_sampletemplate_sampletype"
-msgstr "Selecteer het monstertype voor dit sjabloon"
+msgstr ""
 
 #. Default: "Enable sampling workflow for the created samples"
 #: senaite/core/content/sampletemplate.py:228
 msgid "description_sampletemplate_sampling_required"
-msgstr "Monstername-workflow inschakelen voor de aangemaakte monsters"
+msgstr ""
 
 #. Default: "Select the services for this template"
 #: senaite/core/content/sampletemplate.py:273
 msgid "description_sampletemplate_services"
-msgstr "Selecteer de diensten voor dit sjabloon"
+msgstr ""
 
 #. Default: "Defines the stickers to use for this sample type."
 #: senaite/core/content/sampletype.py:281
 msgid "description_sampletype_admitted_stickers_templates"
-msgstr "Definieert de stickers die voor dit monstertype worden gebruikt."
+msgstr ""
 
 #. automatically assigned a container of this type, unless it has been
 #. specified in more details per analysis service"
 #. Default: "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 #: senaite/core/content/sampletype.py:258
-#, fuzzy
 msgid "description_sampletype_containertype"
-msgstr "Het standaardcontainertype. Nieuwe monsterpartities krijgen automatisch een container van dit type toegewezen, tenzij dit gedetailleerder is opgegeven per analysedienst"
+msgstr ""
 
 #. before they expire and cannot be analysed any further"
 #. Default: "The period for which unpreserved samples of this type can be kept before they expire and cannot be analysed any further"
 #: senaite/core/content/sampletype.py:155
-#, fuzzy
 msgid "description_sampletype_duration_period"
-msgstr "De periode waarin ongeconserveerde monsters van dit type kunnen worden bewaard voordat ze vervallen en niet verder kunnen worden geanalyseerd"
+msgstr ""
 
 #. display the appropriate pictograms in reports and lists."
 #. Default: "Hazard categories that apply to samples of this type. Used to display the appropriate pictograms in reports and lists."
 #: senaite/core/content/sampletype.py:180
-#, fuzzy
 msgid "description_sampletype_hazard_categories"
-msgstr "Gevarencategorieën die van toepassing zijn op monsters van dit type. Worden gebruikt om de juiste pictogrammen weer te geven in rapporten en lijsten."
+msgstr ""
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: senaite/core/content/sampletype.py:168
 msgid "description_sampletype_hazardous"
-msgstr "Monsters van dit type moeten als gevaarlijk worden behandeld"
+msgstr ""
 
 #. kg'."
 #. Default: "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 #: senaite/core/content/sampletype.py:235
-#, fuzzy
 msgid "description_sampletype_min_volume"
-msgstr "Het minimale monstervolume dat vereist is voor analyse, bijv. '10 ml' of '1 kg'."
+msgstr ""
 
 #. Default: "Only ASCII characters without whitespaces are allowed."
 #: senaite/core/content/sampletype.py:222
 msgid "description_sampletype_prefix"
-msgstr "Alleen ASCII-tekens zonder spaties zijn toegestaan."
+msgstr ""
 
 #. Default: "Select the sample matrix for this sample type"
 #: senaite/core/content/sampletype.py:208
 msgid "description_sampletype_samplematrix"
-msgstr "Selecteer de monstermatrix voor dit monstertype"
+msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
 #: senaite/core/content/senaitesetup.py:362
-#, fuzzy
 msgid "description_senaitesetup_allow_manual_result_capture_date"
-msgstr "Als deze optie is geactiveerd, kan de vastlegdatum van het resultaat handmatig worden ingevoerd voor analyses"
+msgstr ""
 
 #. to them or for unassigned analyses. When disabled, users can only submit
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 #: senaite/core/content/senaitesetup.py:456
-#, fuzzy
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
-msgstr "Indien ingeschakeld kunnen gebruikers resultaten indienen voor analyses die niet aan hen zijn toegewezen of voor niet-toegewezen analyses. Indien uitgeschakeld kunnen gebruikers alleen resultaten indienen voor analyses die aan henzelf zijn toegewezen. Deze instelling is niet van toepassing op gebruikers met de rol Labmanager."
+msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
 #: senaite/core/content/senaitesetup.py:289
-#, fuzzy
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
-msgstr "Indien geselecteerd ontvangen de verantwoordelijken van alle betrokken labafdelingen publicatie-e-mails."
+msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 #: senaite/core/content/senaitesetup.py:428
-#, fuzzy
 msgid "description_senaitesetup_auto_log_off"
-msgstr "Het aantal minuten voordat een gebruiker automatisch wordt afgemeld. 0 schakelt automatisch afmelden uit"
+msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 #: senaite/core/content/senaitesetup.py:655
-#, fuzzy
 msgid "description_senaitesetup_auto_verify_samples"
-msgstr "Indien ingeschakeld wordt het monster automatisch geverifieerd zodra alle resultaten zijn geverifieerd. Anders moeten gebruikers met voldoende rechten het monster achteraf handmatig verifiëren. Standaard: ingeschakeld"
+msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
 #: senaite/core/content/senaitesetup.py:600
-#, fuzzy
 msgid "description_senaitesetup_categorise_analysis_services"
-msgstr "Analysediensten per categorie groeperen in de LIMS-tabellen, handig wanneer de lijst lang is"
+msgstr ""
 
 #. Default: "Group analyses by category for samples"
 #: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
-msgstr "Analyses per categorie groeperen voor monsters"
+msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
 #: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
-msgstr "Selecteer de valuta die de site gebruikt om prijzen weer te geven."
+msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
 #: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
-msgstr "Selecteer dit om het dashboard te activeren als standaard startpagina."
+msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
 #: senaite/core/content/senaitesetup.py:387
-#, fuzzy
 msgid "description_senaitesetup_date_sampled_required"
-msgstr "Selecteer dit om het veld Bemonsteringsdatum verplicht te maken bij het aanmaken van een monster. Deze functionaliteit werkt alleen wanneer de 'Monstername-workflow' niet actief is"
+msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
 #: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
-msgstr "Voorkeursdecimaalteken voor rapporten."
+msgstr ""
 
 #. Default: "Select the country the site will show by default"
 #: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
-msgstr "Selecteer het land dat de site standaard toont"
+msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 #: senaite/core/content/senaitesetup.py:745
-#, fuzzy
 msgid "description_senaitesetup_default_number_of_ars_to_add"
-msgstr "Standaardwaarde van het 'Aantal monsters' wanneer gebruikers op de knop 'TOEVOEGEN' klikken om nieuwe monsters aan te maken"
+msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
 #: senaite/core/content/senaitesetup.py:261
-#, fuzzy
 msgid "description_senaitesetup_email_from_sample_publication"
-msgstr "E-mailadres dat als 'Van'-adres wordt gebruikt voor uitgaande e-mails bij het publiceren van resultaatrapporten. Dit adres overschrijft de waarde die is ingesteld bij de 'Mailinstellingen' van het portaal."
+msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
 #: senaite/core/content/senaitesetup.py:642
-#, fuzzy
 msgid "description_senaitesetup_enable_analysis_remarks"
-msgstr "Indien ingeschakeld wordt bij elke analyse in de weergave voor resultaatinvoer een vrij tekstveld weergegeven"
+msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
 #: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
-msgstr "Analysespecificaties die rechtstreeks op het monster worden bewerkt."
+msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
 #: senaite/core/content/senaitesetup.py:759
-#, fuzzy
 msgid "description_senaitesetup_enable_rejection_workflow"
-msgstr "Selecteer dit om de afwijzingsworkflow voor monsters te activeren. In het actiemenu wordt een optie 'Afwijzen' weergegeven."
+msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
 #: senaite/core/content/senaitesetup.py:626
-#, fuzzy
 msgid "description_senaitesetup_exponential_format_threshold"
-msgstr "Resultaatwaarden met ten minste dit aantal significante cijfers worden weergegeven in wetenschappelijke notatie met de letter 'e' om de exponent aan te geven. De precisie kan in afzonderlijke analysediensten worden geconfigureerd."
+msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
 #: senaite/core/content/senaitesetup.py:330
-#, fuzzy
 msgid "description_senaitesetup_immediateresultsentry"
-msgstr "Sta de gebruiker toe om resultaten direct na het aanmaken van het monster in te voeren, bijv. om veldresultaten direct in te voeren, of labresultaten wanneer de automatische monsterontvangst is geactiveerd."
+msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
 #: senaite/core/content/senaitesetup.py:412
-#, fuzzy
 msgid "description_senaitesetup_invalidation_reason_required"
-msgstr "Geef aan of het opgeven van een reden verplicht is bij het ongeldig maken van een monster. Indien ingeschakeld wordt de tijdelijke aanduiding '$reason' in de tekst van de meldingsmail voor het ongeldig maken van het monster vervangen door de ingevoerde reden."
+msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
 #: senaite/core/content/senaitesetup.py:875
-#, fuzzy
 msgid "description_senaitesetup_landing_page"
-msgstr "De landingspagina wordt getoond aan niet-geauthenticeerde gebruikers als het dashboard niet is geselecteerd als standaard startpagina. Als er geen landingspagina is geselecteerd, wordt de standaard startpagina weergegeven."
+msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
 #: senaite/core/content/senaitesetup.py:374
-#, fuzzy
 msgid "description_senaitesetup_maxnumberofsamplesadd"
-msgstr "Maximum aantal monsters dat kan worden aangemaakt overeenkomstig de waarde die is ingesteld voor het veld 'Aantal monsters' op het monsterregistratieformulier"
+msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 #: senaite/core/content/senaitesetup.py:525
-#, fuzzy
 msgid "description_senaitesetup_member_discount"
-msgstr "Het hier ingevoerde kortingspercentage wordt toegepast op de prijzen voor klanten die zijn gemarkeerd als 'leden', doorgaans coöperatieleden of geassocieerden die deze korting verdienen"
+msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 #: senaite/core/content/senaitesetup.py:584
-#, fuzzy
 msgid "description_senaitesetup_minimum_results"
-msgstr "Te weinig gegevenspunten gebruiken is statistisch niet zinvol. Stel een acceptabel minimumaantal resultaten in voordat QC-statistieken worden berekend en uitgezet"
+msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 #: senaite/core/content/senaitesetup.py:688
-#, fuzzy
 msgid "description_senaitesetup_number_of_required_verifications"
-msgstr "Aantal vereiste verificaties voordat een bepaald resultaat als 'geverifieerd' wordt beschouwd. Deze instelling kan voor elke analyse worden overschreven in de bewerkingsweergave van de analysedienst. Standaard 1"
+msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
 #: senaite/core/content/senaitesetup.py:275
-#, fuzzy
 msgid "description_senaitesetup_publication_email_text"
-msgstr "Stel de standaard te gebruiken e-mailtekst in bij het verzenden van resultaatrapporten naar de geselecteerde ontvangers. Je kunt gereserveerde sleutelwoorden gebruiken: $client_name, $recipients, $lab_name, $lab_address"
+msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
 #: senaite/core/content/senaitesetup.py:774
-#, fuzzy
 msgid "description_senaitesetup_rejection_reasons"
-msgstr "Voer de vooraf gedefinieerde afwijzingsredenen in die gebruikers kunnen selecteren bij het afwijzen van een monster."
+msgstr ""
 
 #. When disabled, analysts and lab clerks can also manage worksheets. Note:
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 #: senaite/core/content/senaitesetup.py:472
-#, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_management"
-msgstr "Indien ingeschakeld kunnen alleen labmanagers werkbladen aanmaken en beheren. Indien uitgeschakeld kunnen ook analisten en labmedewerkers werkbladen beheren. Let op: deze instelling wordt automatisch ingeschakeld en vergrendeld wanneer de toegang tot werkbladen is beperkt tot toegewezen analisten."
+msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 #: senaite/core/content/senaitesetup.py:442
-#, fuzzy
 msgid "description_senaitesetup_restrict_worksheet_users_access"
-msgstr "Indien ingeschakeld hebben analisten alleen toegang tot werkbladen waaraan zij zijn toegewezen. Indien uitgeschakeld hebben analisten toegang tot alle werkbladen."
+msgstr ""
 
 #. Default: "Preferred decimal mark for results"
 #: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
-msgstr "Voorkeursdecimaalteken voor resultaten"
+msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
 #: senaite/core/content/senaitesetup.py:969
-#, fuzzy
 msgid "description_senaitesetup_sample_duplicate_enabled"
-msgstr "Indien ingeschakeld kunnen gebruikers met voldoende rechten rechtstreeks vanuit een bestaand monster een broer-monster aanmaken via de actie 'Dupliceren' in de monsterlijst. Standaard ingeschakeld."
+msgstr ""
 
 #. Default: "Analyses are required for sample registration"
 #: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
-msgstr "Analyses zijn vereist voor monsterregistratie"
+msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
 #: senaite/core/content/senaitesetup.py:805
-#, fuzzy
 msgid "description_senaitesetup_sampleview_columns_order"
-msgstr "Selecteer welke kolommen worden weergegeven in de monsteranalyselijsten. De volgorde van selectie bepaalt de weergavevolgorde. Niet-geselecteerde kolommen worden verborgen. Laat leeg om alle kolommen in de standaardvolgorde weer te geven."
+msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
 #: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
-msgstr "Voorkeursnotatie voor wetenschappelijke notatie voor rapporten"
+msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
 #: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
-msgstr "Voorkeursnotatie voor wetenschappelijke notatie voor resultaten"
+msgstr ""
 
 #. verify it. This setting only take effect for those users with a role
 #. assigned that allows them to verify results (by default, managers,
@@ -8548,179 +8461,165 @@ msgstr "Voorkeursnotatie voor wetenschappelijke notatie voor resultaten"
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 #: senaite/core/content/senaitesetup.py:670
-#, fuzzy
 msgid "description_senaitesetup_self_verification_enabled"
-msgstr "Indien ingeschakeld kan een gebruiker die een resultaat heeft ingediend, dit ook verifiëren. Deze instelling werkt alleen voor gebruikers met een toegewezen rol die hen toestaat resultaten te verifiëren (standaard managers, labmanagers en verifieerders). Deze instelling kan voor een bepaalde analyse worden overschreven in de bewerkingsweergave van de analysedienst. Standaard uitgeschakeld."
+msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
 #: senaite/core/content/senaitesetup.py:400
-#, fuzzy
 msgid "description_senaitesetup_show_lab_name_in_login"
-msgstr "Indien geselecteerd wordt de naam van het laboratorium weergegeven op de aanmeldpagina, boven de toegangsgegevens."
+msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 #: senaite/core/content/senaitesetup.py:899
-#, fuzzy
 msgid "description_senaitesetup_show_partitions"
-msgstr "Selecteer dit om monsterpartities te tonen aan klantcontactpersonen. Indien gedeactiveerd worden partities niet opgenomen in lijsten en wordt er geen infobericht met links naar het primaire monster weergegeven aan klantcontactpersonen."
+msgstr ""
 
 #. navigation. The order of selection determines the display order in the
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
 #: senaite/core/content/senaitesetup.py:914
-#, fuzzy
 msgid "description_senaitesetup_sidebar_folders"
-msgstr "Selecteer welke mappen op het hoogste niveau in de zijbalknavigatie moeten worden weergegeven. De volgorde van selectie bepaalt de weergavevolgorde in de zijbalk. Als er geen zijn geselecteerd, worden alle mappen in de standaardvolgorde weergegeven."
+msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
 #: senaite/core/content/senaitesetup.py:933
-#, fuzzy
 msgid "description_senaitesetup_sidebar_navigation_depth"
-msgstr "Maximale diepte van de zijbalknavigatieboom. Niveau 1 toont alleen mappen op het hoogste niveau, niveau 2 bevat de onderliggende mappen, enzovoort."
+msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
 #: senaite/core/content/senaitesetup.py:950
-#, fuzzy
 msgid "description_senaitesetup_sidebar_skip_types"
-msgstr "Selecteer welke inhoudstypes moeten worden uitgesloten van de zijbalknavigatie. Als er geen zijn geselecteerd, worden alle inhoudstypes weergegeven."
+msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
 #: senaite/core/content/senaitesetup.py:704
-#, fuzzy
 msgid "description_senaitesetup_type_of_multi_verification"
-msgstr "Kies het type meervoudige verificatie voor dezelfde gebruiker. Deze instelling kan het meer dan één keer verifiëren/opeenvolgend verifiëren voor dezelfde gebruiker in-/uitschakelen."
+msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
 #: senaite/core/content/senaitesetup.py:542
-#, fuzzy
 msgid "description_senaitesetup_vat"
-msgstr "Voer een percentagewaarde in, bijv. 14.0. Dit percentage wordt systeembreed toegepast, maar kan op afzonderlijke items worden overschreven"
+msgstr ""
 
 #. view. Classic layout displays the Samples in rows and the analyses in
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 #: senaite/core/content/senaitesetup.py:846
-#, fuzzy
 msgid "description_senaitesetup_worksheet_layout"
-msgstr "Voorkeursindeling van de resultaatinvoertabel in de werkbladweergave. De klassieke indeling geeft de monsters in rijen en de analyses in kolommen weer. De getransponeerde indeling geeft de monsters in kolommen en de analyses in rijen weer."
+msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
 #: senaite/core/content/senaitesetup.py:825
-#, fuzzy
 msgid "description_senaitesetup_wsview_columns_order"
-msgstr "Selecteer welke kolommen worden weergegeven in de werkbladanalyselijsten. De volgorde van selectie bepaalt de weergavevolgorde. Niet-geselecteerde kolommen worden verborgen. Laat leeg om alle kolommen in de standaardvolgorde weer te geven."
+msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
 #: bika/lims/content/bikasetup.py:617
-#, fuzzy
 msgid "description_setup_landingpage"
-msgstr "De landingspagina wordt getoond aan niet-geauthenticeerde gebruikers als het dashboard niet is geselecteerd als standaard startpagina. Als er geen landingspagina is geselecteerd, wordt de standaard startpagina weergegeven."
+msgstr ""
 
 #. Default: "Code for the location"
 #: senaite/core/content/storagelocation.py:106
 msgid "description_storagelocation_location_code"
-msgstr "Code voor de locatie"
+msgstr ""
 
 #. Default: "Description of the location"
 #: senaite/core/content/storagelocation.py:118
 msgid "description_storagelocation_location_description"
-msgstr "Beschrijving van de locatie"
+msgstr ""
 
 #. Default: "Title of location"
 #: senaite/core/content/storagelocation.py:94
 msgid "description_storagelocation_location_title"
-msgstr "Titel van locatie"
+msgstr ""
 
 #. Default: "Type of location"
 #: senaite/core/content/storagelocation.py:130
 msgid "description_storagelocation_location_type"
-msgstr "Type locatie"
+msgstr ""
 
 #. Default: "Code the the shelf"
 #: senaite/core/content/storagelocation.py:154
 msgid "description_storagelocation_shelf_code"
-msgstr "Code voor de plank"
+msgstr ""
 
 #. Default: "Description of the shelf"
 #: senaite/core/content/storagelocation.py:166
 msgid "description_storagelocation_shelf_description"
-msgstr "Beschrijving van de plank"
+msgstr ""
 
 #. Default: "Title of the shelf"
 #: senaite/core/content/storagelocation.py:142
 msgid "description_storagelocation_shelf_title"
-msgstr "Titel van de plank"
+msgstr ""
 
 #. Default: "Code for the site"
 #: senaite/core/content/storagelocation.py:70
 msgid "description_storagelocation_site_code"
-msgstr "Code voor de vestiging"
+msgstr ""
 
 #. Default: "Description of the site"
 #: senaite/core/content/storagelocation.py:82
 msgid "description_storagelocation_site_description"
-msgstr "Beschrijving van de vestiging"
+msgstr ""
 
 #. Default: "Title of the site"
 #: senaite/core/content/storagelocation.py:58
 msgid "description_storagelocation_site_title"
-msgstr "Titel van de vestiging"
+msgstr ""
 
 #. Duplicate values are ordered alphabetically."
 #. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 #: senaite/core/content/subgroup.py:60
-#, fuzzy
 msgid "description_subgroup_sort_key"
-msgstr "Float-waarde van 0.0 - 1000.0 die de sorteervolgorde aangeeft. Dubbele waarden worden alfabetisch geordend."
+msgstr ""
 
 #. Default: "International Bank Account Number"
 #: senaite/core/content/supplier.py:100
 msgid "description_supplier_iban"
-msgstr "Internationaal bankrekeningnummer"
+msgstr ""
 
 #. Default: "National Identification Bank Account Number"
 #: senaite/core/content/supplier.py:88
 msgid "description_supplier_nib"
-msgstr "Nationaal identificatiebankrekeningnummer"
+msgstr ""
 
 #. contact profile."
 #. Default: "User is linked to a contact. Please change your settings in the contact profile."
 #: senaite/core/browser/user/userdatapanel.py:82
-#, fuzzy
 msgid "description_user_contact"
-msgstr "De gebruiker is gekoppeld aan een contactpersoon. Wijzig je instellingen in het contactprofiel."
+msgstr ""
 
 #. Default: "Select the preferred instrument"
 #: senaite/core/content/worksheettemplate.py:266
 msgid "description_worksheettemplate_instrument"
-msgstr "Selecteer het gewenste instrument"
+msgstr ""
 
 #. with the selected method.<br/>In order to apply this change to the services
 #. list, you should save the change first."
 #. Default: "Restrict the available analysis services and instruments to those with the selected method.<br/>In order to apply this change to the services list, you should save the change first."
 #: senaite/core/content/worksheettemplate.py:240
-#, fuzzy
 msgid "description_worksheettemplate_restrict_to_method"
-msgstr "Beperk de beschikbare analysediensten en instrumenten tot die met de geselecteerde methode.<br/>Om deze wijziging op de dienstenlijst toe te passen, moet je de wijziging eerst opslaan."
+msgstr ""
 
 #. Default: "Select which Analyses should be included on the Worksheet"
 #: senaite/core/content/worksheettemplate.py:350
 msgid "description_worksheettemplate_services"
-msgstr "Selecteer welke analyses op het werkblad moeten worden opgenomen"
+msgstr ""
 
 #. specific instrument's tray size. Then select an Analysis 'type' per
 #. Worksheet position. Where QC samples are selected, also select which
@@ -8728,405 +8627,402 @@ msgstr "Selecteer welke analyses op het werkblad moeten worden opgenomen"
 #. indicate which sample position it should be a duplicate of"
 #. Default: "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 #: senaite/core/content/worksheettemplate.py:315
-#, fuzzy
 msgid "description_worksheettemplate_template_layout"
-msgstr "Geef de grootte van het werkblad op, bijv. overeenkomend met de traygrootte van een specifiek instrument. Selecteer vervolgens per werkbladpositie een analyse'type'. Waar QC-monsters worden geselecteerd, selecteer ook welk referentiemonster moet worden gebruikt. Als een duplicaatanalyse is geselecteerd, geef dan aan van welke monsterpositie het een duplicaat moet zijn"
+msgstr ""
 
 #. Default: "Not found Analysis position for duplicate."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:114
 msgid "duplicate_reference_not_found"
-msgstr "Analysepositie voor duplicaat niet gevonden."
+msgstr ""
 
 #. routine analysis."
 #. Default: "Duplicate in position ${dup} references this, so it must be a routine analysis."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:164
-#, fuzzy
 msgid "duplicate_reference_this_position"
-msgstr "Duplicaat op positie ${dup} verwijst hiernaar, dus het moet een routineanalyse zijn."
+msgstr ""
 
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr "${days} dagen"
+msgstr ""
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr "${hours} uur"
+msgstr ""
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr "Dagen"
+msgstr ""
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr "Uren"
+msgstr ""
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr "Minuten"
+msgstr ""
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr "Seconden"
+msgstr ""
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr "${minutes} minuten"
+msgstr ""
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr "${seconds} seconden"
+msgstr ""
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
-msgstr "Inhoud van het bestand"
+msgstr ""
 
 #: senaite/core/api/remarks.py:481
 msgid "edited"
-msgstr "bewerkt"
+msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #: bika/lims/browser/analysisrequest/add2.py:2081
-#, fuzzy
 msgid "error_analyssirequest_numsamples_above_max"
-msgstr "Het aantal aan te maken monsters voor record 'Monster ${record_index}' (${num_samples}) ligt boven ${max_num_samples}"
+msgstr ""
 
 #. Default: "${name} is after ${max_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:120
 msgid "error_datetime_after_max"
-msgstr "${name} ligt na ${max_date}, corrigeer dit."
+msgstr ""
 
 #. Default: "${name} is before ${min_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:94
 msgid "error_datetime_before_min"
-msgstr "${name} ligt voor ${min_date}, corrigeer dit."
+msgstr ""
 
 #. Default: "Unable to load the template"
 #: senaite/core/browser/worksheets/worksheet/printview.py:155
 msgid "error_load_template_worksheet"
-msgstr "Kan het sjabloon niet laden"
+msgstr ""
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:48
 msgid "fieldset_samplepoint_location"
-msgstr "Locatie"
+msgstr ""
 
 #. Default: "Analyses"
 #: senaite/core/content/sampletemplate.py:152
 msgid "fieldset_sampletemplate_analyses"
-msgstr "Analyses"
+msgstr ""
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:141
 msgid "fieldset_sampletemplate_partitions"
-msgstr "Partities"
+msgstr ""
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/formula.py:121
 msgid "formula_validation_chain_error"
-msgstr "Interne fout in validatieketen: ${error}"
+msgstr ""
 
 #. Default: "cryogenic / inert gas"
 #: senaite/core/vocabularies/hazard_categories.py:167
 msgid "hazard_ASPH01_common"
-msgstr "cryogeen / inert gas"
+msgstr ""
 
 #. Default: "Asphyxiating atmosphere"
 #: senaite/core/vocabularies/hazard_categories.py:165
 msgid "hazard_ASPH01_name"
-msgstr "Verstikkende atmosfeer"
+msgstr ""
 
 #. Default: "infectious / biological"
 #: senaite/core/vocabularies/hazard_categories.py:104
 msgid "hazard_BIO01_common"
-msgstr "infectieus / biologisch"
+msgstr ""
 
 #. Default: "Biohazard"
 #: senaite/core/vocabularies/hazard_categories.py:103
 msgid "hazard_BIO01_name"
-msgstr "Biologisch gevaar"
+msgstr ""
 
 #. Default: "freezing / cold storage"
 #: senaite/core/vocabularies/hazard_categories.py:158
 msgid "hazard_COLD01_common"
-msgstr "vriezen / koude opslag"
+msgstr ""
 
 #. Default: "Low temperature"
 #: senaite/core/vocabularies/hazard_categories.py:157
 msgid "hazard_COLD01_name"
-msgstr "Lage temperatuur"
+msgstr ""
 
 #. Default: "electric shock"
 #: senaite/core/vocabularies/hazard_categories.py:132
 msgid "hazard_ELEC01_common"
-msgstr "elektrische schok"
+msgstr ""
 
 #. Default: "Electricity"
 #: senaite/core/vocabularies/hazard_categories.py:131
 msgid "hazard_ELEC01_name"
-msgstr "Elektriciteit"
+msgstr ""
 
 #. Default: "explosive"
 #: senaite/core/vocabularies/hazard_categories.py:48
 msgid "hazard_GHS01_common"
-msgstr "explosief"
+msgstr ""
 
 #. Default: "Explosive"
 #: senaite/core/vocabularies/hazard_categories.py:47
 msgid "hazard_GHS01_name"
-msgstr "Explosief"
+msgstr ""
 
 #. Default: "flammable"
 #: senaite/core/vocabularies/hazard_categories.py:54
 msgid "hazard_GHS02_common"
-msgstr "ontvlambaar"
+msgstr ""
 
 #. Default: "Flammable"
 #: senaite/core/vocabularies/hazard_categories.py:53
 msgid "hazard_GHS02_name"
-msgstr "Ontvlambaar"
+msgstr ""
 
 #. Default: "oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:60
 msgid "hazard_GHS03_common"
-msgstr "oxiderend"
+msgstr ""
 
 #. Default: "Oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:59
 msgid "hazard_GHS03_name"
-msgstr "Oxiderend"
+msgstr ""
 
 #. Default: "pressurised gas"
 #: senaite/core/vocabularies/hazard_categories.py:66
 msgid "hazard_GHS04_common"
-msgstr "gas onder druk"
+msgstr ""
 
 #. Default: "Compressed gas"
 #: senaite/core/vocabularies/hazard_categories.py:65
 msgid "hazard_GHS04_name"
-msgstr "Samengeperst gas"
+msgstr ""
 
 #. Default: "acid / caustic"
 #: senaite/core/vocabularies/hazard_categories.py:72
 msgid "hazard_GHS05_common"
-msgstr "zuur / bijtend"
+msgstr ""
 
 #. Default: "Corrosive"
 #: senaite/core/vocabularies/hazard_categories.py:71
 msgid "hazard_GHS05_name"
-msgstr "Corrosief"
+msgstr ""
 
 #. Default: "poisonous"
 #: senaite/core/vocabularies/hazard_categories.py:78
 msgid "hazard_GHS06_common"
-msgstr "giftig"
+msgstr ""
 
 #. Default: "Acute toxicity"
 #: senaite/core/vocabularies/hazard_categories.py:77
 msgid "hazard_GHS06_name"
-msgstr "Acute toxiciteit"
+msgstr ""
 
 #. Default: "harmful / irritant"
 #: senaite/core/vocabularies/hazard_categories.py:84
 msgid "hazard_GHS07_common"
-msgstr "schadelijk / irriterend"
+msgstr ""
 
 #. Default: "Health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:83
 msgid "hazard_GHS07_name"
-msgstr "Gezondheidsgevaar"
+msgstr ""
 
 #. Default: "carcinogenic / mutagenic"
 #: senaite/core/vocabularies/hazard_categories.py:90
 msgid "hazard_GHS08_common"
-msgstr "kankerverwekkend / mutageen"
+msgstr ""
 
 #. Default: "Serious health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:89
 msgid "hazard_GHS08_name"
-msgstr "Ernstig gezondheidsgevaar"
+msgstr ""
 
 #. Default: "environmentally hazardous"
 #: senaite/core/vocabularies/hazard_categories.py:97
 msgid "hazard_GHS09_common"
-msgstr "milieugevaarlijk"
+msgstr ""
 
 #. Default: "Environmental hazard"
 #: senaite/core/vocabularies/hazard_categories.py:96
 msgid "hazard_GHS09_name"
-msgstr "Milieugevaar"
+msgstr ""
 
 #. Default: "heated material"
 #: senaite/core/vocabularies/hazard_categories.py:145
 msgid "hazard_HOT01_common"
-msgstr "verhit materiaal"
+msgstr ""
 
 #. Default: "Hot content"
 #: senaite/core/vocabularies/hazard_categories.py:144
 msgid "hazard_HOT01_name"
-msgstr "Hete inhoud"
+msgstr ""
 
 #. Default: "hot to touch"
 #: senaite/core/vocabularies/hazard_categories.py:139
 msgid "hazard_HSURF01_common"
-msgstr "heet bij aanraking"
+msgstr ""
 
 #. Default: "Hot surface"
 #: senaite/core/vocabularies/hazard_categories.py:138
 msgid "hazard_HSURF01_name"
-msgstr "Heet oppervlak"
+msgstr ""
 
 #. Default: "NMR / MRI"
 #: senaite/core/vocabularies/hazard_categories.py:125
 msgid "hazard_MAG01_common"
-msgstr "NMR / MRI"
+msgstr ""
 
 #. Default: "Magnetic field"
 #: senaite/core/vocabularies/hazard_categories.py:124
 msgid "hazard_MAG01_name"
-msgstr "Magnetisch veld"
+msgstr ""
 
 #. Default: "UV / laser / RF"
 #: senaite/core/vocabularies/hazard_categories.py:118
 msgid "hazard_NIR01_common"
-msgstr "UV / laser / RF"
+msgstr ""
 
 #. Default: "Non-ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:117
 msgid "hazard_NIR01_name"
-msgstr "Niet-ioniserende straling"
+msgstr ""
 
 #. Default: "ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:112
 msgid "hazard_RAD01_common"
-msgstr "ioniserende straling"
+msgstr ""
 
 #. Default: "Radioactive"
 #: senaite/core/vocabularies/hazard_categories.py:111
 msgid "hazard_RAD01_name"
-msgstr "Radioactief"
+msgstr ""
 
 #. Default: "autoclave / sterilisation"
 #: senaite/core/vocabularies/hazard_categories.py:151
 msgid "hazard_STEAM01_common"
-msgstr "autoclaaf / sterilisatie"
+msgstr ""
 
 #. Default: "Hot steam"
 #: senaite/core/vocabularies/hazard_categories.py:150
 msgid "hazard_STEAM01_name"
-msgstr "Hete stoom"
+msgstr ""
 
 #. Default: "Hazardous"
 #: senaite/core/api/hazard.py:37
 msgid "hazard_warning_label"
-msgstr "Gevaarlijk"
+msgstr ""
 
 #. Default: "Legacy Setup"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:16
 msgid "heading_legacy_setup"
-msgstr "Verouderde instellingen"
+msgstr ""
 
 #. Default: "Re-enter the password. Make sure the passwords are identical."
 #: senaite/core/browser/user/passwordpanel.py:44
 msgid "help_confirm_password"
-msgstr "Voer het wachtwoord opnieuw in. Zorg ervoor dat de wachtwoorden identiek zijn."
+msgstr ""
 
 #. Default: "Enter full name, e.g. John Smith."
 #: senaite/core/browser/user/userdatapanel.py:65
 msgid "help_full_name_creation"
-msgstr "Voer de volledige naam in, bijv. Jan Jansen."
+msgstr ""
 
 #. Default: "Enter your new password."
 #: senaite/core/browser/user/passwordpanel.py:37
 msgid "help_new_password"
-msgstr "Voer je nieuwe wachtwoord in."
+msgstr ""
 
 #. Default: "Your time zone"
 #: senaite/core/browser/user/personalpreferences.py:39
 msgid "help_timezone"
-msgstr "Je tijdzone"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "hours"
-msgstr "uur"
+msgstr ""
 
 #. Default: "'${function}' not found in module '${module}'"
 #: senaite/core/validators/imports.py:66
 msgid "importable_function_error"
-msgstr "'${function}' niet gevonden in module '${module}'"
+msgstr ""
 
 #. Default: "Could not import module '${module}'"
 #: senaite/core/validators/imports.py:49
 msgid "importable_module_error"
-msgstr "Kan module '${module}' niet importeren"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:189
 msgid "in"
-msgstr "in"
+msgstr ""
 
 #. Default: "Instrument exporter not found"
 #: senaite/core/browser/worksheets/worksheet/export.py:66
 msgid "instrument_exporter_not_found_message"
-msgstr "Instrumentexporteur niet gevonden"
+msgstr ""
 
 #. Default: "Interim field ${row_num}: ${message}"
 #: senaite/core/validators/interimfields.py:299
 msgid "interim_field_error"
-msgstr "Tussenveld ${row_num}: ${message}"
+msgstr ""
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/interimfields.py:278
 msgid "interims_validation_chain_error"
-msgstr "Interne fout in validatieketen: ${error}"
+msgstr ""
 
 #. Default: "'${field_name}' contains invalid characters"
 #: senaite/core/validators/interimfields.py:68
 msgid "invalid_characters_validator_error"
-msgstr "'${field_name}' bevat ongeldige tekens"
+msgstr ""
 
 #. Default: "AnalysesServices not found for keywords: ${keywords}"
 #: senaite/core/validators/formula.py:92
 msgid "invalid_keyword_error"
-msgstr "Geen analysediensten gevonden voor sleutelwoorden: ${keywords}"
+msgstr ""
 
 #. Default: "Invalid wildcards found: ${wildcards}"
 #: senaite/core/validators/formula.py:71
 msgid "invalid_wildcards_check_error"
-msgstr "Ongeldige jokertekens gevonden: ${wildcards}"
+msgstr ""
 
 #. Default: "Labels"
 #: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
-msgstr "Labels"
+msgstr ""
 
 #. Default: "Add to the following groups:"
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:276
 msgid "label_add_to_groups"
-msgstr "Toevoegen aan de volgende groepen:"
+msgstr ""
 
 #. Default: "Address"
 #: senaite/core/content/person.py:197
 msgid "label_address"
-msgstr "Adres"
+msgstr ""
 
 #. Default: "Analysis Category"
 #: bika/lims/content/abstractbaseanalysis.py:530
 msgid "label_analysis_category"
-msgstr "Analysecategorie"
+msgstr ""
 
 #. Default: "Department"
 #: bika/lims/content/abstractbaseanalysis.py:588
 msgid "label_analysis_department"
-msgstr "Afdeling"
+msgstr ""
 
 #. of a parameter that can be reliably detected by a specified testing
 #. methodology with a defined level of confidence. Results below this
@@ -9135,14 +9031,13 @@ msgstr "Afdeling"
 #. detection capability of the method at a reliable level."
 #. Default: "The Lower Limit of Detection (LLOD) is the lowest concentration of a parameter that can be reliably detected by a specified testing methodology with a defined level of confidence. Results below this threshold are typically reported as '< LLOD' (or 'Not Detected'), indicating that the parameter's concentration, if present, is below the detection capability of the method at a reliable level."
 #: bika/lims/content/abstractbaseanalysis.py:207
-#, fuzzy
 msgid "label_analysis_lower_limit_of_detection_description"
-msgstr "De ondergrens van detectie (LLOD) is de laagste concentratie van een parameter die betrouwbaar kan worden gedetecteerd met een bepaalde testmethode en een gedefinieerd betrouwbaarheidsniveau. Resultaten onder deze drempel worden doorgaans gerapporteerd als '< LLOD' (of 'Niet gedetecteerd'), wat aangeeft dat de concentratie van de parameter, indien aanwezig, onder de detectiecapaciteit van de methode ligt op een betrouwbaar niveau."
+msgstr ""
 
 #. Default: "Lower Limit of Detection (LLOD)"
 #: bika/lims/content/abstractbaseanalysis.py:203
 msgid "label_analysis_lower_limit_of_detection_title"
-msgstr "Ondergrens van detectie (LLOD)"
+msgstr ""
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
@@ -9152,34 +9047,33 @@ msgstr "Ondergrens van detectie (LLOD)"
 #. cannot be determined reliably."
 #. Default: "The Lower Limit of Quantification (LLOQ) is the lowest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results below this value cannot be quantified with confidence and are typically reported as '< LOQ' (or 'Detected but < LOQ'), indicating that while the parameter may be present, its exact concentration cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:231
-#, fuzzy
 msgid "label_analysis_lower_limit_of_quantification_description"
-msgstr "De ondergrens van kwantificering (LLOQ) is de laagste concentratie van een parameter die betrouwbaar en nauwkeurig kan worden gemeten met de bepaalde testmethode, met acceptabele niveaus van precisie en nauwkeurigheid. Resultaten onder deze waarde kunnen niet met vertrouwen worden gekwantificeerd en worden doorgaans gerapporteerd als '< LOQ' (of 'Gedetecteerd maar < LOQ'), wat aangeeft dat de parameter weliswaar aanwezig kan zijn, maar dat de exacte concentratie niet betrouwbaar kan worden bepaald."
+msgstr ""
 
 #. Default: "Lower Limit Of Quantification (LLOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:227
 msgid "label_analysis_lower_limit_of_quantification_title"
-msgstr "Ondergrens van kwantificering (LLOQ)"
+msgstr ""
 
 #. Default: "Maximum holding time"
 #: bika/lims/content/abstractbaseanalysis.py:453
 msgid "label_analysis_maxholdingtime"
-msgstr "Maximale bewaartijd"
+msgstr ""
 
 #. Default: "Sorting criteria"
 #: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
-msgstr "Sorteercriteria"
+msgstr ""
 
 #. Default: "Default Unit"
 #: bika/lims/content/abstractbaseanalysis.py:108
 msgid "label_analysis_unit"
-msgstr "Standaardeenheid"
+msgstr ""
 
 #. Default: "Units for Selection"
 #: bika/lims/content/abstractbaseanalysis.py:158
 msgid "label_analysis_unitchoices"
-msgstr "Eenheden voor selectie"
+msgstr ""
 
 #. of a parameter that can be reliably measured using a specified testing
 #. methodology. Beyond this limit, results may no longer be accurate or valid
@@ -9189,14 +9083,13 @@ msgstr "Eenheden voor selectie"
 #. the method."
 #. Default: "The Upper Limit of Detection (ULOD) is the highest concentration of a parameter that can be reliably measured using a specified testing methodology. Beyond this limit, results may no longer be accurate or valid due to instrument saturation or methodological limitations. Results exceeding this threshold are typically reported as '> ULOD', indicating that the parameter's concentration is above the reliable detection range of the method."
 #: bika/lims/content/abstractbaseanalysis.py:277
-#, fuzzy
 msgid "label_analysis_upper_limit_of_detection_description"
-msgstr "De bovengrens van detectie (ULOD) is de hoogste concentratie van een parameter die betrouwbaar kan worden gemeten met een bepaalde testmethode. Boven deze grens zijn resultaten mogelijk niet langer nauwkeurig of geldig vanwege instrumentverzadiging of methodologische beperkingen. Resultaten die deze drempel overschrijden worden doorgaans gerapporteerd als '> ULOD', wat aangeeft dat de concentratie van de parameter boven het betrouwbare detectiebereik van de methode ligt."
+msgstr ""
 
 #. Default: "Upper Limit of Detection (ULOD)"
 #: bika/lims/content/abstractbaseanalysis.py:274
 msgid "label_analysis_upper_limit_of_detection_title"
-msgstr "Bovengrens van detectie (ULOD)"
+msgstr ""
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
@@ -9205,2405 +9098,2401 @@ msgstr "Bovengrens van detectie (ULOD)"
 #. exact concentration cannot be determined reliably."
 #. Default: "The Upper Limit of Quantification (ULOQ) is the highest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results above this value cannot be quantified with confidence and are typically reported as '> ULOQ', indicating that its exact concentration cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:255
-#, fuzzy
 msgid "label_analysis_upper_limit_of_quantification_description"
-msgstr "De bovengrens van kwantificering (ULOQ) is de hoogste concentratie van een parameter die betrouwbaar en nauwkeurig kan worden gemeten met de bepaalde testmethode, met acceptabele niveaus van precisie en nauwkeurigheid. Resultaten boven deze waarde kunnen niet met vertrouwen worden gekwantificeerd en worden doorgaans gerapporteerd als '> ULOQ', wat aangeeft dat de exacte concentratie niet betrouwbaar kan worden bepaald."
+msgstr ""
 
 #. Default: "Upper Limit Of Quantification (ULOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:252
 msgid "label_analysis_upper_limit_of_quantification_title"
-msgstr "Bovengrens van kwantificering (ULOQ)"
+msgstr ""
 
 #. Default: "Sample types"
 #: senaite/core/content/analysisprofile.py:180
 msgid "label_analysisprofile_sampletypes"
-msgstr "Monstertypes"
+msgstr ""
 
 #. Default: "Number of samples"
 #: bika/lims/content/analysisrequest.py:1437
 msgid "label_analysisrequest_numsamples"
-msgstr "Aantal monsters"
+msgstr ""
 
 #. Default: "Dynamic Analysis Specification"
 #: bika/lims/content/analysisspec.py:69
 msgid "label_analysisspec_dynamicspec"
-msgstr "Dynamische analysespecificatie"
+msgstr ""
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisspec.py:49
 msgid "label_analysisspec_sampletype"
-msgstr "Monstertype"
+msgstr ""
 
 #. Default: "Contained Samples"
 #: bika/lims/content/arreport.py:79
 msgid "label_arreport_contained_samples"
-msgstr "Bevatte monsters"
+msgstr ""
 
 #. Default: "Primary Sample"
 #: bika/lims/content/arreport.py:49
 msgid "label_arreport_sample"
-msgstr "Primair monster"
+msgstr ""
 
 #. Default: "Analysis Profile"
 #: bika/lims/content/artemplate.py:254
 msgid "label_artemplate_profile"
-msgstr "Analyseprofiel"
+msgstr ""
 
 #. Default: "Sample Point"
 #: bika/lims/content/artemplate.py:55
 msgid "label_artemplate_samplepoint"
-msgstr "Monsterpunt"
+msgstr ""
 
 #. Default: "Sample Type"
 #: bika/lims/content/artemplate.py:86
 msgid "label_artemplate_sampletype"
-msgstr "Monstertype"
+msgstr ""
 
 #. Default: "Attachment Type"
 #: bika/lims/content/attachment.py:61
 msgid "label_attachment_type"
-msgstr "Bijlagetype"
+msgstr ""
 
 #. Default: "Instrument"
 #: bika/lims/content/autoimportlog.py:50
 msgid "label_autoimportlog_instrument"
-msgstr "Instrument"
+msgstr ""
 
 #. Default: "Log Time"
 #: bika/lims/content/autoimportlog.py:87
 msgid "label_autoimportlog_logtime"
-msgstr "Logtijd"
+msgstr ""
 
 #. Default: "Results"
 #: bika/lims/content/autoimportlog.py:74
 msgid "label_autoimportlog_results"
-msgstr "Resultaten"
+msgstr ""
 
 #. Default: "Client"
 #: bika/lims/content/batch.py:78
 msgid "label_batch_client"
-msgstr "Client"
+msgstr ""
 
 #. Default: "Allow to set the result capture date"
 #: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
-msgstr "Vastlegdatum van resultaat toestaan in te stellen"
+msgstr ""
 
 #. Default: "Always send publication email to responsibles"
 #: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
-msgstr "Altijd publicatie-e-mail naar verantwoordelijken sturen"
+msgstr ""
 
 #. Default: "Categorize sample analyses"
 #: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
-msgstr "Monsteranalyses categoriseren"
+msgstr ""
 
 #. Default: "Date sampled required"
 #: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
-msgstr "Bemonsteringsdatum vereist"
+msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
 #: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
-msgstr "E-mailtekst voor meldingen over monsterpublicatie"
+msgstr ""
 
 #. Default: "Publication 'From' address"
 #: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
-msgstr "Publicatie-'Van'-adres"
+msgstr ""
 
 #. Default: "Immediate results entry"
 #: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
-msgstr "Directe resultaatinvoer"
+msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
 #: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
-msgstr "E-mailtekst voor meldingen over het ongeldig maken van monsters"
+msgstr ""
 
 #. Default: "Invalidation reason required"
 #: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
-msgstr "Reden voor ongeldig maken vereist"
+msgstr ""
 
 #. Default: "Require sample analyses"
 #: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
-msgstr "Monsteranalyses vereisen"
+msgstr ""
 
 #. Default: "DependentServices"
 #: senaite/core/content/calculation.py:352
 msgid "label_calculation_dependent_services"
-msgstr "Afhankelijke diensten"
+msgstr ""
 
 #. Default: "Dependent services"
 #: bika/lims/content/calculation.py:81
 msgid "label_calculation_dependentservices"
-msgstr "Afhankelijke diensten"
+msgstr ""
 
 #. Default: "Calculation Formula"
 #: senaite/core/content/calculation.py:287
 msgid "label_calculation_formula"
-msgstr "Berekeningsformule"
+msgstr ""
 
 #. Default: "Function"
 #: senaite/core/content/calculation.py:185
 msgid "label_calculation_import_function_name"
-msgstr "Functie"
+msgstr ""
 
 #. Default: "Module"
 #: senaite/core/content/calculation.py:179
 msgid "label_calculation_import_module_name"
-msgstr "Module"
+msgstr ""
 
 #. Default: "Additional Python Libraries"
 #: senaite/core/content/calculation.py:266
 msgid "label_calculation_imports"
-msgstr "Aanvullende Python-bibliotheken"
+msgstr ""
 
 #. Default: "Calculation Interim Fields"
 #: senaite/core/content/calculation.py:243
 msgid "label_calculation_interims"
-msgstr "Tussenvelden voor berekening"
+msgstr ""
 
 #. Default: "Raw Test Result"
 #: senaite/core/content/calculation.py:336
 msgid "label_calculation_raw_test_keywords"
-msgstr "Ruw testresultaat"
+msgstr ""
 
 #. Default: "Keyword"
 #: senaite/core/content/calculation.py:198
 msgid "label_calculation_test_param_keyword"
-msgstr "Sleutelwoord"
+msgstr ""
 
 #. Default: "Value"
 #: senaite/core/content/calculation.py:207
 msgid "label_calculation_test_param_value"
-msgstr "Waarde"
+msgstr ""
 
 #. Default: "Test Parameters"
 #: senaite/core/content/calculation.py:317
 msgid "label_calculation_test_params"
-msgstr "Testparameters"
+msgstr ""
 
 #. Default: "Test Result"
 #: senaite/core/content/calculation.py:343
 msgid "label_calculation_test_result"
-msgstr "Testresultaat"
+msgstr ""
 
 #. Default: "Department"
 #: bika/lims/content/analysiscategory.py:59
 msgid "label_category_department"
-msgstr "Afdeling"
+msgstr ""
 
 #. Default: "Default categories"
 #: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
-msgstr "Standaardcategorieën"
+msgstr ""
 
 #. Default: "Restrict categories"
 #: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
-msgstr "Categorieën beperken"
+msgstr ""
 
 #. Default: "Confirm password"
 #: senaite/core/browser/user/passwordpanel.py:43
 msgid "label_confirm_password"
-msgstr "Wachtwoord bevestigen"
+msgstr ""
 
 #. Default: "Contacts to CC"
 #: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
-msgstr "Contactpersonen voor CC"
+msgstr ""
 
 #. Default: "Email Telephone Fax"
 #: senaite/core/content/person.py:137
 msgid "label_contact_information"
-msgstr "E-mail Telefoon Fax"
+msgstr ""
 
 #. Default: "Preservation"
 #: bika/lims/content/container.py:97
 msgid "label_container_preservation"
-msgstr "Conservering"
+msgstr ""
 
 #. Default: "Container Type"
 #: bika/lims/content/container.py:54
 msgid "label_container_type"
-msgstr "Containertype"
+msgstr ""
 
 #. Default: "Manager"
 #: senaite/core/content/department.py:102
 msgid "label_department_manager"
-msgstr "Manager"
+msgstr ""
 
 #. edit the container itself, ${go_here}."
 #. Default: "You are editing the default view of a container. If you wanted to edit the container itself, ${go_here}."
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
-#, fuzzy
 msgid "label_edit_default_view_container"
-msgstr "Je bewerkt de standaardweergave van een container. Als je de container zelf wilde bewerken, ${go_here}."
+msgstr ""
 
 #. Default: "go here"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
 msgid "label_edit_default_view_container_go_here"
-msgstr "ga hierheen"
+msgstr ""
 
 #. Default: "Bank Details"
 #: senaite/core/content/supplier.py:72
 msgid "label_fieldset_supplier_bank_details"
-msgstr "Bankgegevens"
+msgstr ""
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheettemplate.py:332
 msgid "label_fieldset_worksheettemplate_analyses"
-msgstr "Analyses"
+msgstr ""
 
 #. Default: "Layout"
 #: senaite/core/content/worksheettemplate.py:275
 msgid "label_fieldset_worksheettemplate_layout"
-msgstr "Indeling"
+msgstr ""
 
 #. Default: "Include client contacts"
 #: senaite/core/browser/controlpanel/contacts/templates/contacts_filter.pt:10
 msgid "label_include_client_contacts"
-msgstr "Klantcontactpersonen opnemen"
+msgstr ""
 
 #. Default: "Location"
 #: bika/lims/content/instrument.py:319
 msgid "label_instrument_instrumentlocation"
-msgstr "Locatie"
+msgstr ""
 
 #. Default: "Instrument type"
 #: bika/lims/content/instrument.py:79
 msgid "label_instrument_instrumenttype"
-msgstr "Instrumenttype"
+msgstr ""
 
 #. Default: "Manufacturer"
 #: bika/lims/content/instrument.py:99
 msgid "label_instrument_manufacturer"
-msgstr "Fabrikant"
+msgstr ""
 
 #. Default: "Supported methods"
 #: bika/lims/content/instrument.py:172
 msgid "label_instrument_methods"
-msgstr "Ondersteunde methoden"
+msgstr ""
 
 #. Default: "Result files folders"
 #: bika/lims/content/instrument.py:265
 msgid "label_instrument_result_file_folder"
-msgstr "Mappen voor resultaatbestanden"
+msgstr ""
 
 #. Default: "Supplier"
 #: bika/lims/content/instrument.py:119
 msgid "label_instrument_supplier"
-msgstr "Leverancier"
+msgstr ""
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentcalibration.py:127
 msgid "label_instrumentcalibration_worker"
-msgstr "Uitgevoerd door"
+msgstr ""
 
 #. Default: "Prepared by"
 #: bika/lims/content/instrumentcertification.py:146
 msgid "label_instrumentcertification_preparator"
-msgstr "Voorbereid door"
+msgstr ""
 
 #. Default: "Approved by"
 #: bika/lims/content/instrumentcertification.py:170
 msgid "label_instrumentcertification_validator"
-msgstr "Goedgekeurd door"
+msgstr ""
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentvalidation.py:109
 msgid "label_instrumentvalidation_worker"
-msgstr "Uitgevoerd door"
+msgstr ""
 
 #. Default: "Allow empty"
 #: senaite/core/schema/interimfields.py:87
 msgid "label_interim_allow_empty"
-msgstr "Leeg toestaan"
+msgstr ""
 
 #. Default: "Apply wide"
 #: senaite/core/schema/interimfields.py:127
 msgid "label_interim_apply_wide"
-msgstr "Breed toepassen"
+msgstr ""
 
 #. Default: "Choices"
 #: senaite/core/schema/interimfields.py:67
 msgid "label_interim_choices"
-msgstr "Keuzes"
+msgstr ""
 
 #. Default: "Default value"
 #: senaite/core/schema/interimfields.py:57
 msgid "label_interim_default_value"
-msgstr "Standaardwaarde"
+msgstr ""
 
 #. Default: "Hidden"
 #: senaite/core/schema/interimfields.py:117
 msgid "label_interim_hidden"
-msgstr "Verborgen"
+msgstr ""
 
 #. Default: "Keyword"
 #: senaite/core/schema/interimfields.py:37
 msgid "label_interim_keyword"
-msgstr "Sleutelwoord"
+msgstr ""
 
 #. Default: "Report"
 #: senaite/core/schema/interimfields.py:107
 msgid "label_interim_report"
-msgstr "Rapport"
+msgstr ""
 
 #. Default: "Result type"
 #: senaite/core/schema/interimfields.py:76
 msgid "label_interim_result_type"
-msgstr "Resultaattype"
+msgstr ""
 
 #. Default: "Field title"
 #: senaite/core/schema/interimfields.py:47
 msgid "label_interim_title"
-msgstr "Veldtitel"
+msgstr ""
 
 #. Default: "Unit"
 #: senaite/core/schema/interimfields.py:97
 msgid "label_interim_unit"
-msgstr "Eenheid"
+msgstr ""
 
 #. Default: "Default Department"
 #: bika/lims/content/labcontact.py:86
 msgid "label_labcontact_default_department"
-msgstr "Standaardafdeling"
+msgstr ""
 
 #. Default: "Departments"
 #: bika/lims/content/labcontact.py:59
 msgid "label_labcontact_departments"
-msgstr "Afdelingen"
+msgstr ""
 
 #. Default: "Supervisor"
 #: senaite/core/content/laboratory.py:73
 msgid "label_laboratory_supervisor"
-msgstr "Supervisor"
+msgstr ""
 
 #. Default: "Document ID"
 #: senaite/core/content/multifile.py:39
 msgid "label_multifile_document_id"
-msgstr "Document-ID"
+msgstr ""
 
 #. Default: "Document Location"
 #: senaite/core/content/multifile.py:67
 msgid "label_multifile_document_location"
-msgstr "Documentlocatie"
+msgstr ""
 
 #. Default: "Document Type"
 #: senaite/core/content/multifile.py:79
 msgid "label_multifile_document_type"
-msgstr "Documenttype"
+msgstr ""
 
 #. Default: "Document Version"
 #: senaite/core/content/multifile.py:59
 msgid "label_multifile_document_version"
-msgstr "Documentversie"
+msgstr ""
 
 #. Default: "Document"
 #: senaite/core/content/multifile.py:47
 msgid "label_multifile_file"
-msgstr "Document"
+msgstr ""
 
 #. Default: "New password"
 #: senaite/core/browser/user/passwordpanel.py:36
 msgid "label_new_password"
-msgstr "Nieuw wachtwoord"
+msgstr ""
 
 #. Default: "Fax (business)"
 #: senaite/core/content/person.py:169
 msgid "label_person_business_fax"
-msgstr "Fax (zakelijk)"
+msgstr ""
 
 #. Default: "Phone (business)"
 #: senaite/core/content/person.py:160
 msgid "label_person_business_phone"
-msgstr "Telefoon (zakelijk)"
+msgstr ""
 
 #. Default: "Department"
 #: senaite/core/content/person.py:119
 msgid "label_person_department"
-msgstr "Afdeling"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/person.py:59
 msgid "label_person_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Email Address"
 #: senaite/core/content/person.py:151
 msgid "label_person_email_address"
-msgstr "E-mailadres"
+msgstr ""
 
 #. Default: "Firstname"
 #: senaite/core/content/person.py:79
 msgid "label_person_firstname"
-msgstr "Voornaam"
+msgstr ""
 
 #. Default: "Phone (home)"
 #: senaite/core/content/person.py:178
 msgid "label_person_home_phone"
-msgstr "Telefoon (privé)"
+msgstr ""
 
 #. Default: "Job title"
 #: senaite/core/content/person.py:111
 msgid "label_person_job_title"
-msgstr "Functietitel"
+msgstr ""
 
 #. Default: "Middle initial"
 #: senaite/core/content/person.py:87
 msgid "label_person_middleinitial"
-msgstr "Tussenletter"
+msgstr ""
 
 #. Default: "Middle name"
 #: senaite/core/content/person.py:95
 msgid "label_person_middlename"
-msgstr "Tussennaam"
+msgstr ""
 
 #. Default: "Phone (mobile)"
 #: senaite/core/content/person.py:187
 msgid "label_person_mobile_phone"
-msgstr "Telefoon (mobiel)"
+msgstr ""
 
 #. Default: "Physical address"
 #: senaite/core/content/person.py:210
 msgid "label_person_physical_address"
-msgstr "Fysiek adres"
+msgstr ""
 
 #. Default: "Postal address"
 #: senaite/core/content/person.py:219
 msgid "label_person_postal_address"
-msgstr "Postadres"
+msgstr ""
 
 #. Default: "Salutation"
 #: senaite/core/content/person.py:67
 msgid "label_person_salutation"
-msgstr "Aanhef"
+msgstr ""
 
 #. Default: "Surname"
 #: senaite/core/content/person.py:103
 msgid "label_person_surname"
-msgstr "Achternaam"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/content/person.py:51
 msgid "label_person_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Username"
 #: senaite/core/content/person.py:127
 msgid "label_person_username"
-msgstr "Gebruikersnaam"
+msgstr ""
 
 #. Default: "SENAITE is powered by"
 #: senaite/core/browser/viewlets/templates/colophon.pt:11
 msgid "label_powered_by"
-msgstr "SENAITE draait op"
+msgstr ""
 
 #. Default: "Plone & Python"
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "label_powered_by_plone"
-msgstr "Plone & Python"
+msgstr ""
 
 #. Default: "Publication preference"
 #: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
-msgstr "Publicatievoorkeur"
+msgstr ""
 
 #. Default: "Blank"
 #: bika/lims/content/referencedefinition.py:75
 msgid "label_referencedefinition_blank"
-msgstr "Blanco"
+msgstr ""
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencedefinition.py:104
 msgid "label_referencedefinition_hazard_categories"
-msgstr "Gevarencategorieën"
+msgstr ""
 
 #. Default: "Hazardous"
 #: bika/lims/content/referencedefinition.py:89
 msgid "label_referencedefinition_hazardous"
-msgstr "Gevaarlijk"
+msgstr ""
 
 #. Default: "Reference Values"
 #: bika/lims/content/referencedefinition.py:53
 msgid "label_referencedefinition_referencevalues"
-msgstr "Referentiewaarden"
+msgstr ""
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencesample.py:116
 msgid "label_referencesample_hazard_categories"
-msgstr "Gevarencategorieën"
+msgstr ""
 
 #. Default: "Manufacturer"
 #: bika/lims/content/referencesample.py:133
 msgid "label_referencesample_manufacturer"
-msgstr "Fabrikant"
+msgstr ""
 
 #. Default: "Reference Definition"
 #: bika/lims/content/referencesample.py:79
 msgid "label_referencesample_referencedefinition"
-msgstr "Referentiedefinitie"
+msgstr ""
 
 #. Default: "Catalog mappings"
 #: senaite/core/registry/schema.py:274
 msgid "label_registry_catalog_mappings"
-msgstr "Catalogustoewijzingen"
+msgstr ""
 
 #. Default: "Portal type"
 #: senaite/core/registry/schema.py:286
 msgid "label_registry_catalog_mappings_key"
-msgstr "Portaaltype"
+msgstr ""
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:293
 msgid "label_registry_catalog_mappings_value"
-msgstr "Catalogi"
+msgstr ""
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:265
 msgid "label_registry_catalogs_fieldset"
-msgstr "Catalogi"
+msgstr ""
 
 #. Default: "Client landing page"
 #: senaite/core/registry/schema.py:47
 msgid "label_registry_client_landing_page"
-msgstr "Landingspagina voor klant"
+msgstr ""
 
 #. Default: "Portal types to skip on content structure export"
 #: senaite/core/registry/schema.py:234
 msgid "label_registry_generic_setup_skip_export_types"
-msgstr "Portaaltypes om over te slaan bij export van inhoudsstructuur"
+msgstr ""
 
 #. Default: "Import"
 #: senaite/core/registry/schema.py:428
 msgid "label_registry_import"
-msgstr "Importeren"
+msgstr ""
 
 #. Default: "Attach import file to Analyses"
 #: senaite/core/registry/schema.py:439
 msgid "label_registry_import_analysis_attach_attachment"
-msgstr "Importbestand aan analyses koppelen"
+msgstr ""
 
 #. Default: "Submit Analyses upon import"
 #: senaite/core/registry/schema.py:452
 msgid "label_registry_import_analysis_submit"
-msgstr "Analyses indienen bij import"
+msgstr ""
 
 #. Default: "Allow multi paste"
 #: senaite/core/registry/schema.py:371
 msgid "label_registry_sample_add_allow_multi_paste_fields"
-msgstr "Meervoudig plakken toestaan"
+msgstr ""
 
 #. Default: "Commit each sample in its own transaction"
 #: senaite/core/registry/schema.py:387
 msgid "label_registry_sample_add_commit_per_sample"
-msgstr "Elk monster in een eigen transactie vastleggen"
+msgstr ""
 
 #. Default: "Copy sample structure with partitions"
 #: senaite/core/registry/schema.py:324
 msgid "label_registry_sample_add_copy_partitions"
-msgstr "Monsterstructuur met partities kopiëren"
+msgstr ""
 
 #. Default: "Skip analyses workflow states on copy"
 #: senaite/core/registry/schema.py:355
 msgid "label_registry_sample_add_skip_analyses_in_states"
-msgstr "Werkstroomstatussen van analyses overslaan bij kopiëren"
+msgstr ""
 
 #. Default: "Skip partition analyses on copy"
 #: senaite/core/registry/schema.py:340
 msgid "label_registry_sample_add_skip_partition_analyses"
-msgstr "Partitieanalyses overslaan bij kopiëren"
+msgstr ""
 
 #. Default: "Samples"
 #: senaite/core/registry/schema.py:309
 msgid "label_registry_samples"
-msgstr "Monsters"
+msgstr ""
 
 #. Default: "Trigger events on sample creation"
 #: senaite/core/registry/schema.py:406
 msgid "label_registry_trigger_events_on_sample_creation"
-msgstr "Gebeurtenissen activeren bij aanmaken monster"
+msgstr ""
 
 #. Default: "Worksheet"
 #: senaite/core/registry/schema.py:95
 msgid "label_registry_worksheet_settings"
-msgstr "Werkblad"
+msgstr ""
 
 #. Default: "Contained Samples"
 #: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
-msgstr "Bevatte monsters"
+msgstr ""
 
 #. Default: "Primary Sample"
 #: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
-msgstr "Primair monster"
+msgstr ""
 
 #. Default: "Batch"
 #: bika/lims/content/analysisrequest.py:328
 msgid "label_sample_batch"
-msgstr "Batch"
+msgstr ""
 
 #. Default: "CC Contact"
 #: bika/lims/content/analysisrequest.py:197
 msgid "label_sample_cccontact"
-msgstr "CC-contact"
+msgstr ""
 
 #. Default: "Client"
 #: bika/lims/content/analysisrequest.py:255
 msgid "label_sample_client"
-msgstr "Client"
+msgstr ""
 
 #. Default: "Contact"
 #: bika/lims/content/analysisrequest.py:156
 msgid "label_sample_contact"
-msgstr "Contact"
+msgstr ""
 
 #. Default: "Container"
 #: bika/lims/content/analysisrequest.py:566
 msgid "label_sample_container"
-msgstr "Container"
+msgstr ""
 
 #. Default: "Date Sampled"
 #: bika/lims/content/analysisrequest.py:449
 msgid "label_sample_datesampled"
-msgstr "Datum bemonsterd"
+msgstr ""
 
 #. Default: "Detached from sample"
 #: bika/lims/content/analysisrequest.py:1308
 msgid "label_sample_detached_from"
-msgstr "Losgekoppeld van monster"
+msgstr ""
 
 #. Default: "Duplicated from sample"
 #: bika/lims/content/analysisrequest.py:1280
 msgid "label_sample_duplicated_from"
-msgstr "Gedupliceerd van monster"
+msgstr ""
 
 #. Default: "Invoice"
 #: bika/lims/content/analysisrequest.py:1046
 msgid "label_sample_invoice"
-msgstr "Factuur"
+msgstr ""
 
 #. Default: "Parent sample"
 #: bika/lims/content/analysisrequest.py:1252
 msgid "label_sample_parent_sample"
-msgstr "Bovenliggend monster"
+msgstr ""
 
 #. Default: "Preservation"
 #: bika/lims/content/analysisrequest.py:597
 msgid "label_sample_preservation"
-msgstr "Conservering"
+msgstr ""
 
 #. Default: "Primary Sample"
 #: bika/lims/content/analysisrequest.py:292
 msgid "label_sample_primary"
-msgstr "Primair monster"
+msgstr ""
 
 #. Default: "Analysis Profiles"
 #: bika/lims/content/analysisrequest.py:418
 msgid "label_sample_profiles"
-msgstr "Analyseprofielen"
+msgstr ""
 
 #. Default: "Publication Specification"
 #: bika/lims/content/analysisrequest.py:734
 msgid "label_sample_publicationspecification"
-msgstr "Publicatiespecificatie"
+msgstr ""
 
 #. Default: "Retest from sample"
 #: bika/lims/content/analysisrequest.py:1336
 msgid "label_sample_retracted"
-msgstr "Hertest van monster"
+msgstr ""
 
 #. Default: "Sample Condition"
 #: bika/lims/content/analysisrequest.py:897
 msgid "label_sample_samplecondition"
-msgstr "Monstertoestand"
+msgstr ""
 
 #. Default: "Sample Point"
 #: bika/lims/content/analysisrequest.py:767
 msgid "label_sample_samplepoint"
-msgstr "Monsterpunt"
+msgstr ""
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisrequest.py:538
 msgid "label_sample_sampletype"
-msgstr "Monstertype"
+msgstr ""
 
 #. Default: "Expected Sampling Date"
 #: bika/lims/content/analysisrequest.py:512
 msgid "label_sample_samplingdate"
-msgstr "Verwachte monsternamedatum"
+msgstr ""
 
 #. Default: "Sampling Deviation"
 #: bika/lims/content/analysisrequest.py:869
 msgid "label_sample_samplingdeviation"
-msgstr "Monsternameafwijking"
+msgstr ""
 
 #. Default: "Analysis Specification"
 #: bika/lims/content/analysisrequest.py:690
 msgid "label_sample_specification"
-msgstr "Analysespecificatie"
+msgstr ""
 
 #. Default: "Storage Location"
 #: bika/lims/content/analysisrequest.py:791
 msgid "label_sample_storagelocation"
-msgstr "Opslaglocatie"
+msgstr ""
 
 #. Default: "Batch Sub-group"
 #: bika/lims/content/analysisrequest.py:363
 msgid "label_sample_subgroup"
-msgstr "Batch-subgroep"
+msgstr ""
 
 #. Default: "Sample Template"
 #: bika/lims/content/analysisrequest.py:390
 msgid "label_sample_template"
-msgstr "Monstersjabloon"
+msgstr ""
 
 #. Default: "Sample Types"
 #: bika/lims/content/samplepoint.py:95
 msgid "label_samplepoint_sampletypes"
-msgstr "Monstertypes"
+msgstr ""
 
 #. Default: "Category"
 #: senaite/core/content/samplepreservation.py:55
 msgid "label_samplepreservation_category"
-msgstr "Categorie"
+msgstr ""
 
 #. Default: "Container"
 #: senaite/core/content/sampletemplate.py:81
 msgid "label_sampletemplate_partition_container"
-msgstr "Container"
+msgstr ""
 
 #. Default: "Partition ID"
 #: senaite/core/content/sampletemplate.py:60
 msgid "label_sampletemplate_partition_part_id"
-msgstr "Partitie-ID"
+msgstr ""
 
 #. Default: "Preservation"
 #: senaite/core/content/sampletemplate.py:103
 msgid "label_sampletemplate_partition_preservation"
-msgstr "Conservering"
+msgstr ""
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:125
 msgid "label_sampletemplate_partition_sampletype"
-msgstr "Monstertype"
+msgstr ""
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:243
 msgid "label_sampletemplate_partitions"
-msgstr "Partities"
+msgstr ""
 
 #. Default: "Sample Point"
 #: senaite/core/content/sampletemplate.py:185
 msgid "label_sampletemplate_samplepoint"
-msgstr "Monsterpunt"
+msgstr ""
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:207
 msgid "label_sampletemplate_sampletype"
-msgstr "Monstertype"
+msgstr ""
 
 #. Default: "Admitted stickers for the sample type"
 #: senaite/core/content/sampletype.py:100
 msgid "label_sampletype_admitted"
-msgstr "Toegestane stickers voor het monstertype"
+msgstr ""
 
 #. Default: "Admitted sticker templates"
 #: senaite/core/content/sampletype.py:279
 msgid "label_sampletype_admitted_stickers_templates"
-msgstr "Toegestane stickersjablonen"
+msgstr ""
 
 #. Default: "Default Container Type"
 #: senaite/core/content/sampletype.py:254
 msgid "label_sampletype_containertype"
-msgstr "Standaard containertype"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/sampletype.py:142
 msgid "label_sampletype_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Default large sticker"
 #: senaite/core/content/sampletype.py:120
 msgid "label_sampletype_large_default"
-msgstr "Standaard grote sticker"
+msgstr ""
 
 #. Default: "Sample Matrix"
 #: senaite/core/content/sampletype.py:204
 msgid "label_sampletype_samplematrix"
-msgstr "Monstermatrix"
+msgstr ""
 
 #. Default: "Default small sticker"
 #: senaite/core/content/sampletype.py:111
 msgid "label_sampletype_small_default"
-msgstr "Standaard kleine sticker"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/sampletype.py:134
 msgid "label_sampletype_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Save"
 #: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
-msgstr "Opslaan"
+msgstr ""
 
 #. Default: "SENAITE LIMS"
 #: senaite/core/browser/viewlets/templates/footer.pt:14
 msgid "label_senaite"
-msgstr "SENAITE LIMS"
+msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
 #: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
-msgstr "Maximumwaarde voor het veld 'Aantal monsters' bij registratie"
+msgstr ""
 
 #. Default: "Landing Page"
 #: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
-msgstr "Startpagina"
+msgstr ""
 
 #. Default: "Item"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:78
 msgid "label_setupview_item"
-msgstr "Item"
+msgstr ""
 
 #. Default: "Items"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:81
 msgid "label_setupview_items"
-msgstr "Items"
+msgstr ""
 
 #. Default: "Out of range comment"
 #: bika/lims/browser/fields/resultrangefield.py:42
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:136
 msgid "label_specs_rangecomment"
-msgstr "Opmerking buiten bereik"
+msgstr ""
 
 #. Default: "Time zone"
 #: senaite/core/browser/user/personalpreferences.py:38
 msgid "label_timezone"
-msgstr "Tijdzone"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/browser/install/templates/senaite-addsite.pt:62
 msgid "label_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Upgrade…"
 #: senaite/core/browser/install/templates/senaite-overview.pt:67
 msgid "label_upgrade_hellip"
-msgstr "Upgraden…"
+msgstr ""
 
 #. Default: "Contact"
 #: senaite/core/browser/user/userdatapanel.py:81
 msgid "label_user_contact"
-msgstr "Contact"
+msgstr ""
 
 #. Default: "Email"
 #: senaite/core/browser/user/userdatapanel.py:70
 msgid "label_user_email"
-msgstr "E-mail"
+msgstr ""
 
 #. Default: "Full Name"
 #: senaite/core/browser/user/userdatapanel.py:64
 msgid "label_user_full_name"
-msgstr "Volledige naam"
+msgstr ""
 
 #. Default: "Preferred instrument"
 #: senaite/core/content/worksheettemplate.py:262
 msgid "label_worksheettemplate_instrument"
-msgstr "Voorkeursinstrument"
+msgstr ""
 
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
-msgstr "Beperken tot methode"
+msgstr ""
 
 #. Default: "Added ${count} label(s) to ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:185
 msgid "labels_added"
-msgstr "${count} label(s) toegevoegd aan ${affected} monster(s)"
+msgstr ""
 
 #. sample(s)"
 #. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:174
-#, fuzzy
 msgid "labels_changed"
-msgstr "${added} toegevoegd en ${removed} verwijderd toegepast op ${affected} monster(s)"
+msgstr ""
 
 #. Default: "Removed ${count} label(s) from ${affected} sample(s)"
 #: senaite/core/browser/modals/manage_labels.py:194
 msgid "labels_removed"
-msgstr "${count} label(s) verwijderd van ${affected} monster(s)"
+msgstr ""
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
 msgid "listing_add_analyses_column_category_title"
-msgstr "Categorie"
+msgstr ""
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:93
 msgid "listing_add_analyses_column_client"
-msgstr "Client"
+msgstr ""
 
 #. Default: "Order"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:102
 msgid "listing_add_analyses_column_client_order_number"
-msgstr "Order"
+msgstr ""
 
 #. Default: "Date Received"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:132
 msgid "listing_add_analyses_column_date_received"
-msgstr "Datum ontvangen"
+msgstr ""
 
 #. Default: "Due Date"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:139
 msgid "listing_add_analyses_column_due_date"
-msgstr "Vervaldatum"
+msgstr ""
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:110
 msgid "listing_add_analyses_column_request_id"
-msgstr "Aanvraag-ID"
+msgstr ""
 
 #. Default: "Analysis"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:125
 msgid "listing_add_analyses_column_title"
-msgstr "Analyse"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:150
 msgid "listing_add_analyses_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Filter by template method"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:221
 msgid "listing_add_analyses_state_restrict_to_method"
-msgstr "Filteren op sjabloonmethode"
+msgstr ""
 
 #. Default: "Filter by template services"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:203
 msgid "listing_add_analyses_state_restrict_to_services"
-msgstr "Filteren op sjabloondiensten"
+msgstr ""
 
 #. Default: "Add Analyses"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:74
 msgid "listing_add_analyses_title"
-msgstr "Analyses toevoegen"
+msgstr ""
 
 #. Default: "Add Blank Reference"
 #: senaite/core/browser/worksheets/worksheet/add_blank.py:44
 msgid "listing_add_blank_title"
-msgstr "Blancoreferentie toevoegen"
+msgstr ""
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/add_control.py:43
 msgid "listing_add_control_title"
-msgstr "Controlereferentie toevoegen"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:99
 msgid "listing_add_duplicate_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Add Duplicate"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:51
 msgid "listing_add_duplicate_title"
-msgstr "Duplicaat toevoegen"
+msgstr ""
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:81
 msgid "listing_add_duplication_column_client"
-msgstr "Client"
+msgstr ""
 
 #. Default: "Date Requested"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:88
 msgid "listing_add_duplication_column_created"
-msgstr "Datum aangevraagd"
+msgstr ""
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:74
 msgid "listing_add_duplication_column_request_id"
-msgstr "Aanvraag-ID"
+msgstr ""
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:67
 msgid "listing_add_duplication_column_title"
-msgstr "Positie"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:50
 msgid "listing_analysiscategories_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Department"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:80
 msgid "listing_analysiscategories_column_department"
-msgstr "Afdeling"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:72
 msgid "listing_analysiscategories_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:87
 msgid "listing_analysiscategories_column_sort_key"
-msgstr "Sorteersleutel"
+msgstr ""
 
 #. Default: "Category"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:66
 msgid "listing_analysiscategories_column_title"
-msgstr "Categorie"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:98
 msgid "listing_analysiscategories_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:114
 msgid "listing_analysiscategories_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:106
 msgid "listing_analysiscategories_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Analysis Categories"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:57
 msgid "listing_analysiscategories_title"
-msgstr "Analysecategorieën"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:54
 msgid "listing_analysisprofiles_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:76
 msgid "listing_analysisprofiles_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Profile Key"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:83
 msgid "listing_analysisprofiles_column_profilekey"
-msgstr "Profielsleutel"
+msgstr ""
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:91
 msgid "listing_analysisprofiles_column_sampletypes"
-msgstr "Monstertypes"
+msgstr ""
 
 #. Default: "Profile"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:69
 msgid "listing_analysisprofiles_column_title"
-msgstr "Profiel"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:103
 msgid "listing_analysisprofiles_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:119
 msgid "listing_analysisprofiles_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:111
 msgid "listing_analysisprofiles_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Analysis Profiles"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:61
 msgid "listing_analysisprofiles_title"
-msgstr "Analyseprofielen"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:50
 msgid "listing_attachmenttypes_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:73
 msgid "listing_attachmenttypes_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:67
 msgid "listing_attachmenttypes_column_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:83
 msgid "listing_attachmenttypes_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:99
 msgid "listing_attachmenttypes_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:91
 msgid "listing_attachmenttypes_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Attachment Types"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:57
 msgid "listing_attachmenttypes_title"
-msgstr "Bijlagetypes"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:50
 msgid "listing_batchlabels_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:67
 msgid "listing_batchlabels_column_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:77
 msgid "listing_batchlabels_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:93
 msgid "listing_batchlabels_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:85
 msgid "listing_batchlabels_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Batch Labels"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:57
 msgid "listing_batchlabels_title"
-msgstr "Batchlabels"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/calculations/view.py:51
 msgid "listing_calculation_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/calculations/view.py:75
 msgid "listing_calculation_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Formula"
 #: senaite/core/browser/controlpanel/calculations/view.py:82
 msgid "listing_calculation_formula"
-msgstr "Formule"
+msgstr ""
 
 #. Default: "Calculation"
 #: senaite/core/browser/controlpanel/calculations/view.py:68
 msgid "listing_calculation_title"
-msgstr "Berekening"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/calculations/view.py:93
 msgid "listing_calculations_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/calculations/view.py:111
 msgid "listing_calculations_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/calculations/view.py:102
 msgid "listing_calculations_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Calculations"
 #: senaite/core/browser/controlpanel/calculations/view.py:58
 msgid "listing_calculations_title"
-msgstr "Berekeningen"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/containertypes/view.py:51
 msgid "listing_containertypes_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/containertypes/view.py:72
 msgid "listing_containertypes_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/containertypes/view.py:66
 msgid "listing_containertypes_column_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/containertypes/view.py:82
 msgid "listing_containertypes_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/containertypes/view.py:98
 msgid "listing_containertypes_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/containertypes/view.py:90
 msgid "listing_containertypes_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Container Types"
 #: senaite/core/browser/controlpanel/containertypes/view.py:58
 msgid "listing_containertypes_title"
-msgstr "Containertypes"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:52
 msgid "listing_dynamic_analysisspec_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:61
 msgid "listing_dynamic_analysisspec_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:76
 msgid "listing_dynamic_analysisspecs_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:70
 msgid "listing_dynamic_analysisspecs_column_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:86
 msgid "listing_dynamic_analysisspecs_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:102
 msgid "listing_dynamic_analysisspecs_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:94
 msgid "listing_dynamic_analysisspecs_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Dynamic Analysis Specifications"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:61
 msgid "listing_dynamic_analysisspecs_title"
-msgstr "Dynamische analysespecificaties"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:52
 msgid "listing_instrumentlocations_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:74
 msgid "listing_instrumentlocations_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Location"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:67
 msgid "listing_instrumentlocations_column_title"
-msgstr "Locatie"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:94
 msgid "listing_instrumentlocations_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:86
 msgid "listing_instrumentlocations_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:102
 msgid "listing_instrumentlocations_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Instrument Locations"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:58
 msgid "listing_instrumentlocations_title"
-msgstr "Instrumentlocaties"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:49
 msgid "listing_instrumenttypes_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:72
 msgid "listing_instrumenttypes_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:65
 msgid "listing_instrumenttypes_column_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:83
 msgid "listing_instrumenttypes_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:101
 msgid "listing_instrumenttypes_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:92
 msgid "listing_instrumenttypes_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Instrument Types"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:56
 msgid "listing_instrumenttypes_title"
-msgstr "Instrumenttypes"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:52
 msgid "listing_interpretationtemplates_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:75
 msgid "listing_interpretationtemplates_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:81
 msgid "listing_interpretationtemplates_column_sampletypes"
-msgstr "Monstertypes"
+msgstr ""
 
 #. Default: "Text"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:88
 msgid "listing_interpretationtemplates_column_text"
-msgstr "Tekst"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:68
 msgid "listing_interpretationtemplates_column_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:99
 msgid "listing_interpretationtemplates_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:115
 msgid "listing_interpretationtemplates_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:107
 msgid "listing_interpretationtemplates_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Interpretation Templates"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:58
 msgid "listing_interpretationtemplates_title"
-msgstr "Interpretatiesjablonen"
+msgstr ""
 
 #. Default: "Add"
 #: view.py:49
 msgid "listing_labproduct_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Price"
 #: view.py:87
 msgid "listing_labproducts_column_price"
-msgstr "Prijs"
+msgstr ""
 
 #. Default: "Product"
 #: view.py:66
 msgid "listing_labproducts_column_title"
-msgstr "Product"
+msgstr ""
 
 #. Default: "Total Price"
 #: view.py:102
 msgid "listing_labproducts_column_total_price"
-msgstr "Totaalprijs"
+msgstr ""
 
 #. Default: "Unit"
 #: view.py:80
 msgid "listing_labproducts_column_unit"
-msgstr "Eenheid"
+msgstr ""
 
 #. Default: "VAT Amount"
 #: view.py:95
 msgid "listing_labproducts_column_vatamount"
-msgstr "Btw-bedrag"
+msgstr ""
 
 #. Default: "Volume"
 #: view.py:73
 msgid "listing_labproducts_column_volume"
-msgstr "Volume"
+msgstr ""
 
 #. Default: "Active"
 #: view.py:114
 msgid "listing_labproducts_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: view.py:132
 msgid "listing_labproducts_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: view.py:123
 msgid "listing_labproducts_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Lab Products"
 #: view.py:56
 msgid "listing_labproducts_title"
-msgstr "Labproducten"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:51
 msgid "listing_manufacturers_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:80
 msgid "listing_manufacturers_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:74
 msgid "listing_manufacturers_column_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:91
 msgid "listing_manufacturers_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:107
 msgid "listing_manufacturers_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:99
 msgid "listing_manufacturers_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Manufacturers"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:58
 msgid "listing_manufacturers_title"
-msgstr "Fabrikanten"
+msgstr ""
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:87
 msgid "listing_reference_samples_column_position"
-msgstr "Positie"
+msgstr ""
 
 #. Default: "Supported Services"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:79
 msgid "listing_reference_samples_column_supported_services"
-msgstr "Ondersteunde diensten"
+msgstr ""
 
 #. Default: "Reference Sample"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:72
 msgid "listing_reference_samples_column_title"
-msgstr "Referentiemonster"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:98
 msgid "listing_reference_samples_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:54
 msgid "listing_reference_samples_title"
-msgstr "Controlereferentie toevoegen"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/referencesamples.py:36
 msgid "listing_referencesamples_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:51
 msgid "listing_sampleconatiners_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Capacity"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:86
 msgid "listing_sampleconatiners_column_capacity"
-msgstr "Capaciteit"
+msgstr ""
 
 #. Default: "Container Type"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:79
 msgid "listing_sampleconatiners_column_containertype"
-msgstr "Containertype"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:72
 msgid "listing_sampleconatiners_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Pre-preserved"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:93
 msgid "listing_sampleconatiners_column_pre_preserved"
-msgstr "Voorgeconserveerd"
+msgstr ""
 
 #. Default: "Security seal intact"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:100
 msgid "listing_sampleconatiners_column_security_seal_intact"
-msgstr "Veiligheidszegel intact"
+msgstr ""
 
 #. Default: "Container"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:65
 msgid "listing_sampleconatiners_column_title"
-msgstr "Container"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:111
 msgid "listing_sampleconatiners_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:127
 msgid "listing_sampleconatiners_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:119
 msgid "listing_sampleconatiners_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Sample Containers"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:56
 msgid "listing_sampleconatiners_title"
-msgstr "Monstercontainers"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:47
 msgid "listing_sampleconditions_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:68
 msgid "listing_sampleconditions_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Sample Condition"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:62
 msgid "listing_sampleconditions_column_title"
-msgstr "Monstertoestand"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:78
 msgid "listing_sampleconditions_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:96
 msgid "listing_sampleconditions_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:87
 msgid "listing_sampleconditions_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Sample Conditions"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:54
 msgid "listing_sampleconditions_title"
-msgstr "Monstertoestanden"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:47
 msgid "listing_samplematrices_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:68
 msgid "listing_samplematrices_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Sample Matrix"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:62
 msgid "listing_samplematrices_column_title"
-msgstr "Monstermatrix"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:78
 msgid "listing_samplematrices_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:94
 msgid "listing_samplematrices_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:86
 msgid "listing_samplematrices_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Sample Matrices"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:54
 msgid "listing_samplematrices_title"
-msgstr "Monstermatrices"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:51
 msgid "listing_samplepoints_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:73
 msgid "listing_samplepoints_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:80
 msgid "listing_samplepoints_column_sampletypes"
-msgstr "Monstertypes"
+msgstr ""
 
 #. Default: "Sample Point"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:66
 msgid "listing_samplepoints_column_title"
-msgstr "Monsterpunt"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:92
 msgid "listing_samplepoints_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:108
 msgid "listing_samplepoints_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:100
 msgid "listing_samplepoints_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Sample Points"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:58
 msgid "listing_samplepoints_title"
-msgstr "Monsterpunten"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:47
 msgid "listing_samplepreservations_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:68
 msgid "listing_samplepreservations_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Sample Preservation"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:62
 msgid "listing_samplepreservations_column_title"
-msgstr "Monsterconservering"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:78
 msgid "listing_samplepreservations_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:96
 msgid "listing_samplepreservations_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:87
 msgid "listing_samplepreservations_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Sample Preservations"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:54
 msgid "listing_samplepreservations_title"
-msgstr "Monsterconserveringen"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:52
 msgid "listing_sampletemplates_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:73
 msgid "listing_sampletemplates_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Sample Template"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:67
 msgid "listing_sampletemplates_column_title"
-msgstr "Monstersjabloon"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:83
 msgid "listing_sampletemplates_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:99
 msgid "listing_sampletemplates_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:91
 msgid "listing_sampletemplates_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Sample Templates"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:59
 msgid "listing_sampletemplates_title"
-msgstr "Monstersjablonen"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:52
 msgid "listing_sampletypes_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Default Container"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:109
 msgid "listing_sampletypes_column_default_container"
-msgstr "Standaardcontainer"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:72
 msgid "listing_sampletypes_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Hazardous"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:79
 msgid "listing_sampletypes_column_hazardous"
-msgstr "Gevaarlijk"
+msgstr ""
 
 #. Default: "Minimum Volume"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:91
 msgid "listing_sampletypes_column_min_vol"
-msgstr "Minimumvolume"
+msgstr ""
 
 #. Default: "Prefix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:85
 msgid "listing_sampletypes_column_prefix"
-msgstr "Voorvoegsel"
+msgstr ""
 
 #. Default: "Retention Period"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:97
 msgid "listing_sampletypes_column_retention_period"
-msgstr "Bewaartermijn"
+msgstr ""
 
 #. Default: "SampleMatrix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:103
 msgid "listing_sampletypes_column_sample_matrix"
-msgstr "Monstermatrix"
+msgstr ""
 
 #. Default: "Sample Type"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:66
 msgid "listing_sampletypes_column_title"
-msgstr "Monstertype"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:119
 msgid "listing_sampletypes_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:135
 msgid "listing_sampletypes_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:127
 msgid "listing_sampletypes_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:58
 msgid "listing_sampletypes_title"
-msgstr "Monstertypes"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:49
 msgid "listing_samplingdeviations_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:72
 msgid "listing_samplingdeviations_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Sampling Deviation"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:65
 msgid "listing_samplingdeviations_column_title"
-msgstr "Monsternameafwijking"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:92
 msgid "listing_samplingdeviations_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:84
 msgid "listing_samplingdeviations_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:100
 msgid "listing_samplingdeviations_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Sampling Deviations"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:56
 msgid "listing_samplingdeviations_title"
-msgstr "Monsternameafwijkingen"
+msgstr ""
 
 #. Default: "Calculation"
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:70
 msgid "listing_services_column_calculation"
-msgstr "Berekening"
+msgstr ""
 
 #. Default: "Hidden"
 #: senaite/core/browser/widgets/services_widget.py:112
 msgid "listing_services_column_hidden"
-msgstr "Verborgen"
+msgstr ""
 
 #. Default: "Keyword"
 #: senaite/core/browser/widgets/services_widget.py:84
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:56
 msgid "listing_services_column_keyword"
-msgstr "Sleutelwoord"
+msgstr ""
 
 #. Default: "Methods"
 #: senaite/core/browser/widgets/services_widget.py:91
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:63
 msgid "listing_services_column_methods"
-msgstr "Methoden"
+msgstr ""
 
 #. Default: "Partition"
 #: senaite/core/browser/widgets/sampletemplate_services_widget.py:51
 msgid "listing_services_column_partition"
-msgstr "Partitie"
+msgstr ""
 
 #. Default: "Price"
 #: senaite/core/browser/widgets/services_widget.py:105
 msgid "listing_services_column_price"
-msgstr "Prijs"
+msgstr ""
 
 #. Default: "Service"
 #: senaite/core/browser/widgets/services_widget.py:76
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:48
 msgid "listing_services_column_title"
-msgstr "Dienst"
+msgstr ""
 
 #. Default: "Unit"
 #: senaite/core/browser/widgets/services_widget.py:98
 msgid "listing_services_column_unit"
-msgstr "Eenheid"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/widgets/services_widget.py:127
 msgid "listing_services_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:49
 msgid "listing_storagelocations_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:75
 msgid "listing_storagelocations_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Location Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:104
 msgid "listing_storagelocations_column_location_code"
-msgstr "Locatiecode"
+msgstr ""
 
 #. Default: "Location Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:97
 msgid "listing_storagelocations_column_location_title"
-msgstr "Locatietitel"
+msgstr ""
 
 #. Default: "Shelf Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:118
 msgid "listing_storagelocations_column_shelf_code"
-msgstr "Schapcode"
+msgstr ""
 
 #. Default: "Shelf Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:111
 msgid "listing_storagelocations_column_shelf_title"
-msgstr "Schaptitel"
+msgstr ""
 
 #. Default: "Site Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:90
 msgid "listing_storagelocations_column_site_code"
-msgstr "Sitecode"
+msgstr ""
 
 #. Default: "Site Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:83
 msgid "listing_storagelocations_column_site_title"
-msgstr "Sitetitel"
+msgstr ""
 
 #. Default: "Storage Location"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:68
 msgid "listing_storagelocations_column_title"
-msgstr "Opslaglocatie"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:129
 msgid "listing_storagelocations_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:147
 msgid "listing_storagelocations_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:138
 msgid "listing_storagelocations_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Storage Locations"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:55
 msgid "listing_storagelocations_title"
-msgstr "Opslaglocaties"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/subgroups/view.py:51
 msgid "listing_subgroup_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/subgroups/view.py:73
 msgid "listing_subgroups_column_description"
-msgstr "Omschrijving"
+msgstr ""
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/subgroups/view.py:80
 msgid "listing_subgroups_column_sortkey"
-msgstr "Sorteersleutel"
+msgstr ""
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/subgroups/view.py:67
 msgid "listing_subgroups_column_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/subgroups/view.py:91
 msgid "listing_subgroups_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/subgroups/view.py:109
 msgid "listing_subgroups_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/subgroups/view.py:100
 msgid "listing_subgroups_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Sub-Groups"
 #: senaite/core/browser/controlpanel/subgroups/view.py:58
 msgid "listing_subgroups_title"
-msgstr "Subgroepen"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:51
 msgid "listing_suppliercontacts_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Business Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:79
 msgid "listing_suppliercontacts_column_businessphone"
-msgstr "Zakelijk telefoonnummer"
+msgstr ""
 
 #. Default: "Email Address"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:73
 msgid "listing_suppliercontacts_column_emailaddress"
-msgstr "E-mailadres"
+msgstr ""
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:91
 msgid "listing_suppliercontacts_column_fax"
-msgstr "Fax"
+msgstr ""
 
 #. Default: "FullName"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:67
 msgid "listing_suppliercontacts_column_fullname"
-msgstr "Volledige naam"
+msgstr ""
 
 #. Default: "Mobile Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:85
 msgid "listing_suppliercontacts_column_mobilephone"
-msgstr "Mobiele telefoon"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:101
 msgid "listing_suppliercontacts_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Contacts"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:58
 msgid "listing_suppliercontacts_title"
-msgstr "Contactpersonen"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/view.py:54
 msgid "listing_suppliers_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Email"
 #: senaite/core/browser/controlpanel/suppliers/view.py:77
 msgid "listing_suppliers_column_email"
-msgstr "E-mail"
+msgstr ""
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/view.py:91
 msgid "listing_suppliers_column_fax"
-msgstr "Fax"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/suppliers/view.py:70
 msgid "listing_suppliers_column_name"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Phone"
 #: senaite/core/browser/controlpanel/suppliers/view.py:84
 msgid "listing_suppliers_column_phone"
-msgstr "Telefoon"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/suppliers/view.py:102
 msgid "listing_suppliers_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/view.py:118
 msgid "listing_suppliers_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/suppliers/view.py:110
 msgid "listing_suppliers_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Suppliers"
 #: senaite/core/browser/controlpanel/suppliers/view.py:61
 msgid "listing_suppliers_title"
-msgstr "Leveranciers"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Analyst"
 #: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
-msgstr "Analist"
+msgstr ""
 
 #. Default: "Created"
 #: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
-msgstr "Aangemaakt"
+msgstr ""
 
 #. Default: "Routine Analyses"
 #: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
-msgstr "Routineanalyses"
+msgstr ""
 
 #. Default: "QC Analyses"
 #: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
-msgstr "QC-analyses"
+msgstr ""
 
 #. Default: "Samples"
 #: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
-msgstr "Monsters"
+msgstr ""
 
 #. Default: "Progress"
 #: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
-msgstr "Voortgang"
+msgstr ""
 
 #. Default: "State"
 #: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
-msgstr "Status"
+msgstr ""
 
 #. Default: "Template"
 #: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
-msgstr "Sjabloon"
+msgstr ""
 
 #. Default: "Worksheet"
 #: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
-msgstr "Werkblad"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Mine"
 #: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
-msgstr "Mijn"
+msgstr ""
 
 #. Default: "Open"
 #: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
-msgstr "Open"
+msgstr ""
 
 #. Default: "To be verified"
 #: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
-msgstr "Te verifiëren"
+msgstr ""
 
 #. Default: "Verified"
 #: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
-msgstr "Geverifieerd"
+msgstr ""
 
 #. Default: "Worksheets"
 #: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
-msgstr "Werkbladen"
+msgstr ""
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:54
 msgid "listing_worksheettemplates_action_add"
-msgstr "Toevoegen"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:77
 msgid "listing_worksheettemplates_column_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Instrument"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:91
 msgid "listing_worksheettemplates_column_instrument"
-msgstr "Instrument"
+msgstr ""
 
 #. Default: "Method"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:84
 msgid "listing_worksheettemplates_column_method"
-msgstr "Methode"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:70
 msgid "listing_worksheettemplates_column_name"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:103
 msgid "listing_worksheettemplates_state_active"
-msgstr "Actief"
+msgstr ""
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:119
 msgid "listing_worksheettemplates_state_all"
-msgstr "Alle"
+msgstr ""
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:111
 msgid "listing_worksheettemplates_state_inactive"
-msgstr "Inactief"
+msgstr ""
 
 #. Default: "Worksheet Templates"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:61
 msgid "listing_worksheettemplates_title"
-msgstr "Werkbladsjablonen"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "minutes"
-msgstr "minuten"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — dirty indicator on the applied
 # preset
 msgid "modified"
-msgstr "gewijzigd"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
-msgstr "maandelijks"
+msgstr ""
 
 #. Default: "No analyses added to this worksheet."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:177
 msgid "no_analyses_added_to_this_worksheet"
-msgstr "Geen analyses toegevoegd aan dit werkblad."
+msgstr ""
 
 #. Default: "No analyses were added"
 #: senaite/core/browser/worksheets/worksheet/view.py:39
 msgid "no_analyses_were_added_message"
-msgstr "Er zijn geen analyses toegevoegd"
+msgstr ""
 
 #. Default: "Instrument has no data interface selected"
 #: senaite/core/browser/worksheets/worksheet/export.py:47
 msgid "no_data_instrument_message"
-msgstr "Voor het instrument is geen data-interface geselecteerd"
+msgstr ""
 
 #. Default: "Keyword '${duplicate}' duplicate found for a Analysis Service"
 #: senaite/core/validators/interimfields.py:97
 msgid "no_dup_service_keyword_validator_error"
-msgstr "Sleutelwoord '${duplicate}' dubbel gevonden voor een Analysedienst"
+msgstr ""
 
 #. Default: "'${duplicate}' duplicates found"
 #: senaite/core/validators/interimfields.py:83
 msgid "no_dups_values_validator_error"
-msgstr "'${duplicate}' duplicaten gevonden"
+msgstr ""
 
 #. Default: "Wildcards for  are not allowed: ${wildcards}"
 #: senaite/core/validators/formula.py:45
 msgid "no_wildcards__error"
-msgstr "Jokertekens voor  zijn niet toegestaan: ${wildcards}"
+msgstr ""
 
 #. Default: "'${field_name}' is required"
 #: senaite/core/validators/interimfields.py:54
 msgid "non_blank_validator_error"
-msgstr "'${field_name}' is verplicht"
+msgstr ""
 
 #. view."
 #. Default: "Layout view '${view}' not found. Set '${default}' as layout view."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:66
-#, fuzzy
 msgid "not_found_worksheet_layout_message"
-msgstr "Lay-outweergave '${view}' niet gevonden. '${default}' ingesteld als lay-outweergave."
+msgstr ""
 
 #. Default: "Set"
 #: senaite/core/browser/form/adapters/worksheettemplate.py:239
 msgid "num_of_positions_button_title"
-msgstr "Instellen"
+msgstr ""
 
 #: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
-msgstr "van"
+msgstr ""
 
 #: senaite/core/api/remarks.py:494
 msgid "original"
-msgstr "origineel"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
-msgstr "overzicht"
+msgstr ""
 
 # senaite.app.listing: Saved filter presets — menu subtitle
 msgid "per listing"
-msgstr "per lijst"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
-msgstr "per kwartaal"
+msgstr ""
 
 #: bika/lims/content/instrumentscheduledtask.py:137
 msgid "repeating every"
-msgstr "herhaalt elke"
+msgstr ""
 
 #: bika/lims/content/instrumentscheduledtask.py:138
 msgid "repeatperiod"
-msgstr "herhaalperiode"
+msgstr ""
 
 #. Default: "Not detected"
 #: bika/lims/content/abstractanalysis.py:1120
 msgid "result_below_llod"
-msgstr "Niet gedetecteerd"
+msgstr ""
 
 #. Default: "Detected but < ${LLOQ}"
 #: bika/lims/content/abstractanalysis.py:1131
 msgid "result_below_lloq"
-msgstr "Gedetecteerd maar < ${LLOQ}"
+msgstr ""
 
 #. Default: "Field Preservation"
 #: senaite/core/config/vocabularies.py:24
 msgid "sample_preservation_category_vocab_field"
-msgstr "Veldconservering"
+msgstr ""
 
 #. Default: "Lab Preservation"
 #: senaite/core/config/vocabularies.py:28
 msgid "sample_preservation_category_vocab_lab"
-msgstr "Labconservering"
+msgstr ""
 
 #. Default: "Only ASCII characters in prefix allowed"
 #: senaite/core/content/sampletype.py:88
 msgid "sampletype_prefix_ascii_validator_message"
-msgstr "Alleen ASCII-tekens in prefix toegestaan"
+msgstr ""
 
 #. Default: "No whitespaces in prefix allowed"
 #: senaite/core/content/sampletype.py:81
 msgid "sampletype_prefix_no_whitespace_validator_message"
-msgstr "Geen spaties in prefix toegestaan"
+msgstr ""
 
 #. Default: "You must select an instrument"
 #: senaite/core/browser/worksheets/worksheet/export.py:37
 msgid "select_instrument_message"
-msgstr "U moet een instrument selecteren"
+msgstr ""
 
 #. Default: "Condition"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:35
 msgid "set_analysis_conditions_colname_condition"
-msgstr "Voorwaarde"
+msgstr ""
 
 #. Default: "Show in report"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:37
 msgid "set_analysis_conditions_colname_report"
-msgstr "Tonen in rapport"
+msgstr ""
 
 #. Default: "Value"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:36
 msgid "set_analysis_conditions_colname_value"
-msgstr "Waarde"
+msgstr ""
 
 #. Default: "Folder to import the instrument results from"
 #: bika/lims/content/instrument.py:250
 msgid "subfield_label_instrument_import_folder"
-msgstr "Map waaruit de instrumentresultaten worden geïmporteerd"
+msgstr ""
 
 #. Default: "Interface Code"
 #: bika/lims/content/instrument.py:248
 msgid "subfield_label_instrument_interface_name"
-msgstr "Interfacecode"
+msgstr ""
 
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
-msgstr "Dit monster is verzonden door ${actor} op ${date}"
+msgstr ""
 
 #. Default: "This sample has been disposed by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
 msgid "this_sample_has_been_disposed_by"
-msgstr "Dit monster is afgevoerd door ${actor} op ${date}"
+msgstr ""
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11614,1098 +11503,1093 @@ msgstr "Dit monster is afgevoerd door ${actor} op ${date}"
 #. ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "time_format"
-msgstr "${H}:${M}"
+msgstr ""
 
 #. Default: "Accreditation"
 #: senaite/core/content/laboratory.py:170
 msgid "title_accreditation"
-msgstr "Accreditatie"
+msgstr ""
 
 #. Default: "Accreditation Body Abbreviation"
 #: senaite/core/content/laboratory.py:149
 msgid "title_accreditation_body"
-msgstr "Afkorting accreditatie-instantie"
+msgstr ""
 
 #. Default: "Accreditation Logo"
 #: senaite/core/content/laboratory.py:195
 msgid "title_accreditation_body_logo"
-msgstr "Accreditatielogo"
+msgstr ""
 
 #. Default: "Accreditation Body URL"
 #: senaite/core/content/laboratory.py:160
 msgid "title_accreditation_body_url"
-msgstr "URL accreditatie-instantie"
+msgstr ""
 
 #. Default: "Accreditation page header"
 #: senaite/core/content/laboratory.py:216
 msgid "title_accreditation_page_header"
-msgstr "Paginakop accreditatie"
+msgstr ""
 
 #. Default: "Accreditation Reference"
 #: senaite/core/content/laboratory.py:182
 msgid "title_accreditation_reference"
-msgstr "Accreditatiereferentie"
+msgstr ""
 
 #. Default: "Address"
 #: senaite/core/content/laboratory.py:88
 #: senaite/core/content/organization.py:82
 msgid "title_addresses_tab"
-msgstr "Adres"
+msgstr ""
 
 #. Default: "Comments"
 #: senaite/core/content/analysiscategory.py:60
 msgid "title_analysiscategory_comments"
-msgstr "Opmerkingen"
+msgstr ""
 
 #. Default: "Department"
 #: senaite/core/content/analysiscategory.py:81
 msgid "title_analysiscategory_department"
-msgstr "Afdeling"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/analysiscategory.py:52
 msgid "title_analysiscategory_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Sort Key"
 #: senaite/core/content/analysiscategory.py:95
 msgid "title_analysiscategory_sort_key"
-msgstr "Sorteersleutel"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/analysiscategory.py:44
 msgid "title_analysiscategory_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Commercial ID"
 #: senaite/core/content/analysisprofile.py:121
 msgid "title_analysisprofile_commercial_id"
-msgstr "Commerciële ID"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/analysisprofile.py:82
 msgid "title_analysisprofile_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Profile Keyword"
 #: senaite/core/content/analysisprofile.py:90
 msgid "title_analysisprofile_profile_key"
-msgstr "Profielsleutelwoord"
+msgstr ""
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/analysisprofile.py:145
 msgid "title_analysisprofile_profile_price"
-msgstr "Prijs (exclusief btw)"
+msgstr ""
 
 #. Default: "VAT %"
 #: senaite/core/content/analysisprofile.py:157
 msgid "title_analysisprofile_profile_vat"
-msgstr "Btw %"
+msgstr ""
 
 #. Default: "Profile Analyses"
 #: senaite/core/content/analysisprofile.py:106
 msgid "title_analysisprofile_services"
-msgstr "Profielanalyses"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/analysisprofile.py:74
 msgid "title_analysisprofile_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Use analysis profile price"
 #: senaite/core/content/analysisprofile.py:133
 msgid "title_analysisprofile_use_profile_price"
-msgstr "Analyseprofielprijs gebruiken"
+msgstr ""
 
 #. Default: "Analyst"
 #: senaite/core/permissions/localroles.py:30
 msgid "title_analyst_role"
-msgstr "Analist"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/attachmenttype.py:44
 msgid "title_attachmenttype_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/attachmenttype.py:36
 msgid "title_attachmenttype_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Bank Details"
 #: senaite/core/content/organization.py:110
 msgid "title_bank_details_tab"
-msgstr "Bankgegevens"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/batchlabel.py:36
 msgid "title_batchlabel_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "This site was built using the Plone Open Source CMS/WCM."
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "title_built_with_plone"
-msgstr "Deze site is gebouwd met het Plone Open Source CMS/WCM."
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/calculation.py:228
 msgid "title_calculation_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/calculation.py:220
 msgid "title_calculation_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Confidence Level %"
 #: senaite/core/content/laboratory.py:123
 msgid "title_confidence_level"
-msgstr "Betrouwbaarheidsniveau %"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/containertype.py:44
 msgid "title_containertype_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/containertype.py:36
 msgid "title_containertype_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Copyright"
 #: senaite/core/browser/viewlets/templates/footer.pt:11
 msgid "title_copyright"
-msgstr "Auteursrecht"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/department.py:60
 msgid "title_department_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Department ID"
 #: senaite/core/content/department.py:76
 msgid "title_department_id"
-msgstr "Afdelings-ID"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/department.py:48
 msgid "title_department_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "No instrument"
 #: senaite/core/vocabularies/instruments.py:43
 msgid "title_instrument_no_instrument"
-msgstr "Geen instrument"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/instrumentlocation.py:44
 msgid "title_instrumentlocation_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/instrumentlocation.py:36
 msgid "title_instrumentlocation_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/instrumenttype.py:44
 msgid "title_instrumenttype_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/instrumenttype.py:36
 msgid "title_instrumenttype_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/interpretationtemplate.py:51
 msgid "title_interpretationtemplate_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/interpretationtemplate.py:43
 msgid "title_interpretationtemplate_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Lab Clerk"
 #: senaite/core/permissions/localroles.py:44
 msgid "title_lab_clerk_role"
-msgstr "Labmedewerker"
+msgstr ""
 
 #. Default: "Lab Manager"
 #: senaite/core/permissions/localroles.py:79
 msgid "title_lab_manager_role"
-msgstr "Labmanager"
+msgstr ""
 
 #. Default: "Color"
 #: senaite/core/content/label.py:68
 msgid "title_label_color"
-msgstr "Kleur"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/label.py:56
 msgid "title_label_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/label.py:41
 msgid "title_label_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Laboratory Accredited"
 #: senaite/core/content/laboratory.py:136
 msgid "title_laboratory_accredited"
-msgstr "Laboratorium geaccrediteerd"
+msgstr ""
 
 #. Default: "Lab URL"
 #: senaite/core/content/laboratory.py:98
 msgid "title_laboratory_lab_url"
-msgstr "Lab-URL"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/labproduct.py:60
 msgid "title_labproduct_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/labproduct.py:85
 msgid "title_labproduct_price"
-msgstr "Prijs (exclusief btw)"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/labproduct.py:52
 msgid "title_labproduct_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Total Price"
 #: senaite/core/content/labproduct.py:123
 msgid "title_labproduct_total_price"
-msgstr "Totaalprijs"
+msgstr ""
 
 #. Default: "Unit"
 #: senaite/core/content/labproduct.py:76
 msgid "title_labproduct_unit"
-msgstr "Eenheid"
+msgstr ""
 
 #. Default: "VAT %"
 #: senaite/core/content/labproduct.py:98
 msgid "title_labproduct_vat"
-msgstr "Btw %"
+msgstr ""
 
 #. Default: "VAT"
 #: senaite/core/content/labproduct.py:114
 msgid "title_labproduct_vat_amount"
-msgstr "Btw"
+msgstr ""
 
 #. Default: "Volume"
 #: senaite/core/content/labproduct.py:68
 msgid "title_labproduct_volume"
-msgstr "Volume"
+msgstr ""
 
 #. Default: "Blank Reference"
 #: senaite/core/content/worksheettemplate.py:132
 msgid "title_layout_record_blank_ref"
-msgstr "Blancoreferentie"
+msgstr ""
 
 #. Default: "Control Reference"
 #: senaite/core/content/worksheettemplate.py:158
 msgid "title_layout_record_control_ref"
-msgstr "Controlereferentie"
+msgstr ""
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:191
 msgid "title_layout_record_dup"
-msgstr "Duplicaat van"
+msgstr ""
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:180
 msgid "title_layout_record_dup_proxy"
-msgstr "Duplicaat van"
+msgstr ""
 
 #. Default: "Position"
 #: senaite/core/content/worksheettemplate.py:96
 msgid "title_layout_record_pos"
-msgstr "Positie"
+msgstr ""
 
 #. Default: "Reference"
 #: senaite/core/content/worksheettemplate.py:169
 msgid "title_layout_record_reference_proxy"
-msgstr "Referentie"
+msgstr ""
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
-msgstr "Analysetype"
+msgstr ""
 
 #. Default: "Manage Viewlets"
 #: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
 msgid "title_manage_viewlets"
-msgstr "Viewlets beheren"
+msgstr ""
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
 msgid "title_manager_role"
-msgstr "Manager"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/manufacturer.py:44
 msgid "title_manufacturer_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/manufacturer.py:36
 msgid "title_manufacturer_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Not specified"
 #: senaite/core/vocabularies/methods.py:43
 msgid "title_method_not_specified"
-msgstr "Niet opgegeven"
+msgstr ""
 
 #. Default: "Bank Branch"
 #: senaite/core/content/organization.py:156
 msgid "title_organization_account_bank_branch"
-msgstr "Bankfiliaal"
+msgstr ""
 
 #. Default: "Bank Name"
 #: senaite/core/content/organization.py:148
 msgid "title_organization_account_bank_name"
-msgstr "Banknaam"
+msgstr ""
 
 #. Default: "Account Name"
 #: senaite/core/content/organization.py:132
 msgid "title_organization_account_name"
-msgstr "Rekeningnaam"
+msgstr ""
 
 #. Default: "Account Number"
 #: senaite/core/content/organization.py:140
 msgid "title_organization_account_number"
-msgstr "Rekeningnummer"
+msgstr ""
 
 #. Default: "Account Type"
 #: senaite/core/content/organization.py:124
 msgid "title_organization_account_type"
-msgstr "Rekeningtype"
+msgstr ""
 
 #. Default: "Email"
 #: senaite/core/content/organization.py:93
 msgid "title_organization_email"
-msgstr "E-mail"
+msgstr ""
 
 #. Default: "Fax"
 #: senaite/core/content/organization.py:73
 msgid "title_organization_fax"
-msgstr "Fax"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/organization.py:47
 msgid "title_organization_name"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Phone"
 #: senaite/core/content/organization.py:64
 msgid "title_organization_phone"
-msgstr "Telefoon"
+msgstr ""
 
 #. Default: "VAT number"
 #: senaite/core/content/organization.py:55
 msgid "title_organization_tax_number"
-msgstr "Btw-nummer"
+msgstr ""
 
 #. Default: "Owner"
 #: senaite/core/permissions/localroles.py:37
 msgid "title_owner_role"
-msgstr "Eigenaar"
+msgstr ""
 
 #. Default: "Preserver"
 #: senaite/core/permissions/localroles.py:51
 msgid "title_preserver_role"
-msgstr "Conserveerder"
+msgstr ""
 
 #. Default: "Publisher"
 #: senaite/core/permissions/localroles.py:58
 msgid "title_publisher_role"
-msgstr "Publiceerder"
+msgstr ""
 
 #. Default: "Required"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:47
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:91
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:137
 msgid "title_required"
-msgstr "Verplicht"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/samplecondition.py:44
 msgid "title_samplecondition_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/samplecondition.py:36
 msgid "title_samplecondition_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/samplecontainer.py:52
 msgid "title_samplecontainer_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/samplecontainer.py:44
 msgid "title_samplecontainer_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/samplematrix.py:44
 msgid "title_samplematrix_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/samplematrix.py:36
 msgid "title_samplematrix_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Attachment"
 #: senaite/core/content/samplepoint.py:159
 msgid "title_samplepoint_attachment_file"
-msgstr "Bijlage"
+msgstr ""
 
 #. Default: "Composite"
 #: senaite/core/content/samplepoint.py:143
 msgid "title_samplepoint_composite"
-msgstr "Samengesteld"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/samplepoint.py:64
 msgid "title_samplepoint_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Elevation"
 #: senaite/core/content/samplepoint.py:87
 msgid "title_samplepoint_elevation"
-msgstr "Hoogte"
+msgstr ""
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:72
 msgid "title_samplepoint_location"
-msgstr "Locatie"
+msgstr ""
 
 #. Default: "Sampling Frequency"
 #: senaite/core/content/samplepoint.py:99
 msgid "title_samplepoint_sampling_frequency"
-msgstr "Monsternamefrequentie"
+msgstr ""
 
 #. Default: "Sample Types"
 #: senaite/core/content/samplepoint.py:122
 msgid "title_samplepoint_sampling_sample_types"
-msgstr "Monstertypes"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/samplepoint.py:56
 msgid "title_samplepoint_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/samplepreservation.py:47
 msgid "title_samplepreservation_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/samplepreservation.py:39
 msgid "title_samplepreservation_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Sampler"
 #: senaite/core/permissions/localroles.py:65
 msgid "title_sampler_role"
-msgstr "Monsternemer"
+msgstr ""
 
 #. Default: "Auto-partition on sample reception"
 #: senaite/core/content/sampletemplate.py:256
 msgid "title_sampletemplate_auto_partition"
-msgstr "Automatisch partitioneren bij monsterontvangst"
+msgstr ""
 
 #. Default: "Composite"
 #: senaite/core/content/sampletemplate.py:217
 msgid "title_sampletemplate_composite"
-msgstr "Samengesteld"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/sampletemplate.py:167
 msgid "title_sampletemplate_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Sample collected by the laboratory"
 #: senaite/core/content/sampletemplate.py:226
 msgid "title_sampletemplate_sampling_required"
-msgstr "Monster genomen door het laboratorium"
+msgstr ""
 
 #. Default: "Services"
 #: senaite/core/content/sampletemplate.py:269
 msgid "title_sampletemplate_services"
-msgstr "Diensten"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/sampletemplate.py:161
 msgid "title_sampletemplate_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Retention Period"
 #: senaite/core/content/sampletype.py:151
 msgid "title_sampletype_duration_period"
-msgstr "Bewaartermijn"
+msgstr ""
 
 #. Default: "Hazard categories"
 #: senaite/core/content/sampletype.py:178
 msgid "title_sampletype_hazard_categories"
-msgstr "Gevarencategorieën"
+msgstr ""
 
 #. Default: "Hazardous"
 #: senaite/core/content/sampletype.py:166
 msgid "title_sampletype_hazardous"
-msgstr "Gevaarlijk"
+msgstr ""
 
 #. Default: "Minimum Volume"
 #: senaite/core/content/sampletype.py:231
 msgid "title_sampletype_min_volume"
-msgstr "Minimumvolume"
+msgstr ""
 
 #. Default: "Sample Type Prefix"
 #: senaite/core/content/sampletype.py:218
 msgid "title_sampletype_prefix"
-msgstr "Monstertypeprefix"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/samplingdeviation.py:44
 msgid "title_samplingdeviation_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/samplingdeviation.py:36
 msgid "title_samplingdeviation_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Allow to set the result capture date"
 #: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
-msgstr "Toestaan om de vastlegdatum van het resultaat in te stellen"
+msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
 #: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
-msgstr "Indienen van resultaten voor niet-toegewezen analyses toestaan"
+msgstr ""
 
 #. Default: "Always send publication email to responsibles"
 #: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
-msgstr "Publicatie-e-mail altijd naar verantwoordelijken sturen"
+msgstr ""
 
 #. Default: "Automatic log-off"
 #: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
-msgstr "Automatisch afmelden"
+msgstr ""
 
 #. Default: "Automatic verification of samples"
 #: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
-msgstr "Automatische verificatie van monsters"
+msgstr ""
 
 #. Default: "Categorise analysis services"
 #: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
-msgstr "Analysediensten categoriseren"
+msgstr ""
 
 #. Default: "Categorize sample analyses"
 #: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
-msgstr "Monsteranalyses categoriseren"
+msgstr ""
 
 #. Default: "Currency"
 #: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
-msgstr "Valuta"
+msgstr ""
 
 #. Default: "Use Dashboard as default front page"
 #: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
-msgstr "Dashboard als standaard startpagina gebruiken"
+msgstr ""
 
 #. Default: "Date sampled required"
 #: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
-msgstr "Monsternamedatum verplicht"
+msgstr ""
 
 #. Default: "Default decimal mark"
 #: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
-msgstr "Standaard decimaalteken"
+msgstr ""
 
 #. Default: "Country"
 #: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
-msgstr "Land"
+msgstr ""
 
 #. Default: "Default count of Sample to add."
 #: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
-msgstr "Standaard aantal toe te voegen monsters."
+msgstr ""
 
 #. Default: "Publication 'From' address"
 #: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
-msgstr "Publicatie 'Van'-adres"
+msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
 #: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
-msgstr "Een opmerkingenveld aan alle analyses toevoegen"
+msgstr ""
 
 #. Default: "Enable Sample Specifications"
 #: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
-msgstr "Monsterspecificaties inschakelen"
+msgstr ""
 
 #. Default: "Enable the rejection workflow"
 #: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
-msgstr "De afwijzingsworkflow inschakelen"
+msgstr ""
 
 #. Default: "Exponential format threshold"
 #: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
-msgstr "Drempel voor exponentiële notatie"
+msgstr ""
 
 #. Default: "Invalidation reason required"
 #: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
-msgstr "Reden voor ongeldigverklaring verplicht"
+msgstr ""
 
 #. Default: "Landing Page"
 #: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
-msgstr "Landingspagina"
+msgstr ""
 
 #. Default: "Member discount %"
 #: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
-msgstr "Ledenkorting %"
+msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
 #: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
-msgstr "Minimumaantal resultaten voor QC-statistiekberekeningen"
+msgstr ""
 
 #. Default: "Number of required verifications"
 #: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
-msgstr "Aantal vereiste verificaties"
+msgstr ""
 
 #. Default: "Publication Email Text"
 #: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
-msgstr "Tekst publicatie-e-mail"
+msgstr ""
 
 #. Default: "Rejection reasons"
 #: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
-msgstr "Afwijzingsredenen"
+msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
 #: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
-msgstr "Werkbladbeheer beperken tot labmanagers"
+msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
 #: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
-msgstr "Werkbladtoegang beperken tot toegewezen analisten"
+msgstr ""
 
 #. Default: "Default decimal mark"
 #: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
-msgstr "Standaard decimaalteken"
+msgstr ""
 
 #. Default: "Allow sample duplication"
 #: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
-msgstr "Monsterduplicatie toestaan"
+msgstr ""
 
 #. Default: "Require sample analyses"
 #: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
-msgstr "Monsteranalyses vereisen"
+msgstr ""
 
 #. Default: "Sample view analysis columns"
 #: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
-msgstr "Analysekolommen in monsterweergave"
+msgstr ""
 
 #. Default: "Default scientific notation format for reports"
 #: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
-msgstr "Standaard wetenschappelijke notatie voor rapporten"
+msgstr ""
 
 #. Default: "Default scientific notation format for results"
 #: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
-msgstr "Standaard wetenschappelijke notatie voor resultaten"
+msgstr ""
 
 #. Default: "Allow self-verification of results"
 #: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
-msgstr "Zelfverificatie van resultaten toestaan"
+msgstr ""
 
 #. Default: "Display laboratory name in the login page"
 #: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
-msgstr "Laboratoriumnaam tonen op de aanmeldpagina"
+msgstr ""
 
 #. Default: "Display sample partitions to clients"
 #: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
-msgstr "Monsterpartities tonen aan klanten"
+msgstr ""
 
 #. Default: "Include and display pricing information"
 #: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
-msgstr "Prijsinformatie opnemen en tonen"
+msgstr ""
 
 #. Default: "Sidebar navigation folders"
 #: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
-msgstr "Navigatiemappen zijbalk"
+msgstr ""
 
 #. Default: "Sidebar navigation depth"
 #: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
-msgstr "Navigatiediepte zijbalk"
+msgstr ""
 
 #. Default: "Sidebar skipped portal types"
 #: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
-msgstr "Overgeslagen portaltypes zijbalk"
+msgstr ""
 
 #. Default: "Multi Verification type"
 #: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
-msgstr "Type multiverificatie"
+msgstr ""
 
 #. Default: "VAT %"
 #: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
-msgstr "Btw %"
+msgstr ""
 
 #. Default: "Default layout in worksheet view"
 #: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
-msgstr "Standaard lay-out in werkbladweergave"
+msgstr ""
 
 #. Default: "Worksheet view analysis columns"
 #: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
-msgstr "Analysekolommen in werkbladweergave"
+msgstr ""
 
 #. Default: "Service UID"
 #: senaite/core/content/worksheettemplate.py:86
 msgid "title_service_uid"
-msgstr "Dienst-UID"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/storagelocation.py:46
 msgid "title_storagelocation_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Location Code"
 #: senaite/core/content/storagelocation.py:102
 msgid "title_storagelocation_location_code"
-msgstr "Locatiecode"
+msgstr ""
 
 #. Default: "Location Description"
 #: senaite/core/content/storagelocation.py:114
 msgid "title_storagelocation_location_description"
-msgstr "Locatiebeschrijving"
+msgstr ""
 
 #. Default: "Location Title"
 #: senaite/core/content/storagelocation.py:90
 msgid "title_storagelocation_location_title"
-msgstr "Locatietitel"
+msgstr ""
 
 #. Default: "Location Type"
 #: senaite/core/content/storagelocation.py:126
 msgid "title_storagelocation_location_type"
-msgstr "Locatietype"
+msgstr ""
 
 #. Default: "Shelf Code"
 #: senaite/core/content/storagelocation.py:150
 msgid "title_storagelocation_shelf_code"
-msgstr "Schapcode"
+msgstr ""
 
 #. Default: "Shelf Description"
 #: senaite/core/content/storagelocation.py:162
 msgid "title_storagelocation_shelf_description"
-msgstr "Schapbeschrijving"
+msgstr ""
 
 #. Default: "Shelf Title"
 #: senaite/core/content/storagelocation.py:138
 msgid "title_storagelocation_shelf_title"
-msgstr "Schaptitel"
+msgstr ""
 
 #. Default: "Site Code"
 #: senaite/core/content/storagelocation.py:66
 msgid "title_storagelocation_site_code"
-msgstr "Sitecode"
+msgstr ""
 
 #. Default: "Site Description"
 #: senaite/core/content/storagelocation.py:78
 msgid "title_storagelocation_site_description"
-msgstr "Sitebeschrijving"
+msgstr ""
 
 #. Default: "Site Title"
 #: senaite/core/content/storagelocation.py:54
 msgid "title_storagelocation_site_title"
-msgstr "Sitetitel"
+msgstr ""
 
 #. Default: "Address"
 #: senaite/core/content/storagelocation.py:38
 msgid "title_storagelocation_title"
-msgstr "Adres"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/subgroup.py:48
 msgid "title_subgroup_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Sort Key"
 #: senaite/core/content/subgroup.py:56
 msgid "title_subgroup_sort_key"
-msgstr "Sorteersleutel"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/subgroup.py:40
 msgid "title_subgroup_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "IBAN"
 #: senaite/core/content/supplier.py:96
 msgid "title_supplier_iban"
-msgstr "IBAN"
+msgstr ""
 
 #. Default: "Lab Account Number"
 #: senaite/core/content/supplier.py:47
 msgid "title_supplier_lab_contact_number"
-msgstr "Labrekeningnummer"
+msgstr ""
 
 #. Default: "NIB"
 #: senaite/core/content/supplier.py:84
 msgid "title_supplier_nib"
-msgstr "NIB"
+msgstr ""
 
 #. Default: "Remarks"
 #: senaite/core/content/supplier.py:55
 msgid "title_supplier_remarks"
-msgstr "Opmerkingen"
+msgstr ""
 
 #. Default: "SWIFT code"
 #: senaite/core/content/supplier.py:108
 msgid "title_supplier_swift_code"
-msgstr "SWIFT-code"
+msgstr ""
 
 #. Default: "Website"
 #: senaite/core/content/supplier.py:63
 msgid "title_supplier_website"
-msgstr "Website"
+msgstr ""
 
 #. Default: "Verifier"
 #: senaite/core/permissions/localroles.py:72
 msgid "title_verifier_role"
-msgstr "Verifieerder"
+msgstr ""
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheet.py:165
 msgid "title_worksheet_analyses"
-msgstr "Analyses"
+msgstr ""
 
 #. Default: "Analyst"
 #: senaite/core/content/worksheet.py:187
 msgid "title_worksheet_analyst"
-msgstr "Analist"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/worksheet.py:136
 msgid "title_worksheet_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Instrument"
 #: senaite/core/content/worksheet.py:197
 msgid "title_worksheet_instrument"
-msgstr "Instrument"
+msgstr ""
 
 #. Default: "Layout"
 #: senaite/core/content/worksheet.py:154
 msgid "title_worksheet_layout"
-msgstr "Lay-out"
+msgstr ""
 
 #. Default: "Analysis"
 #: senaite/core/content/worksheet.py:110
 msgid "title_worksheet_layout_analysis"
-msgstr "Analyse"
+msgstr ""
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheet.py:90
 msgid "title_worksheet_layout_analysis_type"
-msgstr "Analysetype"
+msgstr ""
 
 #. Default: "Container"
 #: senaite/core/content/worksheet.py:100
 msgid "title_worksheet_layout_container"
-msgstr "Container"
+msgstr ""
 
 #. Default: "Position"
 #: senaite/core/content/worksheet.py:81
 msgid "title_worksheet_layout_position"
-msgstr "Positie"
+msgstr ""
 
 #. Default: "Method"
 #: senaite/core/content/worksheet.py:176
 msgid "title_worksheet_method"
-msgstr "Methode"
+msgstr ""
 
 #. Default: "Remarks"
 #: senaite/core/content/worksheet.py:209
 msgid "title_worksheet_remarks"
-msgstr "Opmerkingen"
+msgstr ""
 
 #. Default: "Results Layout"
 #: senaite/core/content/worksheet.py:217
 msgid "title_worksheet_results_layout"
-msgstr "Resultatenlay-out"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/worksheet.py:127
 msgid "title_worksheet_title"
-msgstr "Naam"
+msgstr ""
 
 #. Default: "Worksheet Template"
 #: senaite/core/content/worksheet.py:144
 msgid "title_worksheet_worksheettemplate"
-msgstr "Werkbladsjabloon"
+msgstr ""
 
 #. Default: "Description"
 #: senaite/core/content/worksheettemplate.py:213
 msgid "title_worksheettemplate_description"
-msgstr "Beschrijving"
+msgstr ""
 
 #. Default: "Number of Positions"
 #: senaite/core/content/worksheettemplate.py:290
 msgid "title_worksheettemplate_num_of_positions"
-msgstr "Aantal posities"
+msgstr ""
 
 #. Default: "Analysis Services"
 #: senaite/core/content/worksheettemplate.py:346
 msgid "title_worksheettemplate_services"
-msgstr "Analysediensten"
+msgstr ""
 
 #. Default: "Worksheet Layout"
 #: senaite/core/content/worksheettemplate.py:311
 msgid "title_worksheettemplate_template_layout"
-msgstr "Werkbladlay-out"
+msgstr ""
 
 #. Default: "Name"
 #: senaite/core/content/worksheettemplate.py:205
 msgid "title_worksheettemplate_title"
-msgstr "Naam"
+msgstr ""
 
 #: bika/lims/content/instrumentscheduledtask.py:140
 msgid "until"
-msgstr "tot"
+msgstr ""
 
 #. Lower Limit of Quantification (LLOQ)."
 #. Default: "The Lower Limit of Detection (LLOD) cannot be greater than the Lower Limit of Quantification (LLOQ)."
 #: bika/lims/validators.py:1491
-#, fuzzy
 msgid "validator_llod_above_lloq"
-msgstr "De onderste detectielimiet (LLOD) mag niet groter zijn dan de onderste kwantificeringslimiet (LLOQ)."
+msgstr ""
 
 #. or equal to the Upper Limit of Quantification (ULOQ)."
 #. Default: "The Lower Limit of Quantification (LLOQ) cannot be greater than or equal to the Upper Limit of Quantification (ULOQ)."
 #: bika/lims/validators.py:1519
-#, fuzzy
 msgid "validator_lloq_above_uloq"
-msgstr "De onderste kwantificeringslimiet (LLOQ) mag niet groter dan of gelijk aan de bovenste kwantificeringslimiet (ULOQ) zijn."
+msgstr ""
 
 #. associated with other objects, such as QC analyses."
 #. Default: "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
 #: bika/lims/validators.py:1586
-#, fuzzy
 msgid "validator_referencesample_id_children"
-msgstr "De referentiemonster-ID kan niet worden gewijzigd omdat deze al gekoppeld is aan andere objecten, zoals QC-analyses."
+msgstr ""
 
 #. Default: "A Reference Sample with the ID '%s' already exists."
 #: bika/lims/validators.py:1601
 msgid "validator_referencesample_id_exists"
-msgstr "Er bestaat al een referentiemonster met de ID '%s'."
+msgstr ""
 
 #. letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no
 #. other Reference Sample with the same ID already exists."
 #. Default: "The Reference Sample ID is invalid. Ensure it contains only letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no other Reference Sample with the same ID already exists."
 #: bika/lims/validators.py:1576
-#, fuzzy
 msgid "validator_referencesample_id_invalid"
-msgstr "De referentiemonster-ID is ongeldig. Zorg ervoor dat deze alleen letters, cijfers, underscores ('_') of koppeltekens ('-') bevat, en controleer dat er geen ander referentiemonster met dezelfde ID al bestaat."
+msgstr ""
 
 #. the Upper Limit of Detection (ULOD)."
 #. Default: "The Upper Limit of Quantification (LLOQ) cannot be greater than the Upper Limit of Detection (ULOD)."
 #: bika/lims/validators.py:1547
-#, fuzzy
 msgid "validator_uloq_above_ulod"
-msgstr "De bovenste kwantificeringslimiet (LLOQ) mag niet groter zijn dan de bovenste detectielimiet (ULOD)."
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
-msgstr "verificatie(s) in behandeling"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:251
 msgid "weekly"
-msgstr "wekelijks"
+msgstr ""
 
 #. Default: "Created worksheet ${ws_id}"
 #: senaite/core/browser/modals/sample.py:67
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:63
 msgid "worksheet_created"
-msgstr "Werkblad ${ws_id} aangemaakt"
+msgstr ""
 
 #. Default: "Worksheet not created."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:56
 msgid "worksheet_not_created"
-msgstr "Werkblad niet aangemaakt."
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:255
 msgid "yearly"
-msgstr "jaarlijks"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:783
 msgid "{request_id}: calculated result for '{analysis_keyword}': '{analysis_result}'"
-msgstr "{request_id}: berekend resultaat voor '{analysis_keyword}': '{analysis_result}'"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:532
 msgid "{request_id}: {keywords} imported sucessfully"
-msgstr "{request_id}: {keywords} succesvol geïmporteerd"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:731
 msgid "{sid} Updated field '{field}' with '{value}'"
-msgstr "{sid} Veld '{field}' bijgewerkt met '{value}'"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:613
 msgid "{sid} result for '{analysis_keyword}:{interim_keyword}': '{value}'"
-msgstr "{sid} resultaat voor '{analysis_keyword}:{interim_keyword}': '{value}'"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:680
 msgid "{sid} result for '{keyword}': '{result}'"
-msgstr "{sid} resultaat voor '{keyword}': '{result}'"
+msgstr ""
 
 #: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
-msgstr "{} (Verouderd)"
+msgstr ""
 
 #: bika/lims/controlpanel/bika_instruments.py:173
 msgid "{} weeks and {} day(s)"
-msgstr "{} weken en {} dag(en)"
+msgstr ""

--- a/src/senaite/core/locales/nl_BE/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/nl_BE/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Dutch (Belgium) (https://app.transifex.com/senaite/teams/87045/nl_BE/)\n"

--- a/src/senaite/core/locales/nl_BE/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/nl_BE/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Dutch (Belgium) (https://app.transifex.com/senaite/teams/87045/nl_BE/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/nl_BE/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/nl_BE/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Dutch (Belgium) (https://app.transifex.com/senaite/teams/87045/nl_BE/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: nl_BE\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/nl_BE/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/nl_BE/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Dutch (Belgium) (https://app.transifex.com/senaite/teams/87045/nl_BE/)\n"

--- a/src/senaite/core/locales/pl/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pl/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Polish (https://app.transifex.com/senaite/teams/87045/pl/)\n"

--- a/src/senaite/core/locales/pl/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pl/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Polish (https://app.transifex.com/senaite/teams/87045/pl/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/pl/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pl/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Polish (https://app.transifex.com/senaite/teams/87045/pl/)\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: pl\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -29,6 +29,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} załączników o łącznym rozmiarze ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -54,6 +55,7 @@ msgid "%s has no '%s' column."
 msgstr "%s nie ma '%s' kolumny."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Wróć"
@@ -123,6 +125,10 @@ msgstr "*** Wiadomość została wygenerowana automatycznie, prosimy na nią nie
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -140,7 +146,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Witamy w SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -198,7 +204,7 @@ msgid "Account Type"
 msgstr "Typ konta"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -243,21 +249,21 @@ msgstr "Aktywuj"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Aktywne"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Dodaj"
 
@@ -285,15 +291,19 @@ msgstr "Dodaj próbkę zdublowaną"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Dadaj pole komentarza do wszystkich analiz"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -306,8 +316,11 @@ msgstr "Dodaj nowy załącznik"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -371,13 +384,21 @@ msgstr "Poniżej wymieniono wszystkie akredytowane metody badań."
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Wszystkie analizy przypisane"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Zezwól na ręczne wprowadzanie granicy oznaczalności"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -395,11 +416,11 @@ msgstr "Zezwalaj temu samemu użytkownikowi na wielokrotną weryfikację"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Pozwól temu samemu użytkownikowi na wielokrotną weryfikację ale nie kolejno"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Pozwól na samodzielną weryfikację wyników"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -428,14 +449,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Analizę wykonał"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analizy"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -505,7 +542,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -542,7 +579,7 @@ msgstr "Analityk musi być wskazany."
 msgid "Any"
 msgstr "Wszystkie"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -553,6 +590,10 @@ msgstr "Zastosuj"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Zastosuj szablon"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -566,19 +607,15 @@ msgstr "Numer ewidencyjny"
 msgid "Assign"
 msgstr "Przypisz"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Przydzielony"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Przypisany do: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr ""
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -592,7 +629,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -680,11 +717,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Auto-partycja przy odbiorze"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Automatyczne odbieranie próbek"
 
@@ -692,15 +733,15 @@ msgstr "Automatyczne odbieranie próbek"
 msgid "Autofill"
 msgstr "Automatyczne wypełnianie"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Automatyczne wylogowanie"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -751,7 +792,7 @@ msgstr "Seria próbek"
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Kod serii próbek"
 
@@ -781,6 +822,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Azymut"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Adres fakturowania"
@@ -801,7 +846,7 @@ msgstr "Marka"
 msgid "Bulk Discount"
 msgstr "Rabat hurtowy"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Obowiązuje zniżka hurtowa"
@@ -819,19 +864,19 @@ msgstr "Telefon służbowy"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -839,12 +884,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC Emails"
 
@@ -900,23 +945,23 @@ msgstr "Kalibracje"
 msgid "Calibrator"
 msgstr "Kalibrator"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Można zweryfikować, ale przesłane przez bieżącego użytkownika"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Może zweryfikować, ale został już zweryfikowany przez bieżącego użytkownika"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Anuluj"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Anulowane"
 
@@ -936,15 +981,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "Nie można zweryfikować, ostatnio zweryfikowano przez bieżącego użytkownika"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "Nie można zweryfikować, przesłane przez bieżącego użytkownika"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "Nie można zweryfikować, zostało zweryfikowane przez bieżącego użytkownika"
 
@@ -970,7 +1015,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Numer katalogowy"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Klasyfikowane metody analityczne"
 
@@ -1002,11 +1047,11 @@ msgid "Changes Saved"
 msgstr "Zmiany zapisano"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Zmiany zapisano."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1043,31 +1088,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Wybierz typ wielokrotnej weryfikacji dla tego samego użytkownika. To ustawienie może włączać/wyłączać weryfikację w efekcie umożliwiając weryfikowanie więcej niż raz dla tego samego użytkownika."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1080,20 +1125,34 @@ msgstr "Miasto"
 msgid "Classic"
 msgstr "Klasyczny"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Kliknij, aby rozwinąć tę kategorię"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Klient"
@@ -1105,7 +1164,7 @@ msgstr "Kod serii próbek nadany przez klienta"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID klienta"
 
@@ -1117,7 +1176,7 @@ msgstr "Strona docelowa klienta"
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Zlecenie klienta"
 
@@ -1127,7 +1186,7 @@ msgstr "Zlecenie klienta"
 msgid "Client Order Number"
 msgstr "Numer Zamówienia Klienta"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Odniesienie do klienta"
 
@@ -1136,7 +1195,7 @@ msgstr "Odniesienie do klienta"
 msgid "Client Reference"
 msgstr "Odniesienie do klienta"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Kod próbki nadany przez klienta"
 
@@ -1229,7 +1288,7 @@ msgstr "Komentarze"
 msgid "Comments or results interpretation"
 msgstr "Komentarz lub interpretacja wyników"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "Komercyjny ID"
@@ -1267,6 +1326,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1285,7 +1348,7 @@ msgstr "Potwierdź hasło"
 msgid "Considerations"
 msgstr "Uwarunkowania"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Kontakt"
@@ -1329,7 +1392,7 @@ msgstr "Pojemniki na próbki"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1362,15 +1425,15 @@ msgstr "Kopiuj metodę badań"
 msgid "Copy from"
 msgstr "Kopiuj z"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Kopiuj jako nowy"
 
@@ -1380,6 +1443,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1398,11 +1465,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1415,7 +1482,7 @@ msgstr "Kraj"
 msgid "Create Invoice PDF"
 msgstr "Utwórz fakturę PDF"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1423,7 +1490,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1435,7 +1502,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr "Utwórz nowego Użytkownika"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1465,7 +1532,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Twórca"
 
@@ -1474,7 +1541,7 @@ msgstr "Twórca"
 msgid "Criteria"
 msgstr "Kryteria"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Waluta"
 
@@ -1482,13 +1549,21 @@ msgstr "Waluta"
 msgid "Current"
 msgstr "Bieżące"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Defininiowany separator miejsca dziesiętnego"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "Lista Dystrybucyjna"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1535,23 +1610,23 @@ msgstr "Data modyfikacji"
 msgid "Date Opened"
 msgstr "Data otwarcia"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Data utrwalenia"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Data opublikowania"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Data dostarczenia"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1563,11 +1638,11 @@ msgstr "Data zgłoszenia"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Data pobrania"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1609,7 +1684,7 @@ msgstr "Data uzyskania świadectwa kalibracji"
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1632,11 +1707,11 @@ msgstr "Nieaktywny do następnego testu kalibracji"
 msgid "Deactivate"
 msgstr "Dezaktywuj"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Separator dziesiętny do zastosowania w raportach tego Klienta."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1648,7 +1723,7 @@ msgstr "Domyślny pojemnik"
 msgid "Default Department"
 msgstr "Domyślny dział"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1660,7 +1735,7 @@ msgstr "Domyślny instrument"
 msgid "Default Method"
 msgstr "Domyślna metoda"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1668,20 +1743,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Domyślne utrwalanie"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Domyślny separator dziesiętny"
 
@@ -1693,7 +1768,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr "Domyślna duża naklejka"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Domyślny układ w widoku arkusza"
 
@@ -1725,15 +1800,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Domyślny okres przechowywania próbki"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Domyślny format notacji naukowej dla raportów"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Domyślny format notacji naukowej dla wyników"
 
@@ -1745,7 +1820,7 @@ msgstr "Domyślna mała naklejka"
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Domyślny czas przetwarzania analiz."
 
@@ -1754,7 +1829,7 @@ msgstr "Domyślny czas przetwarzania analiz."
 msgid "Default value"
 msgstr "Wartość domyślna"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1778,7 +1853,7 @@ msgstr "Definicja precyzji podczas konwersji wartości do notacji wykładniczej.
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1790,8 +1865,17 @@ msgstr "Określa naklejki, których należy użyć dla tego typu próbki."
 msgid "Degrees"
 msgstr "Stopnie"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1820,9 +1904,9 @@ msgstr "Działy"
 msgid "Dependent Analyses"
 msgstr "Analizy zależne"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Opis"
 
@@ -1869,7 +1953,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr "Wyłącz wielokrotną weryfikację dla tego samego użytkownika"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Rabat"
@@ -1887,7 +1975,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Wysłane"
@@ -1912,15 +2000,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr "Wyświetl wskaźnik Limit Detekcji"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Usuń"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Usunięte"
 
@@ -1990,11 +2086,15 @@ msgstr "Pobierz PDF"
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Planowana"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Data planowana"
@@ -2011,7 +2111,7 @@ msgstr "Duplikat"
 msgid "Duplicate Analysis"
 msgstr "Analiza podwójna"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2059,6 +2159,7 @@ msgstr "Np. PCA itp."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2073,21 +2174,21 @@ msgstr "Wysokość - głębokość"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "E-mail"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Adres E-mail"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2095,27 +2196,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "Treść wiadomości e-mail z powiadomieniami o unieważnieniu próbki"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2128,16 +2229,20 @@ msgstr "E-mail anulowany"
 msgid "Email notification"
 msgstr "Powiadomienie e-mail"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "Powiadomienie e-mail przy odrzuceniu próbki"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2148,27 +2253,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Włącz wielokrotne używanie instrumentu w arkuszach."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Włącz utrwalenie próbki"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "Włącz próbkowanie"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "Włącz harmonogram próbkowania"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2176,8 +2281,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr "Włącz przepływ próbkowania dla utworzonej próbki"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2201,7 +2314,7 @@ msgstr "Wprowadź adres e-mail. Jest on konieczny w przypadku zgubienia hasła. 
 msgid "Enter discount percentage value"
 msgstr "Wprowadź wartość procentową rabatu"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2214,7 +2327,7 @@ msgstr "Wprowadź wartość procentową, np. 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Wprowadź wartość procentową np. 23.0. Zostanie ona zastosowana tylko dla Profilu Analizy, zastępując sytemową stawkę podatku VAT"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Wprowadź wartość procentową, np. 14.0. Ma ona zasięg globalny ale może zostać zmieniona w razie potrzeby."
 
@@ -2238,7 +2351,7 @@ msgstr "Wprowadź szczegółowe informacje  dla każdej usługi analitycznej, kt
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Wprowadź szczegółowe informacje dotyczące akredytacji laboratorium. Dostępne są następujące pola:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2250,15 +2363,15 @@ msgstr "Warunki środowiskowe"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2270,7 +2383,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Wyłączenie z faktury"
 
@@ -2280,7 +2393,7 @@ msgstr "Wyłączenie z faktury"
 msgid "Expected Result"
 msgstr "Oczekiwany wynik"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2306,7 +2419,7 @@ msgstr "Data przedawnienia"
 msgid "Exponential format precision"
 msgstr "Precyzja formatu wykładniczego"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Wartość graniczna dla notacji wykładniczej"
 
@@ -2314,7 +2427,7 @@ msgstr "Wartość graniczna dla notacji wykładniczej"
 msgid "Export"
 msgstr "Eksport"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "Nie udało się załadować naklejki"
 
@@ -2401,7 +2514,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "Rozmiar pliku"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2415,6 +2528,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2431,11 +2556,11 @@ msgstr "Imię"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Wartość zmiennoprzecinkowa od 0,0 do 1000,0, wskazująca kolejność sortowania. Zduplikowane wartości są uporządkowane alfabetycznie."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Konfiguracja formatu"
 
@@ -2458,13 +2583,17 @@ msgstr "Piątek"
 msgid "From"
 msgstr "Od"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Imię i nazwisko"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2472,7 +2601,7 @@ msgstr ""
 msgid "Function"
 msgstr "Funkcja"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Próbka do pobrania w przyszłości"
 
@@ -2505,7 +2634,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Tytuł np. Pan, Pani, Dr"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Grupuj metody badań według kategorii, pomocne jeśli lista jest długa"
 
@@ -2519,7 +2648,7 @@ msgid "Hazardous"
 msgstr "Niebezpieczna"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Ukryty"
@@ -2532,8 +2661,20 @@ msgstr "Pole ukryte"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2557,7 +2698,7 @@ msgstr "Podstawowe stałe"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2565,7 +2706,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2585,15 +2726,15 @@ msgstr "Jeżeli zaznaczone, obok pola wyniku analizy wyświetlona zostanie lista
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Jeżeli zaznaczone, instrument będzie niedostępny do czasu wykonania ważnej kalibracji, po czym to pole opcji zostanie automatycznie odznaczone."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Jeśli jest włączone, dodatkowe pole tekstowe będzie wyświetlane blisko każdej analizy w widoku wprowadzania wyników"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Jeśli ta opcja jest włączona, użytkownik, który przesłał wynik tej analizy, będzie mógł ją zweryfikować. To ustawienie obowiązuje dla użytkowników z przypisaną rolą, która pozwala im weryfikować wyniki (domyślnie menedżerowie, kierownicy laboratorium i weryfikatorzy). Ustawiona tutaj opcja ma pierwszeństwo przed opcją ustawioną w Senaite Setup"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Jeśli ta opcja jest włączona użytkownik, który przesłał wynik, będzie mógł go zweryfikować. To ustawienie obowiązuje tylko dla użytkowników z przypisaną rolą, która pozwala im weryfikować wyniki (domyślnie menedżerów, kierowników laboratorium i weryfikatorów). To ustawienie można pominąć dla danego widoku edycji Analiza w Analysis Services (AS). Domyślnie wyłączone."
 
@@ -2601,7 +2742,7 @@ msgstr "Jeśli ta opcja jest włączona użytkownik, który przesłał wynik, b�
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Jeżeli włączone, nazwa analizy będzie zapisana kursywą."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "Jeżeli włączone, ta analiza i powiązane z nią wyniki nie będą domyślnie wyświetlane w raportach. Ustawienie to może być nadpisane w Profilu Analizy i/lub Zastawieniu Analiz"
 
@@ -2641,7 +2782,7 @@ msgstr "Jeśli ta opcja nie jest zaznaczona, menedżerowie laboratorium nie będ
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "Jeśli formuła wymaga specjalnej funkcji z zewnętrznej biblioteki Pythona, możesz ją zaimportować tutaj. Na przykład. jeśli chcesz użyć funkcji \"floor\" z modułu matematycznego Pythona, dodajesz 'math' do pola modułu i 'floor' do pola funkcji. Odpowiednikiem w Pythonie będzie 'from math import floor'. W twoich obliczeniach możesz użyć 'floor([Ca] + [Mg])'. "
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2672,11 +2813,11 @@ msgstr "Wewnętrzna procedura kalibracyjna"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Nieaktywne"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Zawiera i wyświetla informacje cenowe"
 
@@ -2873,7 +3014,7 @@ msgid "Internal Certificate"
 msgstr "Świadectwo wewnętrzne"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2894,13 +3035,13 @@ msgstr ""
 msgid "Interval"
 msgstr "Interwał"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Nieprawidłowe"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2963,15 +3104,15 @@ msgstr "Faktura dla"
 msgid "Invoice {} created"
 msgstr "Faktura {} utworzona"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "Zestawienie faktur nie ma daty końcowej"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "Zestawienie faktur nie ma daty początkowej"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "Zestawienie faktur nie ma Nazwy"
 
@@ -2983,7 +3124,7 @@ msgstr "Stanowisko"
 msgid "Job title"
 msgstr "Stanowisko"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2995,9 +3136,9 @@ msgstr "Klucz"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Słowo kluczowe"
 
@@ -3013,6 +3154,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Słowa kluczowe"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3057,8 +3202,8 @@ msgstr "Produkty Laboratorium"
 msgid "Lab URL"
 msgstr "Adres URL Laboratorium"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Etykieta"
@@ -3067,7 +3212,7 @@ msgstr "Etykieta"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3075,13 +3220,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3094,7 +3239,7 @@ msgstr "Laboratorium"
 msgid "Laboratory Accredited"
 msgstr "Laboratorium akredytowane"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Dni robocze laboratorium"
 
@@ -3106,7 +3251,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Duża naklejka"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3118,11 +3263,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr "Ostatnia data logowania"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Spóźnione"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Analizy spóźnione"
 
@@ -3168,15 +3313,15 @@ msgstr "Połącz użytkownika"
 msgid "Link an existing User"
 msgstr "Połącz z istniejącym użytkownikiem"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3200,7 +3345,7 @@ msgstr "Pobierz plik świadectwa"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3228,6 +3373,14 @@ msgstr "Typ miejsca"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Miejsce, w którym dokument jest umieszczony"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3291,7 +3444,7 @@ msgstr "Męski"
 msgid "Manage Analyses"
 msgstr "Zarządzanie analizami"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3315,7 +3468,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr "Zarządzaj połączonym użytkownikiem"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3339,7 +3492,7 @@ msgstr "E-mail do Kierownika"
 msgid "Manager Phone"
 msgstr "Telefon do Kierownika"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Ręczny"
 
@@ -3368,7 +3521,7 @@ msgstr "Producenci"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "Oznacz próbkę tylko do użytku wewnętrznego. Oznacza to, że jest dostępna tylko dla personelu laboratorium, a nie dla klientów."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3383,7 +3536,7 @@ msgstr "Maksymalny czas"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3418,15 +3571,15 @@ msgid "Member Discount"
 msgstr "Zniżka użytkownika"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Zniżki użytkowanika %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Obowiązuje zniżka członkowska"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Użytkownik zarejestrowany i powiązany z bieżącym Kontaktem."
 
@@ -3434,7 +3587,7 @@ msgstr "Użytkownik zarejestrowany i powiązany z bieżącym Kontaktem."
 msgid "Message sent to {}, "
 msgstr "Wiadomość wysłana do {}, "
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3465,7 +3618,7 @@ msgstr "Inicjały"
 msgid "Middle name"
 msgstr "Drugie imię"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3476,7 +3629,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3494,7 +3647,7 @@ msgstr "Minimum 5 znaków."
 msgid "Minimum Volume"
 msgstr "Objętość minimalna"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Minimalna liczba wyników wymagana do obliczania statystyki QC"
 
@@ -3525,6 +3678,10 @@ msgstr ""
 msgid "Monday"
 msgstr "Poniedziałek"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3538,11 +3695,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3578,13 +3735,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nazwa"
 
@@ -3594,6 +3755,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3637,6 +3802,10 @@ msgstr ""
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "Nie zdefiniowano akcji."
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3684,6 +3853,10 @@ msgstr "Nie wykonano zmian"
 msgid "No changes made."
 msgstr "Nie wykonano zmian."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "Nie ustawiono daty"
@@ -3728,12 +3901,26 @@ msgstr "Nie zaznaczono żadnego elementu"
 msgid "No items selected."
 msgstr "No items selected."
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "Żaden nowy element nie został utworzony."
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3751,6 +3938,10 @@ msgstr "Żadne próbki nie zostały odrzucone"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Brak przepływu pracy próbkowania"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3778,7 +3969,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Żaden"
 
@@ -3794,11 +3985,11 @@ msgstr ""
 msgid "Not defined"
 msgstr "Niezdefiniowany"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Nie ustawione"
@@ -3819,7 +4010,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "Uwaga: Możesz również przeciągać i upuszczać wiersze załączników, aby zmienić kolejność, w jakiej pojawiają się w raporcie."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3831,7 +4022,7 @@ msgstr "Ilość kolumn"
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Ilość Analiz"
 
@@ -3847,16 +4038,16 @@ msgstr "Liczba kopii"
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Liczba wymaganych weryfikacji"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Liczba wymaganych weryfikacji, zanim dany wynik zostanie uznany za 'zweryfikowany'. To ustawienie można zastąpić dla dowolnego widoku edycji usługi Metody Badań. Domyślnie: 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Liczba wymaganych weryfikacji od różnych użytkowników posiadających wystarczające uprawnienia, zanim dany wynik zostanie uznany za 'zweryfikowany'. Ustawiona tutaj opcja ma pierwszeństwo przed opcją ustawioną w Setup"
 
@@ -3866,6 +4057,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3884,11 +4079,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "Do obliczeń czasu realizacji analizy brane są pod uwagę tylko dni robocze w laboratorium."
 
@@ -3896,13 +4091,13 @@ msgstr "Do obliczeń czasu realizacji analizy brane są pod uwagę tylko dni rob
 msgid "Only to empty or zero fields"
 msgstr "Tylko dla pól o zerowej wartości lub pustych"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Otwarte"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3910,8 +4105,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Internetowy system zarządzania informacjami laboratoryjnymi typu Open Source"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3939,7 +4142,7 @@ msgstr "Inne powody"
 msgid "Other reasons:"
 msgstr "Inne powody:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Inny status"
 
@@ -3961,11 +4164,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4062,11 +4265,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Proszę wybrać Użytkownika z listy"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4079,6 +4282,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4098,12 +4302,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Miejsce uzyskania wyników"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4142,31 +4350,31 @@ msgstr "Liczba miejsc po przecinku"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Precyzja jako ilość cyfr znaczących stosownie do niepewności pomiaru. Miejsce dziesiętne będzie określone jako pozycja pierwszej cyfry różnej od zera w niepewności i system zaokrągli do tej wartości wynik pomiaru i niepewność. Na przykład, dla wyniku 5.243 i niepewności 0.22, wyświetlona zostanie wartość 5.2+-0.2. Jeżeli nie określono niepewności wyników, system użyje ustalonej precyzji."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Preferowany w raportach separator miejsca dziesiętnego."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Preferowany dla wyników separator miejsca dziesiętnego"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "Preferowany układ tabeli wprowadzania wyników w widoku arkusza roboczego. Klasyczny układ wyświetla próbki w wierszach, a analizy w kolumnach. Transponowany układ wyświetla próbki w kolumnach, a analizy w wierszach."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Notacja naukowa preferowana w raportach"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Preferowana dla wyników notacja naukowa"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4199,7 +4407,7 @@ msgstr ""
 msgid "Preserve"
 msgstr "Utrwalenie"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Utrwalający"
 
@@ -4216,11 +4424,11 @@ msgstr "Zapobiegawczy"
 msgid "Preventive maintenance procedure"
 msgstr "Procedura przeglądu okresowego"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "Podgląd"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4248,7 +4456,7 @@ msgstr "Cennik dla"
 msgid "Pricelists"
 msgstr "Cenniki"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4257,7 +4465,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4279,11 +4487,11 @@ msgstr "Wydrukowano dnia:"
 msgid "Print pricelist"
 msgstr "Drukuj cennik"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Wydrukuj nalepki"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Wydrukowane"
 
@@ -4296,7 +4504,7 @@ msgstr ""
 msgid "Priority"
 msgstr "Priorytet"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Profil"
 
@@ -4320,7 +4528,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Postęp"
 
@@ -4329,7 +4537,7 @@ msgstr "Postęp"
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "ID protokołu"
 
@@ -4337,7 +4545,7 @@ msgstr "ID protokołu"
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4346,8 +4554,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Opublikowane"
@@ -4363,6 +4575,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Opublikowane wyniki"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4384,6 +4600,14 @@ msgstr "Wyniki QC"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "Identyfikator próbki kontrolnej QC ID"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4409,7 +4633,7 @@ msgstr "Wprowadź ponownie hasło. Upewnij się, że hasła są identyczne."
 msgid "Reasons for rejection"
 msgstr "Przyczyny odrzucenia"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Przypisz"
 
@@ -4421,30 +4645,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Odbiór"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Dostarczone"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Odbiorcy"
 
@@ -4495,11 +4723,15 @@ msgstr "Wartości odniesienia"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Wartość odniesienia wynosi zero lub jest to \"próbka ślepa\""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Rejestracja"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4525,9 +4757,9 @@ msgstr "Analiza Odrzucona"
 msgid "Reject samples"
 msgstr "Odrzuć próbki"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Odrzucone"
 
@@ -4543,7 +4775,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4604,8 +4836,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4641,11 +4881,11 @@ msgstr "Identyfikator Raportu"
 msgid "Report identification number"
 msgstr "Numer identyfikacyjny raportu"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4657,7 +4897,7 @@ msgstr "Pobieranie raportu"
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4666,7 +4906,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "Kod zestawu analiz"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Nowy próbka"
 
@@ -4682,8 +4922,20 @@ msgstr "Wymagana objętość"
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4691,15 +4943,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4724,15 +4977,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Wyniki w zakresie"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Wynik poza zakresem"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4740,7 +4993,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Ilość cyfr znaczących, powyżej której wyniki wyświetlane będą w notacji naukowej z  literą 'e' jako znacznikiem wykładnika. Precyzja wyników może zostać zdefiniowana w każdej Usłudze Analitycznej AR niezależnie."
 
@@ -4756,16 +5009,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr "Interpretacja wyników"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Wyniki zostały unieważnione"
 
@@ -4773,7 +5030,7 @@ msgstr "Wyniki zostały unieważnione"
 msgid "Results interpretation"
 msgstr "Interpretacja wyników"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4797,7 +5054,7 @@ msgstr "Ponownie przebadane"
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4833,6 +5090,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4858,6 +5119,7 @@ msgstr "Strona główna SENAITE LIMS"
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4867,7 +5129,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr "Strona główna SENAITE"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4881,7 +5143,7 @@ msgstr "Zwrot grzecznościowy"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Próbka"
 
@@ -4918,7 +5180,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "Kod próbki"
 
@@ -4938,7 +5200,7 @@ msgstr "Matryca próbki"
 msgid "Sample Partitions"
 msgstr "Części próbki"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4965,7 +5227,7 @@ msgid "Sample Templates"
 msgstr "Szablony próbek"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Rodzaj próbki"
@@ -5026,7 +5288,7 @@ msgstr "Typ próbki"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Próbobiorca"
 
@@ -5038,8 +5300,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Próbki"
@@ -5056,6 +5318,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5065,7 +5339,23 @@ msgstr "Próbki tego typu powinny być traktowane jako niebezpieczne"
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5073,7 +5363,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Data pobrania próbki"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Zmienność próbek"
@@ -5086,7 +5376,7 @@ msgstr "Uwagi dot. pobierania próbek"
 msgid "Sampling Frequency"
 msgstr "Częstotliwość pobierania próbek"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5094,14 +5384,23 @@ msgstr ""
 msgid "Saturday"
 msgstr "Sobota"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Zapisz"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5116,7 +5415,7 @@ msgstr "Harmonogram"
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5133,6 +5432,10 @@ msgstr "Nazwa naukowa"
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5141,7 +5444,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Sekundy"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5231,11 +5534,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Wybierz szablon"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Zaznacz kraj wyświetlany domyślnie na witrynie"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Wybierz walutę, którą witryna będzie używała do wyświetlania cen."
 
@@ -5247,11 +5550,11 @@ msgstr "Zaznacz domyślny pojemnik dla tej usługi analitycznej. W tabeli poniż
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Wybierz domyślną stronę docelową przeznaczoną dla klienta logującego się do systemu lub wybranego z listy."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5259,31 +5562,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr "Wybierz typy, dla których to ID służy do identyfikacji."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "Wybierz tę opcję, aby aktywować automatyczne powiadomienia pocztą elektroniczną klienta, gdy próbka zostanie odrzucona."
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "Wybierz tę opcję, aby aktywować Dashboard jako domyślną stronę główną."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Zaznacz dla aktywacji instrukcji opisującej proces pobierania próbek."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Wybierz tę opcję, aby umożliwić koordynatorowi pobierania próbek zaplanowanie pobierania próbek. Ta funkcja działa tylko wtedy, gdy aktywny jest przepływ pracy próbkowania"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "Wybierz, aby otrzymywać próbki automatycznie, gdy są tworzone przez personel laboratorium, a przepływ pracy pobierania próbek jest wyłączony. Próbki utworzone przez kontakty klienta nie będą odbierane automatycznie"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5295,7 +5606,7 @@ msgstr "Zaznacz, które analizy powinny być uwzględniane w karcie pracy"
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Samodzielna weryfikacja wyników"
 
@@ -5307,11 +5618,11 @@ msgstr "Wyślij"
 msgid "Send Analysis Reports via Email"
 msgstr "Wysyłaj raporty analizy pocztą e-mail"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5333,7 +5644,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Oddzielny pojemnik"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5347,7 +5658,7 @@ msgstr "Nr seryjny"
 msgid "Service"
 msgstr "Usługa"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "Usługi nie można odznaczyć. Kliknij przycisk informacji, aby uzyskać więcej informacji"
 
@@ -5375,7 +5686,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr "Ustaw zadanie przeglądu technicznego jako zakończone."
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5423,28 +5734,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5467,11 +5790,11 @@ msgstr "Kod miejsca"
 msgid "Site Description"
 msgstr "Opis miejsca"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5492,7 +5815,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Mała naklejka"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5509,6 +5832,14 @@ msgstr "Niektóre analizy używają przeterminowanych lub niekalibrowanych przyr
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Klucz sortowania"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5534,7 +5865,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "Specyfikacje"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5542,7 +5873,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Określ rozmiar arkusza roboczego, np. odpowiadający rozmiarowi tacy określonego instrumentu. Następnie wybierz 'typ' Analizy dla pozycji arkusza roboczego. W przypadku wybrania próbek QC, wybierz również, która próbka referencyjna powinna zostać użyta. Jeśli wybrano duplikat analizy, wskaż, która pozycja próbki powinna być duplikatem"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5559,17 +5890,17 @@ msgstr "Data początkowa"
 msgid "Start date must be before End Date"
 msgstr "Data rozpoczęcia musi być wcześniejsza niż data zakończenia"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Status"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Status"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Naklejka"
@@ -5578,7 +5909,11 @@ msgstr "Naklejka"
 msgid "Stickers preview"
 msgstr "Podgląd naklejek"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Miejsce przechowywania"
@@ -5618,7 +5953,11 @@ msgstr "Prześlij"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "Przesłane i zweryfikowane przez tego samego użytkownika: {}"
 
@@ -5626,7 +5965,7 @@ msgstr "Przesłane i zweryfikowane przez tego samego użytkownika: {}"
 msgid "Submitter"
 msgstr "Zgłaszający"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Suma częściowa"
@@ -5668,7 +6007,7 @@ msgstr "Przejdź do dashboard"
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "Domyślne ustawienie systemowe"
 
@@ -5694,7 +6033,7 @@ msgstr "Podatki"
 msgid "Technical description and instructions intended for analysts"
 msgstr "Opis techniczny i instrukcje przeznaczone dla analityków"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5776,7 +6115,7 @@ msgstr "Data utrwalenia próbki"
 msgid "The date when the sample was received"
 msgstr "Data otrzymania próbki"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Użyty zostanie separator dziesiętny zdefiniowany w Konfiguracji Senaite."
 
@@ -5784,7 +6123,7 @@ msgstr "Użyty zostanie separator dziesiętny zdefiniowany w Konfiguracji Senait
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "Wprowadzona tu wartość procentowa rabatu ma zastosowanie do cen dla klientów oznaczonych jako członkowie, wielokrotni klienci lub współpracownicy"
 
@@ -5812,7 +6151,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5820,11 +6163,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Wysokości lub głębokości, na której próbka powinna zostać pobrana"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5861,11 +6204,11 @@ msgstr "Minimalna ilość próbki wymagana do analizy np. '10 ml' lub '1 kg'."
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Liczba dni, po których  próbka traci ważność i nie może być więcej analizowana. To ustawienie może być nadpisane dla pojedynczego rodzaju próbki w ustawieniach typów próbek"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Liczba minut, zanim użytkownik zostanie automatycznie wylogowany. 0 powoduje wyłączenie automatycznego wylogowania"
 
@@ -5905,7 +6248,7 @@ msgstr "Numer akredytacji przypisany laboratorium przez organ akredytacyjny"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "Wynik po obliczeniach z wartościami testowymi. Należy zapisać obliczenia, zanim ta wartość zostanie obliczona."
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5929,11 +6272,11 @@ msgstr "Próbka jest mieszanką podpróbek"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Numer seryjny, który unikatowo identyfikuje przyrząd"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "Identyfikator protokołu analitycznego danej usługi"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "Identyfikator handlowy usługi do celów księgowych"
 
@@ -5985,11 +6328,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "Jest to domyślny maksymalny czas przeznaczony na wykonywanie analiz. Służy wyłącznie do analiz, w których usługa analizy nie określa czasu realizacji. Pod uwagę brane są tylko dni robocze w laboratorium."
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6013,11 +6356,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6049,8 +6392,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Wskazówka. Załączone dokumenty nie zostaną załadowane, chyba że są one obecne w instancji."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Tytuł"
@@ -6077,34 +6420,42 @@ msgstr "Nazwa miejsca"
 msgid "To"
 msgstr "Do"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Do utrwalenia"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Do pobrania"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Będzie wyświetlony na sprawozdaniu wyników poniżej każdej sekcji Kategorii Analiz."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Do utrwalenia"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "Do wydrukowania"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Do sprawdzenia"
@@ -6117,7 +6468,7 @@ msgstr "Aby przetestować obliczenia, wprowadź tutaj wartości dla wszystkich p
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Ogółem"
 
@@ -6139,7 +6490,7 @@ msgid "Tuesday"
 msgstr "Wtorek"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Typ"
@@ -6164,6 +6515,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6172,7 +6527,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6184,6 +6539,7 @@ msgstr "Nie można załadować szablonu"
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Nieprzypisane"
@@ -6216,8 +6572,12 @@ msgstr "Nieznany IBAN kraju %s"
 msgid "Unlink User"
 msgstr "Odłącz użytkownika"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6234,13 +6594,17 @@ msgstr "Nieznany format pliku ${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr "Nierozpoznany format pliku ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Zaktualizuj załączniki"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6250,7 +6614,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Wczytaj zeskanowany podpis, który będzie używany w drukowanym sprawozdaniu z badań. Idealny rozmiar wynosi 250 pikseli szerokości oraz 150 wysoki"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6258,7 +6622,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Użyj Ceny Profilu Analtycznego"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Użyj Dashboard jako domyślnej strony głównej"
 
@@ -6296,7 +6660,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "Użytkownik powiązany z tym kontaktem"
 
@@ -6304,15 +6668,15 @@ msgstr "Użytkownik powiązany z tym kontaktem"
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Używanie zbyt małej ilości danych nie ma statystycznego sensu. Ustaw minimalną akceptowalną liczbę wyników, zanim statystyki QC będą obliczane i wykreślane"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6320,7 +6684,7 @@ msgstr "VAT"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "VAT %"
 
@@ -6567,8 +6931,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Wpisana tu wartość zastąpi domyślną zdefiniowaną w konfiguracji Pól Tymczasowych Formuł Obliczeniowych."
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Sprawdzone"
@@ -6577,10 +6941,18 @@ msgstr "Sprawdzone"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6595,6 +6967,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6630,6 +7010,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "Środa"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Tygodni do wygaśnięcia"
@@ -6642,19 +7026,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6705,10 +7089,18 @@ msgstr "Szablony kart pracy"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Karty pracy"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6717,6 +7109,10 @@ msgstr ""
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Nieprawidłowa długość numeru IBAN %s: %sshort by %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6800,6 +7196,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6904,8 +7304,17 @@ msgstr "dni"
 msgid "deactivate"
 msgstr "ukryj"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6970,7 +7379,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7137,46 +7546,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7188,19 +7597,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7221,16 +7630,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7255,12 +7669,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7270,7 +7684,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7373,6 +7787,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7402,6 +7829,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7548,12 +7982,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7806,7 +8240,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7814,163 +8248,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7978,47 +8412,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8027,20 +8461,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8048,32 +8482,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8081,21 +8515,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8251,6 +8685,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8563,7 +9001,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8624,7 +9062,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8740,52 +9178,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8855,12 +9293,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8870,7 +9308,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9166,7 +9604,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9291,12 +9729,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9506,7 +9944,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9516,12 +9954,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9579,6 +10017,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10755,87 +11209,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10888,6 +11342,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10938,12 +11397,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11021,6 +11488,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11255,13 +11727,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11348,6 +11825,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11593,222 +12075,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12062,7 +12544,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12105,7 +12587,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/pl/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pl/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Polish (https://app.transifex.com/senaite/teams/87045/pl/)\n"

--- a/src/senaite/core/locales/pl_PL/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pl_PL/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Polish (Poland) (https://app.transifex.com/senaite/teams/87045/pl_PL/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/pl_PL/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pl_PL/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Polish (Poland) (https://app.transifex.com/senaite/teams/87045/pl_PL/)\n"

--- a/src/senaite/core/locales/pl_PL/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pl_PL/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Polish (Poland) (https://app.transifex.com/senaite/teams/87045/pl_PL/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: pl_PL\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/pl_PL/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pl_PL/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Polish (Poland) (https://app.transifex.com/senaite/teams/87045/pl_PL/)\n"

--- a/src/senaite/core/locales/plone.pot
+++ b/src/senaite/core/locales/plone.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/src/senaite/core/locales/plone.pot
+++ b/src/senaite/core/locales/plone.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -854,6 +854,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/pt/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (https://app.transifex.com/senaite/teams/87045/pt/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/pt/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (https://app.transifex.com/senaite/teams/87045/pt/)\n"

--- a/src/senaite/core/locales/pt/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Portuguese (https://app.transifex.com/senaite/teams/87045/pt/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: pt\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Tipo da Conta"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Ativo"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Adicionar"
 
@@ -284,15 +290,19 @@ msgstr "Adicionar Cópia"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Todas as amostras assinadas"
 
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
+
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Análises"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr ""
 msgid "Any"
 msgstr "Qualquer"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr ""
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Aplicar Template"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,18 +606,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Incluída"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Log-off automatico"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Rumo"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Endereço de facturação"
@@ -800,7 +845,7 @@ msgstr "Marca"
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr "Contacto Profissional"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC Emails"
 
@@ -899,23 +944,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Número de Catálogo"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr "Cidade"
 msgid "Classic"
 msgstr "Clássico"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Cliente"
@@ -1104,7 +1163,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID do Cliente"
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Pedido de Cliente"
 
@@ -1126,7 +1185,7 @@ msgstr "Pedido de Cliente"
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Ref. do Cliente"
 
@@ -1135,7 +1194,7 @@ msgstr "Ref. do Cliente"
 msgid "Client Reference"
 msgstr "Referência do Cliente"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID do Cliente"
 
@@ -1228,7 +1287,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Confirme a senha"
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contato"
@@ -1328,7 +1391,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr "Copiar de"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "País"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1473,7 +1540,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1481,12 +1548,20 @@ msgstr ""
 msgid "Current"
 msgstr "Currente"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Data de recepção"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr "Data do pedido"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Valores Padrão"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Descrição"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Despachado"
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Endereço de e-mail"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr "Sobrenome do arquivo"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Nome Completo"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr "Chave"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr "Lab Produtos"
 msgid "Lab URL"
 msgstr "URL de laboratório"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr "Laboratório"
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr "Masculino"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr "Email do Gerente"
 msgid "Manager Phone"
 msgstr "Telefone do Gerente"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr "Max Tempo"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr "Mínimo 5 carácteres"
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nome"
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Abrir"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Perfil"
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Publicado"
@@ -4361,6 +4573,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registro"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr "Volume requerido"
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Salvar"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Selecionar Tema"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr "Número de serie"
 msgid "Service"
 msgstr "Serviço"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Estado"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Estado"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr "Submeter"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Gerir resultados"
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Título"
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "A verificar"
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Tipo"
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sem Assinatura"
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr "IVA"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "% DE IVA"
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verificado"
@@ -6576,10 +6940,18 @@ msgstr "Verificado"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,10 +7088,18 @@ msgstr "Tema da Ficha de Trabalho"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Fichas de trabalho"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/pt/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Portuguese (https://app.transifex.com/senaite/teams/87045/pt/)\n"

--- a/src/senaite/core/locales/pt_AO/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt_AO/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Angola) (https://app.transifex.com/senaite/teams/87045/pt_AO/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/pt_AO/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt_AO/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Angola) (https://app.transifex.com/senaite/teams/87045/pt_AO/)\n"

--- a/src/senaite/core/locales/pt_AO/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt_AO/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Angola) (https://app.transifex.com/senaite/teams/87045/pt_AO/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: pt_AO\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/pt_AO/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt_AO/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Angola) (https://app.transifex.com/senaite/teams/87045/pt_AO/)\n"

--- a/src/senaite/core/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt_BR/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Fabiano Solari, 2022\n"
 "Language-Team: Portuguese (Brazil) (https://app.transifex.com/senaite/teams/87045/pt_BR/)\n"
@@ -912,6 +912,11 @@ msgstr "precisa_uma_conta"
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt_BR/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Fabiano Solari, 2022\n"
 "Language-Team: Portuguese (Brazil) (https://app.transifex.com/senaite/teams/87045/pt_BR/)\n"

--- a/src/senaite/core/locales/pt_BR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt_BR/LC_MESSAGES/senaite.core.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Portuguese (Brazil) (https://app.transifex.com/senaite/teams/87045/pt_BR/)\n"

--- a/src/senaite/core/locales/pt_BR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt_BR/LC_MESSAGES/senaite.core.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Portuguese (Brazil) (https://app.transifex.com/senaite/teams/87045/pt_BR/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: pt_BR\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -30,6 +30,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -55,6 +56,7 @@ msgid "%s has no '%s' column."
 msgstr "%s não possui coluna '%s'"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Voltar"
@@ -124,6 +126,10 @@ msgstr ""
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -141,7 +147,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -199,7 +205,7 @@ msgid "Account Type"
 msgstr "Tipo da Conta"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -244,21 +250,21 @@ msgstr "Ativar"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Ativo"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Adicionar"
 
@@ -286,15 +292,19 @@ msgstr "Adicionar Duplicata"
 msgid "Add Samples"
 msgstr "Adicionar Amostra"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Adiciona campo de observação para todas as análises"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -307,8 +317,11 @@ msgstr "Adionar novo Anexo"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -372,13 +385,21 @@ msgstr "Todos os serviços de análises Certificadas estão listados aqui."
 msgid "All Analyses of Service"
 msgstr "Todos os Serviços de Análises"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Todas as amostras designadas"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Permitir entrada manual de Limite de Detecção "
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -396,11 +417,11 @@ msgstr "Permitir que o mesmo usuário verifique várias vezes"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Permitir que o mesmo usuário verifique várias vezes, mas não consecutivamente"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Permitir auto-verificação de resultados"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -429,14 +450,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Análises"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -506,7 +543,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -543,7 +580,7 @@ msgstr "Análise deve ser especificada."
 msgid "Any"
 msgstr "Qualquer"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -554,6 +591,10 @@ msgstr "Submeter"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Aplicar modelo"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -567,19 +608,15 @@ msgstr "Número de ativos"
 msgid "Assign"
 msgstr "Designar"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Designada"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Designado para: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Designação pendente"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -593,7 +630,7 @@ msgstr "Anexar à amostra"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -681,11 +718,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -693,15 +734,15 @@ msgstr ""
 msgid "Autofill"
 msgstr "Autopreenchimento"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Log-off Automático"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -752,7 +793,7 @@ msgstr "Lote"
 msgid "Batch Book"
 msgstr "Livro de lotes"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID do Lote"
 
@@ -782,6 +823,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Direção"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Endereço de cobrança"
@@ -802,7 +847,7 @@ msgstr "Marca"
 msgid "Bulk Discount"
 msgstr "Desconto para volumes"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Descontos por volume são aplicáveis"
@@ -820,19 +865,19 @@ msgstr "Telefone Comercial"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -840,12 +885,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "Emails em CC"
 
@@ -901,23 +946,23 @@ msgstr "Calibração"
 msgid "Calibrator"
 msgstr "Calibrador"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Pode verificar, mas enviado pelo usuário atual"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -937,15 +982,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -971,7 +1016,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Número do Catálogo"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Categorizar serviços de análise"
 
@@ -1003,11 +1048,11 @@ msgid "Changes Saved"
 msgstr "Modificações salvas"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Modificações salvas."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1044,31 +1089,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Escolha o tipo de verificação múltipla para o mesmo usuário. Esta configuração pode ativar / desativar a verificação / verificação consecutiva mais de uma vez para o mesmo usuário."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1081,12 +1126,26 @@ msgstr "Cidade"
 msgid "Classic"
 msgstr "Clássico"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1094,7 +1153,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Cliente"
@@ -1106,7 +1165,7 @@ msgstr "ID Cliente em lote"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID do Cliente"
 
@@ -1118,7 +1177,7 @@ msgstr "Pagina inicial do Cliente"
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Pedido de Cliente"
 
@@ -1128,7 +1187,7 @@ msgstr "Pedido de Cliente"
 msgid "Client Order Number"
 msgstr "Número de ordem do cliente"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Referência de Cliente"
 
@@ -1137,7 +1196,7 @@ msgstr "Referência de Cliente"
 msgid "Client Reference"
 msgstr "Referência de Cliente"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID do Cliente"
 
@@ -1230,7 +1289,7 @@ msgstr "Comentários"
 msgid "Comments or results interpretation"
 msgstr "Comentários ou interpretação de resultados"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "ID do comercio"
@@ -1268,6 +1327,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1286,7 +1349,7 @@ msgstr "Confirme a senha"
 msgid "Considerations"
 msgstr "Considerações"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contato"
@@ -1330,7 +1393,7 @@ msgstr "Recipientes"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1363,15 +1426,15 @@ msgstr "Copiar serviços de análise"
 msgid "Copy from"
 msgstr "Copiar de"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Copiar para um novo"
 
@@ -1381,6 +1444,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1399,11 +1466,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1416,7 +1483,7 @@ msgstr "País"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1424,7 +1491,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr "Criar Site SENAITE"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1436,7 +1503,7 @@ msgstr "Criar um novo site SENAITE"
 msgid "Create a new User"
 msgstr "Criar um novo Usuário"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1466,7 +1533,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Criar"
 
@@ -1475,7 +1542,7 @@ msgstr "Criar"
 msgid "Criteria"
 msgstr "Critério"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Moeda"
 
@@ -1483,13 +1550,21 @@ msgstr "Moeda"
 msgid "Current"
 msgstr "Atual"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Marca decimal padrão"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "DL"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1536,23 +1611,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Data de Abertura"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Data da Preservação"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Data de Publicação"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Data de Recebimento"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Data Registro"
 
@@ -1564,11 +1639,11 @@ msgstr "Data do Pedido"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Data da Amostra"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Data Verificada"
 
@@ -1610,7 +1685,7 @@ msgstr "Data de quando o certificado de calibração foi concedido"
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1633,11 +1708,11 @@ msgstr "Desativar até a próxima calibração"
 msgid "Deactivate"
 msgstr "Desativar"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Marca decimal para uso nos Laudos deste cliente."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1649,7 +1724,7 @@ msgstr "Recipiente Padrão"
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1661,7 +1736,7 @@ msgstr "Instrumento padrão"
 msgid "Default Method"
 msgstr "Método padrão"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1669,20 +1744,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Preservação Padrão"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Marca decimal padrão"
 
@@ -1694,7 +1769,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Layout padrão na exibição da planilha"
 
@@ -1726,15 +1801,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Período padrão de retenção de amostra"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Formato de notação científica padrão para laudos"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Formato de notação científica padrão para resultados"
 
@@ -1746,7 +1821,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr "Fuso horário padrão"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1755,7 +1830,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Valor Padrão"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1779,7 +1854,7 @@ msgstr "Defina a precisão quando convertendo valores para notação exponencial
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Definir o coletor que deve amostrar na data programada"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1791,8 +1866,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Graus"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1821,9 +1905,9 @@ msgstr "Departamentos"
 msgid "Dependent Analyses"
 msgstr "Análise Dependente"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Descrição"
 
@@ -1870,7 +1954,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr "Desabilitar multi-verificação para o mesmo usuário"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1888,7 +1976,7 @@ msgstr "Despachar"
 msgid "Dispatch samples"
 msgstr "Amostras despachadas"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Enviado"
@@ -1913,15 +2001,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr "Mostrar seletor de limite de detecção"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Descartar"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Descarte"
 
@@ -1991,11 +2087,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Entrega"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Data de Entrega"
@@ -2012,7 +2112,7 @@ msgstr "Duplicada"
 msgid "Duplicate Analysis"
 msgstr "Análise repetida"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2060,6 +2160,7 @@ msgstr "Por exemplo, SANAS, APLAC, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "Para cada interface de importação pode ser definida uma pasta, onde o sistema irá procurar automaticamente os arquivos para importar quando for chamado o 1 auto_import_results 1."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Editar"
@@ -2074,21 +2175,21 @@ msgstr "Elevação"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Endereço de Email"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2096,27 +2197,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2129,16 +2230,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2149,27 +2254,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2177,8 +2282,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2202,7 +2315,7 @@ msgstr "Digite um endereço de email. Isto é necessário para a eventualidade d
 msgid "Enter discount percentage value"
 msgstr "Digite o percentual de desconto"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2215,7 +2328,7 @@ msgstr "Digite um valor percentual, exemplo: 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Digite um valor percentual , ex:14,0. Este percentual é aplicado somente ao perfil de analises, sobrepondo o VAT do sistema"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Digite um valor percentual, exemplo: 14.0. Este percentual é aplicado a todo o sistema, mas pode ser sobreposto em itens individuais"
 
@@ -2239,7 +2352,7 @@ msgstr "Insira os detalhes de cada um dos serviços de análise que deseja copia
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2251,15 +2364,15 @@ msgstr "Condições Climaticas"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Andamento das Análises"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Evolução das amostras"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Andamento das Requisições de Análises"
 
@@ -2271,7 +2384,7 @@ msgstr "Exemplo cronograma de trabalho para executar a importação automática 
 msgid "Example content"
 msgstr "Conteúdo de Exemplo"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Excluir da fatura"
 
@@ -2281,7 +2394,7 @@ msgstr "Excluir da fatura"
 msgid "Expected Result"
 msgstr "Resultado Esperado"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Data Esperada para Amostragem"
 
@@ -2307,7 +2420,7 @@ msgstr "Data de Vencimento"
 msgid "Exponential format precision"
 msgstr "Precisão do formato exponencial"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Limite do formato exponencial"
 
@@ -2315,7 +2428,7 @@ msgstr "Limite do formato exponencial"
 msgid "Export"
 msgstr "Exportar"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2402,7 +2515,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2416,6 +2529,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2432,11 +2557,11 @@ msgstr "Primeiro Nome"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Valor de flutuação de 0,0 - 1000,0 indicando a ordem de classificação. Os valores duplicados são ordenados alfabeticamente."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2459,13 +2584,17 @@ msgstr ""
 msgid "From"
 msgstr "De"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Nome Completo"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2473,7 +2602,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Amostra datada no futuro"
 
@@ -2506,7 +2635,7 @@ msgstr "Vá para sua instância"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Título de saudação, como Sr, Sra, Srta, Dr"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Agrupar serviços de análise por categoria nas tabelas de LIMS, útil quando a lista é longa"
 
@@ -2520,7 +2649,7 @@ msgid "Hazardous"
 msgstr "Perigoso"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Oculto"
@@ -2533,8 +2662,20 @@ msgstr "Campo Oculto"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2558,7 +2699,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2566,7 +2707,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2586,15 +2727,15 @@ msgstr "Se marcada, uma lista de seleção será exibida ao lado do campo result
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "Se selecionado, o instrumento estará indisponível até a próxima calibração válida ser realizada. Esta caixa de seleção será automaticamente desmarcada."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Se ativado, um campo de texto livre será exibido perto de cada análise na exibição de entrada de resultados"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Se ativado, um usuário que enviou um resultado para essa análise também poderá confirmá-lo. Esta configuração tem efeito para os usuários com uma função atribuída que lhes permite verificar resultados (por padrão, gerentes, gerentes de laboratório e verificadores). A opção definida aqui tem prioridade sobre a opção definida no Bika Setup"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Se ativado, um usuário que enviou um resultado também poderá confirmá-lo. Essa configuração só terá efeito para os usuários com uma função atribuída que lhes permita verificar resultados (por padrão, gerentes, gerentes de laboratório e verificadores). Essa configuração pode ser sobrescrita por uma determinada análise no modo de exibição de edição do Serviço de Análise. Por padrão, desativado."
 
@@ -2602,7 +2743,7 @@ msgstr "Se ativado, um usuário que enviou um resultado também poderá confirm�
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Se acionado, o nome da análise vai ser escrito em itálico."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2642,7 +2783,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2673,11 +2814,11 @@ msgstr "Procedimento de calibração no laboratório"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Inativo"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Incluir e exibir informações sobre preço"
 
@@ -2874,7 +3015,7 @@ msgid "Internal Certificate"
 msgstr "Certificado interno"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "Uso Interno"
 
@@ -2895,13 +3036,13 @@ msgstr "Modelos de Interpretação"
 msgid "Interval"
 msgstr "Intervalo"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Inválido"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2964,15 +3105,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "FaturaLote não possui data final"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "FaturaLote não possui data inicial"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "FaturaLote não possui título"
 
@@ -2984,7 +3125,7 @@ msgstr "Cargo"
 msgid "Job title"
 msgstr "Cargo"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2996,9 +3137,9 @@ msgstr "Chave"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Palavra-chave"
 
@@ -3014,6 +3155,10 @@ msgstr "Palavra-chave requerida"
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Palavras-chave"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3058,8 +3203,8 @@ msgstr "Produtos do Laboratório"
 msgid "Lab URL"
 msgstr "URL do laboratório"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Rótulo"
@@ -3068,7 +3213,7 @@ msgstr "Rótulo"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3076,13 +3221,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3095,7 +3240,7 @@ msgstr "Laboratório"
 msgid "Laboratory Accredited"
 msgstr "Laboratório Certificado"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3107,7 +3252,7 @@ msgstr "Linguagem"
 msgid "Large Sticker"
 msgstr "Lista de preço"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3119,11 +3264,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr "Último Horário de Acesso"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Atrasado"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Análise Atrasada"
 
@@ -3169,15 +3314,15 @@ msgstr "Link Usuário"
 msgid "Link an existing User"
 msgstr "Vincular um usuário existente"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3201,7 +3346,7 @@ msgstr "Carregar o documento certificado aqui"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3229,6 +3374,14 @@ msgstr "Tipo do local"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Local onde o conjunto de documentos está arquivado"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3292,7 +3445,7 @@ msgstr "Masculino"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3316,7 +3469,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr "Gerenciar usuário vinculado"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3340,7 +3493,7 @@ msgstr "Email do Gerente"
 msgid "Manager Phone"
 msgstr "Telefone do Gerente"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Manual"
 
@@ -3369,7 +3522,7 @@ msgstr "Fabricante"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3384,7 +3537,7 @@ msgstr "Tempo Máximo"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3419,15 +3572,15 @@ msgid "Member Discount"
 msgstr "Desconto de membro"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Desconto para o associado %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Há desconto para associado aqui"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Membro registrado e vinculado ao contato atual."
 
@@ -3435,7 +3588,7 @@ msgstr "Membro registrado e vinculado ao contato atual."
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3466,7 +3619,7 @@ msgstr "Inicial do nome do meio"
 msgid "Middle name"
 msgstr "Nome do meio"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3477,7 +3630,7 @@ msgstr "Mínimo"
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3495,7 +3648,7 @@ msgstr "Cinco caracteres no mínimo."
 msgid "Minimum Volume"
 msgstr "Volume Mínimo"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Número mínimo de resultados para cálculos estatísticos de CQ"
 
@@ -3526,6 +3679,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3539,11 +3696,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "Múltiplo Tipo de verificação"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Múltipla verificação requerida "
 
@@ -3579,13 +3736,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Nome"
 
@@ -3595,6 +3756,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3637,6 +3802,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3685,6 +3854,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "Sem data definida"
@@ -3729,12 +3902,26 @@ msgstr "Nenhum item selecionado"
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "Nenhum item novo foi criado"
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3752,6 +3939,10 @@ msgstr ""
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "Sem processo de amostragem"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3779,7 +3970,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Nenhum"
 
@@ -3795,11 +3986,11 @@ msgstr ""
 msgid "Not defined"
 msgstr "Não definido"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Não configurado"
@@ -3820,7 +4011,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "Observação: Você também pode arrastar e soltar as linhas de anexo para alterar a ordem em que aparecem no relatório."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3832,7 +4023,7 @@ msgstr "Número de colunas"
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Número de Análises"
 
@@ -3848,16 +4039,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Número de verificações necessárias"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Número de verificações necessárias antes de um determinado resultado ser considerado como \"verificado\". Essa configuração pode ser sobrescrita por qualquer  análise em Serviços Análises. Por padrão, 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Número de verificações necessárias de diferentes utilizadores com privilégios suficientes antes de um determinado resultado para esta análise ser considerado como \"verificado\". A opção definida aqui tem prioridade sobre a opção definida no Bika Setup"
 
@@ -3867,6 +4058,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3885,11 +4080,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3897,13 +4092,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr "Somente para campos vazios ou iguais a zero"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Abrir"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3911,8 +4106,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3940,7 +4143,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Outro status"
 
@@ -3962,11 +4165,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4063,11 +4266,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Selecione um usuário na lista"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4080,6 +4283,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr "Por favor, especifique uma razão"
 
@@ -4099,12 +4303,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr "Por favor, escreva um comentário onde as amostra(s) listadas são despachadas"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Local de Captura"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4143,31 +4351,31 @@ msgstr "Precisão em números decimais"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Precisão como o número de algarismos significativos de acordo com a incerteza. A posição decimal será dada pelo primeiro número diferente de zero na incerteza, nessa posição o sistema arredondará a incerteza e resultados. Por exemplo, com um resultado de 5,243 e uma incerteza de 0,22, o sistema irá exibir corretamente como 5,2+-0.2. Se nenhuma margem de incerteza for definida para o resultado, o sistema usará o conjunto de precisão fixo."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Marca decimal preferida nos laudos."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Marca decimal preferida nos resultados"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Preferência de notação científica padrão para laudos"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Preferência de notação científica para formatação resultados"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4200,7 +4408,7 @@ msgstr ""
 msgid "Preserve"
 msgstr "Preservar"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Preservador"
 
@@ -4217,11 +4425,11 @@ msgstr "Preveção"
 msgid "Preventive maintenance procedure"
 msgstr "Prever procedimento de manutenção"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4249,7 +4457,7 @@ msgstr "Lista de preços"
 msgid "Pricelists"
 msgstr "Listas de preço"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4258,7 +4466,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4280,11 +4488,11 @@ msgstr "Data de impressão:"
 msgid "Print pricelist"
 msgstr "Imprimir lista de compra"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Imprimir etiquetas"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Impresso"
 
@@ -4297,7 +4505,7 @@ msgstr ""
 msgid "Priority"
 msgstr "Prioridade"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Perfil"
 
@@ -4321,7 +4529,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4330,7 +4538,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "ID de Protocolo"
 
@@ -4338,7 +4546,7 @@ msgstr "ID de Protocolo"
 msgid "Province"
 msgstr "Estado"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4347,8 +4555,12 @@ msgstr ""
 msgid "Publish"
 msgstr "Publicar"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Publicado"
@@ -4364,6 +4576,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Resultados publicados"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4385,6 +4601,14 @@ msgstr "Resultados CQ"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "ID da amostra do CQ"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4410,7 +4634,7 @@ msgstr "Digite novamente a senha. Certifique-se de que as senhas são idênticas
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Reatribuição"
 
@@ -4422,30 +4646,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Receber"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Recebido"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Recepção pendente"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Recipientes"
 
@@ -4496,11 +4724,15 @@ msgstr "Valor de referência"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Valores de referência da amostra são brancos ou nulos"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Registro"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4526,9 +4758,9 @@ msgstr "Rejeitar análise"
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Rejeitado"
 
@@ -4544,7 +4776,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4605,8 +4837,16 @@ msgstr ""
 msgid "Remove"
 msgstr "Remover"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4642,11 +4882,11 @@ msgstr "ID do Laudo"
 msgid "Report identification number"
 msgstr "Número de identificação do Laudo"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4658,7 +4898,7 @@ msgstr "Upload de Laudo"
 msgid "Republish"
 msgstr "Republicar"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "Republicado depois da última impressão"
 
@@ -4667,7 +4907,7 @@ msgstr "Republicado depois da última impressão"
 msgid "Request ID"
 msgstr "ID da Requisição"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Requisitar nova análise"
 
@@ -4683,8 +4923,20 @@ msgstr "Volume Requerido"
 msgid "Reset"
 msgstr "Reiniciar"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4692,15 +4944,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr "Restaurar"
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4725,15 +4978,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Resultado no limite do intervalo"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Resultado fora do intervalo"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4741,7 +4994,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Valores de resultado com pelo menos esse número de dígitos significativos são exibidos em notação científica com a letra 'e' para indicar o expoente. A precisão pode ser configurado em Serviços de análises individuais"
 
@@ -4757,16 +5010,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr "Interpretação de resultados"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Resultados têm sido retirados"
 
@@ -4774,7 +5031,7 @@ msgstr "Resultados têm sido retirados"
 msgid "Results interpretation"
 msgstr "Interpretação de resultados"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Resultados pendentes"
 
@@ -4798,7 +5055,7 @@ msgstr "Retestado"
 msgid "Retract"
 msgstr "Retratar"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4834,6 +5091,10 @@ msgstr "Reverter"
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr "SENAITE CORE"
@@ -4859,6 +5120,7 @@ msgstr "SENAITE LIMS primeira página"
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4868,7 +5130,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr "SENAITE primeira página"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "Servidor SMTP desconectado. A criação do usuário foi interrompida."
 
@@ -4882,7 +5144,7 @@ msgstr "Cumprimento"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Amostra"
 
@@ -4919,7 +5181,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "ID da Amostra"
 
@@ -4939,7 +5201,7 @@ msgstr "Matriz de Amostras"
 msgid "Sample Partitions"
 msgstr "Partições de Amostra"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4966,7 +5228,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Tipo de Amostra"
@@ -5027,7 +5289,7 @@ msgstr "Tipo de amostra"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Particionador"
 
@@ -5039,8 +5301,8 @@ msgstr "Coletor para amostragem programada"
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Amostras"
@@ -5057,6 +5319,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5066,7 +5340,23 @@ msgstr "Amostras deste tipo devem ser tratadas como perigosas"
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5074,7 +5364,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Data de Amostragem"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Desvio de Amostragem"
@@ -5087,7 +5377,7 @@ msgstr "Desvios de Amostragens"
 msgid "Sampling Frequency"
 msgstr "Frequência de Amostragem"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "Programação de amostragem"
 
@@ -5095,14 +5385,23 @@ msgstr "Programação de amostragem"
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Salvar"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5117,7 +5416,7 @@ msgstr "Programação"
 msgid "Schedule sampling"
 msgstr "Amostragem programada"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Amostragem programada"
@@ -5134,6 +5433,10 @@ msgstr "Nome científico"
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5142,7 +5445,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Segundos"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5232,11 +5535,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Selecionar modelo"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Selecione o pais que o site vai ser mostrado como padrão"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Selecione a moeda que o site usará para exibir os preços."
 
@@ -5248,11 +5551,11 @@ msgstr "Selecione o recipiente padrão a ser usado por este serviço de análise
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Seleccione a página inicial padrão. Isso é usado quando um usuário cliente registra no sistema, ou quando um cliente é selecionado a partir da listagem pasta do cliente."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5260,31 +5563,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr "Selecione os tipos que esse ID é usado para identificar."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "Selecione esta opção para ativar o painel de controle como uma página inicial padrão."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Selecione aqui para ativar os passos do processo (workflow) de coleção de amostras."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Selecione isto para permitir que um Coordenador de Amostragem programe uma amostragem. Esta funcionalidade só tem efeito quando o 'Fluxo de trabalho de amostragem' está ativo"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5296,7 +5607,7 @@ msgstr "Selecione quais Análises devem ser incluídas na Planilha"
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Auto-verificação dos resultados"
 
@@ -5308,11 +5619,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5334,7 +5645,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Recipiente Separado"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5348,7 +5659,7 @@ msgstr "Número de série"
 msgid "Service"
 msgstr "Serviço"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5376,7 +5687,7 @@ msgstr "Defina o fluxo de trabalho de Rejeição de amostra e as razões"
 msgid "Set the maintenance task as closed."
 msgstr "Configurar a tarefa de manutenção como fechada."
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5424,28 +5735,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr "O conteúdo de exemplo padrão deve ser adicionado ao site?"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr "Mostrar os últimos registros de importação automática"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5468,11 +5791,11 @@ msgstr "Código do Site"
 msgid "Site Description"
 msgstr "Descrição do Site"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5493,7 +5816,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Etiqueta pequena"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5510,6 +5833,14 @@ msgstr "Algumas análises estão desatualizadas ou instrumentos não calibrados.
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Chave de classificação"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5535,7 +5866,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "Especificações"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5543,7 +5874,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5560,17 +5891,17 @@ msgstr "Data inicial"
 msgid "Start date must be before End Date"
 msgstr "A data de início deve ser anterior à data de término"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Estado"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Estado"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Etiqueta"
@@ -5579,7 +5910,11 @@ msgstr "Etiqueta"
 msgid "Stickers preview"
 msgstr "Pré-visualização das etiquetas"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Local de armazenamento"
@@ -5619,7 +5954,11 @@ msgstr "Submeter"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr "Enviar um arquivo Open XML (.XLSX) válido contendo registros de configuração para continuar."
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5627,7 +5966,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotal"
@@ -5669,7 +6008,7 @@ msgstr "Mudar para o painel de controle"
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "Padrão do Sistema"
 
@@ -5695,7 +6034,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descrição técnica e instruções a serem seguidas por analistas"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5777,7 +6116,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "O marcador decimal nas configurações Bika serão usados."
 
@@ -5785,7 +6124,7 @@ msgstr "O marcador decimal nas configurações Bika serão usados."
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr "Configuração de fuso horário padrão do portal. Os usuários poderão definir seu próprio fuso horário, se os fusos horários disponíveis estiverem definidos nas configurações de data e hora."
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "O percentual de desconto digitado aqui é aplicado aos preços para os clientes identificados como 'associados', normalmente membros cooperados e parceiros merecedores deste desconto."
 
@@ -5813,7 +6152,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr "A(s) seguinte(s) amostra(s) será(ão) despachada(s)"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5821,11 +6164,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "A altura ou profundidade na qual a amostra deve ser obtida"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5862,11 +6205,11 @@ msgstr "O mínimo volume de amostra necessário para a análise, exemplo '10 ml'
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "O número de dias antes que uma amostra expire e não possa mais ser analisada. Esta configuração pode ser definida por tipo individual de amostra"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "O número de minutos antes que o logoff automático de um usuário aconteça. O número '0' desabilita o logoff automático"
 
@@ -5906,7 +6249,7 @@ msgstr "O código de referência emitido pelo órgão de certificação."
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "O resultado após o cálculo foi realizado com valores de teste. Você precisará salvar o cálculo antes que esse valor seja calculado."
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5930,11 +6273,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "O número de série que identifica, de forma única, o instrumento."
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "ID de protocolo de serviço analítico"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "ID serviço do perfil para fins contábeis."
 
@@ -5986,11 +6329,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6014,11 +6357,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6050,8 +6393,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Dica. Documentos anexados não serão carregados a menos que eles estão presentes na instância."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Título"
@@ -6078,34 +6421,42 @@ msgstr "Título do Site"
 msgid "To"
 msgstr "Para"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "A Ser Preservado"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "A Ser Amostrado"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "A ser exibido abaixo de cada seção de Categoria de Análise nos Laudos."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Para ser preservado"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "A ser impresso"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Para ser amostrado"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "A verificar"
@@ -6118,7 +6469,7 @@ msgstr "Para testar o cálculo, insira aqui valores para todos os parâmetros de
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6140,7 +6491,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Tipo"
@@ -6165,6 +6516,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr "Digite para filtrar..."
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6173,7 +6528,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6185,6 +6540,7 @@ msgstr "Não foi possível carregar o template"
 msgid "Unassign"
 msgstr "Cancelar atribuição"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Não designado"
@@ -6217,9 +6573,13 @@ msgstr "IBAN países desconhecidos %s"
 msgid "Unlink User"
 msgstr "Desvincular o usuário"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
 msgstr "Usuário não vinculado"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6235,13 +6595,17 @@ msgstr "Formato do arquivo não reconhecido ${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr "Formato de arquivo não reconhecido ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "Não atribuído"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Atualizar anexos"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6251,7 +6615,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Faça o upload de uma assinatura digitalizada a ser usada em Laudos impressos. O tamanho ideal é 250 pixels de largura por 150 pixels de altura"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6259,7 +6623,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Use Perfil de Análise de Preço"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Usar o Painel de Controle como página inicial padrão"
 
@@ -6297,7 +6661,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "Usuário vinculado a este contato"
 
@@ -6305,15 +6669,15 @@ msgstr "Usuário vinculado a este contato"
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Usar muito poucos dados não faz sentido estatisticamente. Configure um número mínimo aceitável de resultados antes que as estatísticas de CQ possam ser calculadas e exibidas"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6321,7 +6685,7 @@ msgstr "IVA"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "% DE IVA"
 
@@ -6568,8 +6932,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Valores podem ser inseridos aqui os quais substituirão os predefinidos especificados nos Campos de Cálculo Provisório"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verificado"
@@ -6578,11 +6942,19 @@ msgstr "Verificado"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Verificar"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6597,6 +6969,14 @@ msgstr "Visão"
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
 msgstr "Veja seu site do SENAITE"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr ""
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -6631,6 +7011,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Semanas para expirar"
@@ -6643,19 +7027,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr "Bem-vindo ao SENAITE"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6706,10 +7090,18 @@ msgstr "Modelos de Planilhas"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Planilhas"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6718,6 +7110,10 @@ msgstr ""
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Tamanho de IBAN errado por %s: %s muito curto por %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6801,6 +7197,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6905,8 +7305,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "desativar"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6971,7 +7380,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7138,46 +7547,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7189,19 +7598,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7222,16 +7631,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7256,12 +7670,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7271,7 +7685,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7374,6 +7788,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7403,6 +7830,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7549,12 +7983,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7807,7 +8241,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7815,163 +8249,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7979,47 +8413,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8028,20 +8462,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8049,32 +8483,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8082,21 +8516,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8252,6 +8686,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8564,7 +9002,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8625,7 +9063,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8741,52 +9179,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8856,12 +9294,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8871,7 +9309,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9167,7 +9605,7 @@ msgid "label_powered_by_plone"
 msgstr "rótulo_alimentado_por_plone"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9292,12 +9730,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9507,7 +9945,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9517,12 +9955,12 @@ msgid "label_senaite"
 msgstr "rótulo_senaite"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9580,6 +10018,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10756,87 +11210,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10889,6 +11343,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "por mês"
@@ -10939,12 +11398,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "de"
 
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
+
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11023,6 +11490,11 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
 msgstr "esta_amostra_foi_dispachada_por"
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
+msgstr ""
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11256,13 +11728,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11349,6 +11826,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11594,222 +12076,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12063,7 +12545,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "Verificação(s) pendente"
 
@@ -12106,7 +12588,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/pt_MZ/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt_MZ/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Mozambique) (https://app.transifex.com/senaite/teams/87045/pt_MZ/)\n"

--- a/src/senaite/core/locales/pt_MZ/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt_MZ/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Mozambique) (https://app.transifex.com/senaite/teams/87045/pt_MZ/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/pt_MZ/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt_MZ/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Mozambique) (https://app.transifex.com/senaite/teams/87045/pt_MZ/)\n"

--- a/src/senaite/core/locales/pt_MZ/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt_MZ/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Mozambique) (https://app.transifex.com/senaite/teams/87045/pt_MZ/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: pt_MZ\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/pt_PT/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt_PT/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Portugal) (https://app.transifex.com/senaite/teams/87045/pt_PT/)\n"

--- a/src/senaite/core/locales/pt_PT/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/pt_PT/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Portugal) (https://app.transifex.com/senaite/teams/87045/pt_PT/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/pt_PT/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt_PT/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Portugal) (https://app.transifex.com/senaite/teams/87045/pt_PT/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: pt_PT\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/pt_PT/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/pt_PT/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese (Portugal) (https://app.transifex.com/senaite/teams/87045/pt_PT/)\n"

--- a/src/senaite/core/locales/ro/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ro/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Florin Ghidu, 2023\n"
 "Language-Team: Romanian (https://app.transifex.com/senaite/teams/87045/ro/)\n"

--- a/src/senaite/core/locales/ro/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ro/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Florin Ghidu, 2023\n"
 "Language-Team: Romanian (https://app.transifex.com/senaite/teams/87045/ro/)\n"
@@ -903,6 +903,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ro/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ro/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Romanian (https://app.transifex.com/senaite/teams/87045/ro/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ro\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ro/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ro/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Romanian (https://app.transifex.com/senaite/teams/87045/ro/)\n"

--- a/src/senaite/core/locales/ro_RO/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ro_RO/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Romanian (Romania) (https://app.transifex.com/senaite/teams/87045/ro_RO/)\n"

--- a/src/senaite/core/locales/ro_RO/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ro_RO/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Romanian (Romania) (https://app.transifex.com/senaite/teams/87045/ro_RO/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ro_RO/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ro_RO/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Romanian (Romania) (https://app.transifex.com/senaite/teams/87045/ro_RO/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ro_RO\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr "%s nu are coloana '%s'."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Tip cont"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Activ"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Adaugă"
 
@@ -284,15 +290,19 @@ msgstr "Adaugă duplicat"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Adaugă un câmp de mențiuni pentru toate analizele"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analize"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr "Analistul trebuie specificat."
 msgid "Any"
 msgstr "Orice"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr "Aplică"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Aplică șablon"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,19 +606,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Asignat"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Asignat la: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr ""
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr "Completare automată"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Deautentificare automată"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr "Lot"
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID lot"
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Adresă facturare"
@@ -800,7 +845,7 @@ msgstr "Marcă"
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -818,19 +863,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -899,23 +944,23 @@ msgstr "Calibrări"
 msgid "Calibrator"
 msgstr "Calibrator"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Anulat"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Număr catalog"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr "Oraș"
 msgid "Classic"
 msgstr "Clasic"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Client"
@@ -1104,7 +1163,7 @@ msgstr "ID lot client"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID client"
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Comandă client"
 
@@ -1126,7 +1185,7 @@ msgstr "Comandă client"
 msgid "Client Order Number"
 msgstr "Număr comandă client"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Ref. client"
 
@@ -1135,7 +1194,7 @@ msgstr "Ref. client"
 msgid "Client Reference"
 msgstr "Referință client"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID client"
 
@@ -1228,7 +1287,7 @@ msgstr "Comentarii"
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "ID comercial"
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Confirmă parola"
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contact"
@@ -1328,7 +1391,7 @@ msgstr "Containere"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr ""
 msgid "Copy from"
 msgstr "Copiază de la"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "Țară"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Autor"
 
@@ -1473,7 +1540,7 @@ msgstr "Autor"
 msgid "Criteria"
 msgstr "Criterii"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Monedă"
 
@@ -1481,12 +1548,20 @@ msgstr "Monedă"
 msgid "Current"
 msgstr "Curent"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr "Data de emitere a certificatului de calibrare"
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr "Container implicit"
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr "Instrument implicit"
 msgid "Default Method"
 msgstr "Metodă implicită"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Conservare implicită"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Format implicit notație științifică pentru rapoarte"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Format implicit notație științifică pentru rezultate"
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Valoare implicită"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Analize dependente"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Descriere"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2010,7 +2110,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2279,7 +2392,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr "Exportă"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2531,8 +2660,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3011,6 +3152,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3056,8 +3201,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3066,7 +3211,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4362,6 +4574,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Rezultate publicate"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4681,8 +4921,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4937,7 +5199,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5577,7 +5908,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6576,10 +6940,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,9 +7088,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ro_RO/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ro_RO/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Romanian (Romania) (https://app.transifex.com/senaite/teams/87045/ro_RO/)\n"

--- a/src/senaite/core/locales/ru/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ru/LC_MESSAGES/plone.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: PavelFadeev, 2022\n"
 "Language-Team: Russian (https://app.transifex.com/senaite/teams/87045/ru/)\n"

--- a/src/senaite/core/locales/ru/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ru/LC_MESSAGES/plone.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: PavelFadeev, 2022\n"
 "Language-Team: Russian (https://app.transifex.com/senaite/teams/87045/ru/)\n"
@@ -904,6 +904,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ru/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ru/LC_MESSAGES/senaite.core.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Russian (https://app.transifex.com/senaite/teams/87045/ru/)\n"
@@ -24,7 +24,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ru\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -33,6 +33,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} вложений общим размером ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link} "
@@ -58,6 +59,7 @@ msgid "%s has no '%s' column."
 msgstr "%s не содержит колонку '%s'"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Назад"
@@ -127,6 +129,10 @@ msgstr "*** Это автоматически сгенерированное с�
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -144,7 +150,7 @@ msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" />Перейти к нас
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Добро пожаловать в SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -202,7 +208,7 @@ msgid "Account Type"
 msgstr "Тип счета"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr "Учет"
 
@@ -247,21 +253,21 @@ msgstr "Активировать"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Активные"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Исполнитель"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Добавить"
 
@@ -289,15 +295,19 @@ msgstr "Добавить повторный"
 msgid "Add Samples"
 msgstr "Добавить образцы"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Добавить замечания ко всем анализам"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "Добавить пользовательские CSS стили для логотипа, например height:15px; width:150px;"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -310,8 +320,11 @@ msgstr "Добавить вложение"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Добавить замечания"
 
@@ -375,13 +388,21 @@ msgstr "Все аккредитованные услуги на анализ н�
 msgid "All Analyses of Service"
 msgstr "Все анализы по услугам"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Все назначенные анализы "
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Разрешить ручной ввод определения лимитов"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -399,11 +420,11 @@ msgstr "Разрешить пользователю верифицировать
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Разрешить пользователю верифицировать результаты несколько раз, но не последовательно"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Разрешить самопроверку результатов"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -432,14 +453,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Анализ выполнен"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Анализы"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -509,7 +546,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr "Обновление условий анализа: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -546,7 +583,7 @@ msgstr ""
 msgid "Any"
 msgstr "Любое"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -557,6 +594,10 @@ msgstr ""
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Применить шаблон"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -570,19 +611,15 @@ msgstr ""
 msgid "Assign"
 msgstr "Назначить"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Назначен"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Назначение ожидается"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -596,7 +633,7 @@ msgstr "Приложить к Образцу"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -684,11 +721,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr "Журналы автоматического импорта"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -696,15 +737,15 @@ msgstr ""
 msgid "Autofill"
 msgstr "Автозаполнение"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Автоматический выход"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -755,7 +796,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr "Книга пачек"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID Партии"
 
@@ -785,6 +826,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Подшипник"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Адрес для выставления счета"
@@ -805,7 +850,7 @@ msgstr "Производитель(ТМ)"
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -823,19 +868,19 @@ msgstr "Рабочий телефон "
 msgid "Business address"
 msgstr "Рабочий адрес"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -843,12 +888,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "Копия Emails"
 
@@ -904,23 +949,23 @@ msgstr "Калибровка"
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Отменить"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Отменено"
 
@@ -940,15 +985,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -974,7 +1019,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Номер по каталогу"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Категоризация аналитических услуг"
 
@@ -1006,11 +1051,11 @@ msgid "Changes Saved"
 msgstr "Изменения Сохранены"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Изменения сохранены."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Изменения будут применены к субпробам"
 
@@ -1047,31 +1092,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1084,12 +1129,26 @@ msgstr "Город"
 msgid "Classic"
 msgstr "Классический"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "Сбросить выделение"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1097,7 +1156,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Клиент"
@@ -1109,7 +1168,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID клиента"
 
@@ -1121,7 +1180,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Заказ клиента"
 
@@ -1131,7 +1190,7 @@ msgstr "Заказ клиента"
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Ссылка Клиента"
 
@@ -1140,7 +1199,7 @@ msgstr "Ссылка Клиента"
 msgid "Client Reference"
 msgstr "Ссылка клиента "
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID Клиента"
 
@@ -1233,7 +1292,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1271,6 +1330,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1289,7 +1352,7 @@ msgstr "Подтверждение пароля"
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Контакт"
@@ -1333,7 +1396,7 @@ msgstr "Контейнеры"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1366,15 +1429,15 @@ msgstr ""
 msgid "Copy from"
 msgstr "Копировать из"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Копировать в новый"
 
@@ -1384,6 +1447,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1402,11 +1469,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr "Страна"
 msgid "Create Invoice PDF"
 msgstr "Создать pdf-документ счета"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1427,7 +1494,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr "Создать сайт SENAITE"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr "Создать рабочий лист"
 
@@ -1439,7 +1506,7 @@ msgstr "Создать новый сайт SENAITE"
 msgid "Create a new User"
 msgstr "Ввести нового пользователя"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr "Создайте новый рабочий лист для выбранных образцов"
 
@@ -1469,7 +1536,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Выполнено"
 
@@ -1478,7 +1545,7 @@ msgstr "Выполнено"
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Валюта"
 
@@ -1486,12 +1553,20 @@ msgstr "Валюта"
 msgid "Current"
 msgstr "Текущий"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1539,23 +1614,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Дата открытия"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Дата Сохранения"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Напечатан"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Дата публикации"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Дата получения"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Дата Регистрации"
 
@@ -1567,11 +1642,11 @@ msgstr "Дата запроса"
 msgid "Date Sample Received"
 msgstr "Получен"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Дата получения пробы"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Дата проверки"
 
@@ -1613,7 +1688,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1636,11 +1711,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr "Отключить"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1652,7 +1727,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1664,7 +1739,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1672,20 +1747,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1697,7 +1772,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1729,15 +1804,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Срок хранения образцов по умолчанию"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1749,7 +1824,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr "Часовой пояс по умолчанию"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1758,7 +1833,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Значение по умолчанию"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1782,7 +1857,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1794,8 +1869,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Градусы"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1824,9 +1908,9 @@ msgstr "Подразделения"
 msgid "Dependent Analyses"
 msgstr "Анализы подразделения"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Описание"
 
@@ -1873,7 +1957,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1891,7 +1979,7 @@ msgstr "Отправить"
 msgid "Dispatch samples"
 msgstr "Отправить образцы"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Отправлено"
@@ -1916,15 +2004,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Ликвидировать"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Извлечено"
 
@@ -1994,11 +2090,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Ожидается"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Дата ожидания"
@@ -2015,7 +2115,7 @@ msgstr "Дублировать"
 msgid "Duplicate Analysis"
 msgstr "Повторный анализ"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2063,6 +2163,7 @@ msgstr "Например SANAS, APLAC и т.д."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "Каждый интерфейс импорта может определить папку, в которой система ищет файлы результатов при автоматическом импорте результатов при вызове представления <code>auto_import_results</code>"
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Редактировать"
@@ -2077,21 +2178,21 @@ msgstr "Высота"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Отправить по электронной почте"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Адрес электронной почты"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2099,27 +2200,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2132,16 +2233,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2152,27 +2257,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2180,8 +2285,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2205,7 +2318,7 @@ msgstr "Введите адрес электронной почты. Это не
 msgid "Enter discount percentage value"
 msgstr "Введите процентное значение скидки"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2218,7 +2331,7 @@ msgstr "Введите процентное значение напр. 14,0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Введите процентное значение напр. 14.0. Это процент всей прикладной системе но может быть переписан для отдельных элементов"
 
@@ -2242,7 +2355,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2254,15 +2367,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Продвижение анализов"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Динамика образцов"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Динамика рабочих листов"
 
@@ -2274,7 +2387,7 @@ msgstr "Пример Cronjob для выполнения автоматичес�
 msgid "Example content"
 msgstr "Пример содержания"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Исключить из счета"
 
@@ -2284,7 +2397,7 @@ msgstr "Исключить из счета"
 msgid "Expected Result"
 msgstr "Ожидаемый результат"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Ожидаемая дата отбора проб"
 
@@ -2310,7 +2423,7 @@ msgstr "Дата истечения срока действия"
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2318,7 +2431,7 @@ msgstr ""
 msgid "Export"
 msgstr "Экспорт"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2405,7 +2518,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2419,6 +2532,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2435,11 +2560,11 @@ msgstr "Имя"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2462,13 +2587,17 @@ msgstr ""
 msgid "From"
 msgstr "От"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Полное имя"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2476,7 +2605,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Образец с будущей датой"
 
@@ -2509,7 +2638,7 @@ msgstr "Перейти к своему образцу"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Приветствие напр. Г-Н, миссис, Dr"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Группировка аналитических услуг в таблицах LIMS, полезно, когда список длинный"
 
@@ -2523,7 +2652,7 @@ msgid "Hazardous"
 msgstr "Опасные"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2536,8 +2665,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2569,7 +2710,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2589,15 +2730,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2605,7 +2746,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2645,7 +2786,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2676,11 +2817,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Неактивные"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Включить и отображать информацию о ценах"
 
@@ -2877,7 +3018,7 @@ msgid "Internal Certificate"
 msgstr "Внутренний сертификат "
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2898,13 +3039,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Недействительный"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2967,15 +3108,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2987,7 +3128,7 @@ msgstr ""
 msgid "Job title"
 msgstr "Название должности"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2999,9 +3140,9 @@ msgstr "Ключ"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Ключевое слово"
 
@@ -3017,6 +3158,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Ключевые слова"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3061,8 +3206,8 @@ msgstr "Лаборатория: Расходные матриалы"
 msgid "Lab URL"
 msgstr "URL-адрес лаборатории"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3071,7 +3216,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3079,13 +3224,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3098,7 +3243,7 @@ msgstr "Лаборатория"
 msgid "Laboratory Accredited"
 msgstr "Аккредитованные лаборатории"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3110,7 +3255,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Большой стикер"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3122,11 +3267,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Отложить"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Отложенные анализы"
 
@@ -3172,15 +3317,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3204,7 +3349,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3231,6 +3376,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3295,7 +3448,7 @@ msgstr "Мужской"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3319,7 +3472,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3343,7 +3496,7 @@ msgstr "электронная почта менеджера"
 msgid "Manager Phone"
 msgstr "Телефон менеджера"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3372,7 +3525,7 @@ msgstr "Производители"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3387,7 +3540,7 @@ msgstr "Максимальное время"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3422,15 +3575,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Членская скидка %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Член скидка распространяется"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3438,7 +3591,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3469,7 +3622,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3480,7 +3633,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3498,7 +3651,7 @@ msgstr "Минимум 5 символов."
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3529,6 +3682,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3542,11 +3699,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3582,13 +3739,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Имя"
 
@@ -3598,6 +3759,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3640,6 +3805,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3688,6 +3857,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3732,12 +3905,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3754,6 +3941,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3782,7 +3973,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3798,11 +3989,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3823,7 +4014,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3835,7 +4026,7 @@ msgstr "Кол-во столбцов"
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3851,16 +4042,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3870,6 +4061,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3888,11 +4083,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3900,13 +4095,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Открытые"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3914,8 +4109,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Информационная система лаборатории с открытым исходным кодом на базе веб-технологий"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3943,7 +4146,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3965,11 +4168,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4066,11 +4269,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Пожалуйста выберите Пользователя из списка"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4083,6 +4286,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4102,12 +4306,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Место отбора пробы"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4146,31 +4354,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Предпочитаемый разделитель целой и дробной частей чисел в отчетах"
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4203,7 +4411,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4220,11 +4428,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4252,7 +4460,7 @@ msgstr "Прейскурант для"
 msgid "Pricelists"
 msgstr "Прейскуранты"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4261,7 +4469,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4283,11 +4491,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr "Распечатать прейскурант"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4300,7 +4508,7 @@ msgstr ""
 msgid "Priority"
 msgstr "Приоритет"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Профиль"
 
@@ -4324,7 +4532,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4341,7 +4549,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4350,8 +4558,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Опубликовано"
@@ -4367,6 +4579,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Опубликованные результаты"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4387,6 +4603,14 @@ msgstr "QC Результаты"
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4413,7 +4637,7 @@ msgstr "Повторно введите пароль. Убедитесь, что
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Переназначить"
 
@@ -4425,30 +4649,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Получить"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Получено"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Ожидают прием"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4499,11 +4727,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Значения эталонного образца 0 или \"пусто\""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Зарегистрировать"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4529,9 +4761,9 @@ msgstr "Отклонить анализ"
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4547,7 +4779,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4608,8 +4840,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4645,11 +4885,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4661,7 +4901,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4670,7 +4910,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "ID Запроса"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Запросить новые анализы"
 
@@ -4686,24 +4926,37 @@ msgstr "Требуемый объем"
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr "Сбросить"
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4728,15 +4981,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Результат за пределами допустимого диапазона"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4744,7 +4997,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4760,16 +5013,20 @@ msgstr "Результаты"
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4777,7 +5034,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Ожидают результатов"
 
@@ -4801,7 +5058,7 @@ msgstr "Повторный анализ"
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4837,6 +5094,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4862,6 +5123,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4871,7 +5133,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4885,7 +5147,7 @@ msgstr "Приветствие"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Образец"
 
@@ -4922,7 +5184,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "Образец ID"
 
@@ -4942,7 +5204,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4969,7 +5231,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Тип образца"
@@ -5030,7 +5292,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Пробоотборщик"
 
@@ -5042,8 +5304,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Образцы"
@@ -5060,6 +5322,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5069,7 +5343,23 @@ msgstr "С образцами этого типа следует обращат�
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5077,7 +5367,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Дата отбора"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5090,7 +5380,7 @@ msgstr "Отбор проб: Отклонения"
 msgid "Sampling Frequency"
 msgstr "Частота взятия образца"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5098,14 +5388,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Сохранить"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5120,7 +5419,7 @@ msgstr "Расписание"
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5137,6 +5436,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5145,7 +5448,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Секунд"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5235,11 +5538,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Выбрать шаблон"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Выберите страну, сайт будет отображать по умолчанию"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Выберите валюту, сайт будет использовать для отображения цены."
 
@@ -5251,11 +5554,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5263,31 +5566,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Выберите эту опцию, чтобы активировать этапы рабочего процесса сбора образцов."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5299,7 +5610,7 @@ msgstr "Выберете, какие анализы должны быть вкл
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Самопроверка результатов"
 
@@ -5311,11 +5622,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5337,7 +5648,7 @@ msgstr "Отправлен"
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5351,7 +5662,7 @@ msgstr "Серийный номер"
 msgid "Service"
 msgstr "Услуга"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5379,7 +5690,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5427,28 +5738,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5471,11 +5794,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5496,7 +5819,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Мелкий стикер"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5512,6 +5835,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5546,7 +5877,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5563,17 +5894,17 @@ msgstr "Дата начала действия"
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Статус"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Статус"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Наклейка"
@@ -5582,7 +5913,11 @@ msgstr "Наклейка"
 msgid "Stickers preview"
 msgstr "Предварительный просмотр наклеек"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5622,7 +5957,11 @@ msgstr "Отправить"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5630,7 +5969,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Итого"
@@ -5672,7 +6011,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr "Переключить на транспонированное представление"
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5698,7 +6037,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr "Техническое описание и инструкции, предназначенные для аналитиков"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5788,7 +6127,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "Процент скидки введен здесь, применяется к ценам для клиентов с пометкой \"член\", как правило, кооператоров или партнеров, заслуживающих этой скидки"
 
@@ -5816,7 +6155,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5824,11 +6167,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5865,11 +6208,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Количество дней до того, как образец будет просрочен и не может быть проанализирован. Этот параметр может быть перезаписан каждый тип отдельных образцов в типы Установка образцов"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "Количество минут до автоматического выхода пользователя . 0 отключает автоматический выход"
 
@@ -5909,7 +6252,7 @@ msgstr "Код ссылки, выданного органом аккредит�
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5933,11 +6276,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Серийный номер, который однозначно идентифицирует инструмент"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5989,11 +6332,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6017,11 +6360,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6053,8 +6396,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Название"
@@ -6081,34 +6424,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Должны быть сохранены"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Ожидаемый образец"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Должны быть сохранены"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Ожидаемые образцы"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "На проверку"
@@ -6121,7 +6472,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Итого"
 
@@ -6143,7 +6494,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Тип"
@@ -6168,6 +6519,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6176,7 +6531,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6188,6 +6543,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6220,8 +6576,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6238,13 +6598,17 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Обновить вложения"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6262,7 +6626,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6300,7 +6664,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6308,15 +6672,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6324,7 +6688,7 @@ msgstr "НДС"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "% НДС"
 
@@ -6571,8 +6935,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Проверено"
@@ -6581,10 +6945,18 @@ msgstr "Проверено"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6599,6 +6971,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6634,6 +7014,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "Сре́да"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6646,19 +7030,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6709,10 +7093,18 @@ msgstr "Рабочий лист: Шаблоны"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Рабочие листы"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6721,6 +7113,10 @@ msgstr ""
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Неверная IBAN длина %s: %sсокращен до %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6804,6 +7200,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6908,8 +7308,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "отключить"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6974,7 +7383,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7141,46 +7550,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7192,19 +7601,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7225,16 +7634,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7259,12 +7673,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7274,7 +7688,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7377,6 +7791,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7406,6 +7833,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7552,12 +7986,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7810,7 +8244,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7818,163 +8252,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7982,47 +8416,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8031,20 +8465,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8052,32 +8486,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8085,21 +8519,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8255,6 +8689,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8567,7 +9005,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8628,7 +9066,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8744,52 +9182,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8859,12 +9297,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8874,7 +9312,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9170,7 +9608,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9295,12 +9733,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9510,7 +9948,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9520,12 +9958,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9583,6 +10021,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10759,87 +11213,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10892,6 +11346,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "ежемесячно"
@@ -10942,13 +11401,21 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "из"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "обзор"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11025,6 +11492,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11259,13 +11731,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11352,6 +11829,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11597,222 +12079,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12066,7 +12548,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "проверка(и) в ожидании"
 
@@ -12109,7 +12591,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ru/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ru/LC_MESSAGES/senaite.core.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Russian (https://app.transifex.com/senaite/teams/87045/ru/)\n"

--- a/src/senaite/core/locales/ru_RU/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ru_RU/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Russian (Russia) (https://app.transifex.com/senaite/teams/87045/ru_RU/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ru_RU/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ru_RU/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Russian (Russia) (https://app.transifex.com/senaite/teams/87045/ru_RU/)\n"

--- a/src/senaite/core/locales/ru_RU/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ru_RU/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Russian (Russia) (https://app.transifex.com/senaite/teams/87045/ru_RU/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ru_RU\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ru_RU/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ru_RU/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Russian (Russia) (https://app.transifex.com/senaite/teams/87045/ru_RU/)\n"

--- a/src/senaite/core/locales/senaite.core.pot
+++ b/src/senaite/core/locales/senaite.core.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -23,6 +23,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -48,6 +49,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -117,6 +119,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -134,7 +140,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -192,7 +198,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -237,21 +243,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -279,15 +285,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -300,8 +310,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -365,12 +378,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -389,11 +410,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -422,14 +443,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -499,7 +536,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -536,7 +573,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -546,6 +583,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -560,18 +601,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -586,7 +623,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -674,11 +711,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -686,15 +727,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -745,7 +786,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -775,6 +816,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -795,7 +840,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -813,19 +858,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -833,12 +878,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -894,23 +939,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -930,15 +975,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -964,7 +1009,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -996,11 +1041,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1037,31 +1082,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1074,12 +1119,24 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1087,7 +1144,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1099,7 +1156,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1111,7 +1168,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1121,7 +1178,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1130,7 +1187,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1223,7 +1280,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1261,6 +1318,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1279,7 +1340,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1323,7 +1384,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1356,15 +1417,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1374,6 +1435,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1392,11 +1457,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1409,7 +1474,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1417,7 +1482,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1429,7 +1494,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1459,7 +1524,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1468,7 +1533,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1476,12 +1541,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1529,23 +1602,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1557,11 +1630,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1603,7 +1676,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1626,11 +1699,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1642,7 +1715,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1654,7 +1727,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1662,20 +1735,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1687,7 +1760,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1719,15 +1792,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1739,7 +1812,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1748,7 +1821,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1772,7 +1845,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1784,8 +1857,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1814,9 +1896,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1863,7 +1945,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1881,7 +1967,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1906,15 +1992,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1984,11 +2078,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2005,7 +2103,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2053,6 +2151,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2067,21 +2166,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2089,27 +2188,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2122,16 +2221,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2142,27 +2245,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2170,8 +2273,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2195,7 +2306,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2208,7 +2319,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2232,7 +2343,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2244,15 +2355,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2264,7 +2375,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2274,7 +2385,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2300,7 +2411,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2308,7 +2419,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2395,7 +2506,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2409,6 +2520,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2425,11 +2548,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2452,13 +2575,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2466,7 +2593,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2499,7 +2626,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2513,7 +2640,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2526,8 +2653,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2551,7 +2690,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2559,7 +2698,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2579,15 +2718,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2595,7 +2734,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2635,7 +2774,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2666,11 +2805,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2867,7 +3006,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2888,13 +3027,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2957,15 +3096,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2977,7 +3116,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2989,9 +3128,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,7 +3147,7 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:239
+#: senaite/core/browser/samples/view.py:249
 msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
@@ -3055,8 +3194,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3065,7 +3204,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3073,13 +3212,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3092,7 +3231,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3104,7 +3243,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3116,11 +3255,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3166,15 +3305,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3198,7 +3337,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3225,6 +3364,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3289,7 +3436,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3313,7 +3460,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3337,7 +3484,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3366,7 +3513,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3381,7 +3528,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3416,15 +3563,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3432,7 +3579,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3463,7 +3610,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3474,7 +3621,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3492,7 +3639,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3523,6 +3670,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3536,11 +3687,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3576,13 +3727,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3592,6 +3747,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3634,6 +3793,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3682,6 +3845,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3726,12 +3893,24 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3748,6 +3927,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3776,7 +3959,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3792,11 +3975,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3817,7 +4000,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3829,7 +4012,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3845,16 +4028,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3864,6 +4047,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3882,11 +4069,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3894,13 +4081,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3908,8 +4095,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3937,7 +4132,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3959,11 +4154,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4060,11 +4255,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4077,6 +4272,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4096,12 +4292,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4140,31 +4340,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4197,7 +4397,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4214,11 +4414,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4246,7 +4446,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4255,7 +4455,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4277,11 +4477,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4294,7 +4494,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4318,7 +4518,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4327,7 +4527,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4335,7 +4535,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4344,8 +4544,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4360,6 +4564,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4381,6 +4589,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4407,7 +4623,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4419,30 +4635,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4493,11 +4713,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4523,9 +4747,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4541,7 +4765,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4602,8 +4826,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4639,11 +4871,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4655,7 +4887,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4664,7 +4896,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4680,12 +4912,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr ""
 
-# senaite.app.listing: Reset-columns button tooltip
-msgid "Reset column visibility and order to the defaults"
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4693,15 +4933,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4726,15 +4967,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4742,7 +4983,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4758,16 +4999,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4775,7 +5020,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4799,7 +5044,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4835,6 +5080,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4860,6 +5109,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4869,7 +5119,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4883,7 +5133,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4920,7 +5170,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4940,7 +5190,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4967,7 +5217,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5028,7 +5278,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5040,8 +5290,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5058,6 +5308,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5067,7 +5329,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5075,7 +5353,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5088,7 +5366,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5096,14 +5374,22 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5118,7 +5404,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5135,6 +5421,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5143,7 +5433,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5233,11 +5523,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5249,11 +5539,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5261,31 +5551,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5297,7 +5595,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5309,11 +5607,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5335,7 +5633,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5349,7 +5647,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5377,7 +5675,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5425,28 +5723,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5469,11 +5779,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5494,7 +5804,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5510,6 +5820,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5536,7 +5854,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5544,7 +5862,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5561,17 +5879,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5580,7 +5898,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5620,7 +5942,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5628,7 +5954,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5670,7 +5996,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5696,7 +6022,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5778,7 +6104,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5786,7 +6112,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5814,7 +6140,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5822,11 +6152,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5863,11 +6193,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5907,7 +6237,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5931,11 +6261,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5987,11 +6317,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6015,11 +6345,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6051,8 +6381,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6079,34 +6409,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6119,7 +6457,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6141,7 +6479,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6166,6 +6504,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6174,7 +6516,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6186,6 +6528,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6218,8 +6561,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6236,12 +6583,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6252,7 +6603,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6260,7 +6611,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6298,7 +6649,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6306,15 +6657,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6322,7 +6673,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6569,8 +6920,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6579,10 +6930,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6597,6 +6956,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6632,6 +6999,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6644,19 +7015,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6707,9 +7078,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6718,6 +7097,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6802,6 +7185,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6904,8 +7291,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6955,7 +7351,7 @@ msgid "description_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7095,52 +7491,52 @@ msgid "description_batch_client"
 msgstr ""
 
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7180,12 +7576,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7195,7 +7591,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7289,6 +7685,16 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7317,6 +7723,11 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7435,12 +7846,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7670,232 +8081,232 @@ msgid "description_sampletype_samplematrix"
 msgstr ""
 
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8042,6 +8453,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8353,7 +8768,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8403,7 +8818,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8508,52 +8923,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8623,12 +9038,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8638,7 +9053,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -8933,7 +9348,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9058,12 +9473,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9273,7 +9688,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9283,12 +9698,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9346,6 +9761,21 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10522,87 +10952,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10655,6 +11085,10 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10704,12 +11138,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -10787,6 +11229,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11021,13 +11468,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11114,6 +11566,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11359,222 +11816,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -11822,7 +12279,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -11865,130 +12322,10 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 
 #: bika/lims/controlpanel/bika_instruments.py:173
 msgid "{} weeks and {} day(s)"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:507
-msgid "Filter samples by this analysis"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:537
-msgid "Remove this analysis from the filter"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:518
-msgid "Showing samples that contain:"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:519
-msgid "Clear filter"
-#: senaite/core/browser/dashboard/dashboard.py:368
-msgid "Samples awaiting collection of the sample"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:372
-msgid "Samples awaiting preservation"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:377
-msgid "Samples with a scheduled sampling date"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:384
-msgid "Samples awaiting reception at the laboratory"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:388
-msgid "Received samples with analyses awaiting results"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:392
-msgid "Samples whose results are awaiting verification"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:396
-msgid "Verified samples ready to be published"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:400
-msgid "Samples whose reports have been published"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:416
-msgid "Published samples whose reports have not been printed yet"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:448
-msgid "Analyses not yet assigned to a worksheet"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:453
-msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:458
-msgid "Submitted analyses awaiting verification"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:462
-msgid "Analyses that have been verified"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:486
-msgid "Open worksheets with analyses awaiting results"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:490
-msgid "Worksheets whose results are awaiting verification"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:495
-msgid "Worksheets that have been verified"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:466
-msgid "Analyses included in a published report"
-#: senaite/core/api/remarks.py
-msgid "Add a remark..."
-msgstr ""
-
-#: senaite/core/api/remarks.py
-msgid "Hide history"
-msgstr ""
-
-#: senaite/core/api/remarks.py
-msgid "No remarks yet"
-msgstr ""
-
-#: senaite/core/api/remarks.py
-msgid "Show history"
-msgstr ""
-
-#: senaite/core/api/remarks.py
-msgid "edited"
-msgstr ""
-
-#: senaite/core/api/remarks.py
-msgid "original"
-msgstr ""
-
-#: senaite/core/api/remarks.py
-msgid "Delete this remark?"
-msgstr ""
-
-#: senaite/core/api/remarks.py
-msgid "deleted by {user} at {time}"
-msgstr ""
-
-#: senaite/core/api/remarks.py
-msgid "Newest first"
-msgstr ""
-
-#: senaite/core/api/remarks.py
-msgid "Oldest first"
 msgstr ""

--- a/src/senaite/core/locales/senaite.core.pot
+++ b/src/senaite/core/locales/senaite.core.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/src/senaite/core/locales/sq_AL/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/sq_AL/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Albion Shala, 2023\n"
 "Language-Team: Albanian (Albania) (https://app.transifex.com/senaite/teams/87045/sq_AL/)\n"

--- a/src/senaite/core/locales/sq_AL/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/sq_AL/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Albion Shala, 2023\n"
 "Language-Team: Albanian (Albania) (https://app.transifex.com/senaite/teams/87045/sq_AL/)\n"
@@ -919,6 +919,11 @@ msgstr "need_an_account"
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/sq_AL/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/sq_AL/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Albanian (Albania) (https://app.transifex.com/senaite/teams/87045/sq_AL/)\n"

--- a/src/senaite/core/locales/sq_AL/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/sq_AL/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Albanian (Albania) (https://app.transifex.com/senaite/teams/87045/sq_AL/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: sq_AL\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/sv/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/sv/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Swedish (https://app.transifex.com/senaite/teams/87045/sv/)\n"

--- a/src/senaite/core/locales/sv/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/sv/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Swedish (https://app.transifex.com/senaite/teams/87045/sv/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/sv/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/sv/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Swedish (https://app.transifex.com/senaite/teams/87045/sv/)\n"

--- a/src/senaite/core/locales/sv/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/sv/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Swedish (https://app.transifex.com/senaite/teams/87045/sv/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: sv\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ta/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ta/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Tamil (https://app.transifex.com/senaite/teams/87045/ta/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ta/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ta/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Tamil (https://app.transifex.com/senaite/teams/87045/ta/)\n"

--- a/src/senaite/core/locales/ta/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ta/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Tamil (https://app.transifex.com/senaite/teams/87045/ta/)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ta\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -27,6 +27,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -52,6 +53,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -121,6 +123,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -138,7 +144,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -196,7 +202,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -241,21 +247,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -283,15 +289,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -304,8 +314,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -369,12 +382,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -393,11 +414,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -426,14 +447,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -503,7 +540,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -540,7 +577,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -550,6 +587,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -564,18 +605,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -590,7 +627,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -678,11 +715,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -690,15 +731,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -749,7 +790,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -779,6 +820,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -799,7 +844,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -817,19 +862,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -837,12 +882,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -898,23 +943,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -934,15 +979,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -968,7 +1013,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1000,11 +1045,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1041,31 +1086,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1078,12 +1123,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1091,7 +1150,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1103,7 +1162,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1115,7 +1174,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1125,7 +1184,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1134,7 +1193,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1227,7 +1286,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1265,6 +1324,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1283,7 +1346,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1327,7 +1390,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1360,15 +1423,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1378,6 +1441,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1396,11 +1463,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1413,7 +1480,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1421,7 +1488,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1433,7 +1500,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1463,7 +1530,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1472,7 +1539,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1480,12 +1547,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1533,23 +1608,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1561,11 +1636,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1607,7 +1682,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1630,11 +1705,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1646,7 +1721,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1658,7 +1733,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1666,20 +1741,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1691,7 +1766,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1723,15 +1798,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1743,7 +1818,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1752,7 +1827,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1776,7 +1851,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1788,8 +1863,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1818,9 +1902,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1867,7 +1951,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1885,7 +1973,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1910,15 +1998,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1988,11 +2084,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2009,7 +2109,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2057,6 +2157,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2071,21 +2172,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2093,27 +2194,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2126,16 +2227,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2146,27 +2251,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2174,8 +2279,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2199,7 +2312,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2212,7 +2325,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2236,7 +2349,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2248,15 +2361,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2268,7 +2381,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2278,7 +2391,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2304,7 +2417,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2312,7 +2425,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2399,7 +2512,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2413,6 +2526,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2429,11 +2554,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2456,13 +2581,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2470,7 +2599,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2503,7 +2632,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2517,7 +2646,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2530,8 +2659,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2555,7 +2696,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2563,7 +2704,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2583,15 +2724,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2599,7 +2740,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2639,7 +2780,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2670,11 +2811,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2871,7 +3012,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2892,13 +3033,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2961,15 +3102,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2981,7 +3122,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2993,9 +3134,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3010,6 +3151,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3055,8 +3200,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3065,7 +3210,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3073,13 +3218,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3092,7 +3237,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3104,7 +3249,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3116,11 +3261,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3166,15 +3311,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3198,7 +3343,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3225,6 +3370,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3289,7 +3442,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3313,7 +3466,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3337,7 +3490,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3366,7 +3519,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3381,7 +3534,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3416,15 +3569,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3432,7 +3585,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3463,7 +3616,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3474,7 +3627,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3492,7 +3645,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3523,6 +3676,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3536,11 +3693,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3576,13 +3733,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3592,6 +3753,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3634,6 +3799,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3682,6 +3851,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3726,12 +3899,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3748,6 +3935,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3776,7 +3967,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3792,11 +3983,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3817,7 +4008,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3829,7 +4020,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3845,16 +4036,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3864,6 +4055,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3882,11 +4077,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3894,13 +4089,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3908,8 +4103,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3937,7 +4140,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3959,11 +4162,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4060,11 +4263,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4077,6 +4280,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4096,12 +4300,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4140,31 +4348,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4197,7 +4405,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4214,11 +4422,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4246,7 +4454,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4255,7 +4463,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4277,11 +4485,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4294,7 +4502,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4318,7 +4526,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4327,7 +4535,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4335,7 +4543,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4344,8 +4552,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4360,6 +4572,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4381,6 +4597,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4407,7 +4631,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4419,30 +4643,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4493,11 +4721,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4523,9 +4755,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4541,7 +4773,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4602,8 +4834,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4639,11 +4879,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4655,7 +4895,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4664,7 +4904,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4680,8 +4920,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4689,15 +4941,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4722,15 +4975,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4738,7 +4991,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4754,16 +5007,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4771,7 +5028,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4795,7 +5052,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4831,6 +5088,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4856,6 +5117,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4865,7 +5127,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4879,7 +5141,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4916,7 +5178,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4936,7 +5198,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4963,7 +5225,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5024,7 +5286,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5036,8 +5298,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5054,6 +5316,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5063,7 +5337,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5071,7 +5361,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5084,7 +5374,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5092,14 +5382,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5114,7 +5413,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5131,6 +5430,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5139,7 +5442,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5229,11 +5532,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5245,11 +5548,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5257,31 +5560,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5293,7 +5604,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5305,11 +5616,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5331,7 +5642,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5345,7 +5656,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5373,7 +5684,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5421,28 +5732,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5465,11 +5788,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5490,7 +5813,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5506,6 +5829,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5532,7 +5863,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5540,7 +5871,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5557,17 +5888,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5576,7 +5907,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5616,7 +5951,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5624,7 +5963,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5666,7 +6005,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5692,7 +6031,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5774,7 +6113,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5782,7 +6121,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5810,7 +6149,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5818,11 +6161,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5859,11 +6202,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5903,7 +6246,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5927,11 +6270,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5983,11 +6326,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6011,11 +6354,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6047,8 +6390,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6075,34 +6418,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6115,7 +6466,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6137,7 +6488,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6162,6 +6513,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6170,7 +6525,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6182,6 +6537,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6214,8 +6570,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6232,12 +6592,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6248,7 +6612,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6256,7 +6620,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6294,7 +6658,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6302,15 +6666,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6318,7 +6682,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6565,8 +6929,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6575,10 +6939,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6593,6 +6965,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6628,6 +7008,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6640,19 +7024,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6703,9 +7087,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6714,6 +7106,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6798,6 +7194,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6902,8 +7302,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6968,7 +7377,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7135,46 +7544,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7186,19 +7595,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7219,16 +7628,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7253,12 +7667,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7268,7 +7682,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7371,6 +7785,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7400,6 +7827,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7546,12 +7980,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7804,7 +8238,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7812,163 +8246,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7976,47 +8410,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8025,20 +8459,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8046,32 +8480,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8079,21 +8513,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8249,6 +8683,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8561,7 +8999,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8622,7 +9060,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8738,52 +9176,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8853,12 +9291,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8868,7 +9306,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9164,7 +9602,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9289,12 +9727,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9504,7 +9942,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9514,12 +9952,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9577,6 +10015,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10753,87 +11207,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10886,6 +11340,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10936,12 +11395,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11019,6 +11486,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11253,13 +11725,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11346,6 +11823,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11591,222 +12073,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12060,7 +12542,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12103,7 +12585,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ta/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ta/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Tamil (https://app.transifex.com/senaite/teams/87045/ta/)\n"

--- a/src/senaite/core/locales/te_IN/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/te_IN/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Telugu (India) (https://app.transifex.com/senaite/teams/87045/te_IN/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/te_IN/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/te_IN/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Telugu (India) (https://app.transifex.com/senaite/teams/87045/te_IN/)\n"

--- a/src/senaite/core/locales/te_IN/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/te_IN/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Telugu (India) (https://app.transifex.com/senaite/teams/87045/te_IN/)\n"

--- a/src/senaite/core/locales/te_IN/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/te_IN/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Telugu (India) (https://app.transifex.com/senaite/teams/87045/te_IN/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: te_IN\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/tg/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/tg/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Bakhtiyor Barotov, 2023\n"
 "Language-Team: Tajik (https://app.transifex.com/senaite/teams/87045/tg/)\n"
@@ -922,6 +922,11 @@ msgstr "need_an_account"
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/tg/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/tg/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Bakhtiyor Barotov, 2023\n"
 "Language-Team: Tajik (https://app.transifex.com/senaite/teams/87045/tg/)\n"

--- a/src/senaite/core/locales/tg/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/tg/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Tajik (https://app.transifex.com/senaite/teams/87045/tg/)\n"

--- a/src/senaite/core/locales/tg/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/tg/LC_MESSAGES/senaite.core.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Tajik (https://app.transifex.com/senaite/teams/87045/tg/)\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: tg\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr "<p>Сервери ID метавонад ID-ҳои пайдарпайии беназирро барои объектҳо ба монанди Намунаҳо ва варақаҳои корӣ ва ғ. дар асоси формате, ки барои ҳар як намуди мундариҷа муайян шудааст, пешниҳод кунад. </p><p>Формат ба таври шабеҳ ба синтаксиси формати Python бо истифода аз тағирёбандаҳои пешакӣ муайяншуда барои як намуди мундариҷа сохта мешавад ва ID-ҳо тавассути рақами пайдарпай, 'seq' ва пуркунии он ҳамчун шумораи рақамҳо, масалан, '03d' барои пайдарпаии ID-ҳо аз 001 то 999. </p><p>Префиксҳои алифбоӣ-рақамӣ барои ID-ҳо ҳамчун дар форматҳо дохил карда мешаванд, масалан, WS барои Worksheet дар WS-{seq:03d} ID-ҳои пайдарпайи варақи корро тавлид мекунад: WS-001, WS-002, WS-003 ва ғайра.</p><p> Барои тавлиди динамикии ID-ҳои алифбоӣ-рақамӣ ва пайдарпай, аломати ҷонишини {alpha} метавонад истифода шавад. Масалан, WS-{alpha:2a3d} WS-AA001, WS-AA002, WS-AB034 ва ғайраро истеҳсол мекунад. </p><p>Тағйирёбандаҳое, ки метавонанд истифода шаванд, инҳоро дар бар мегиранд: <table><tr><th style='width:150px'> Навъи Мундарича </th><th> Тағйирёбандаҳо </th></tr><tr><td> ID Client </td><td> {clientId} </td></tr><tr><td> Сол </td><td> {year}  </td></tr><tr><td>ID-и намуна </td><td> {sampleId} </td></tr><tr><td> Намуди намуна </td><td> {sampleType} </td></tr><tr> Санаи намунагирӣ <td> {samplingDate} <td></td></tr><tr><td> Санаи гирифташудани намуна </td><td> {dateSampled} </td></tr></table></p><p> Танзимоти конфигуратсия: <ul><li>формат: <ul><li> сатри формати python, ки аз тағирёбандаҳои пешакӣ муайяншуда ба мисли sampleId, clientId, sampleType сохта шудааст. </li><li> тағирёбандаи махсуси 'seq' бояд дар навъи сатри </li></ul></li><li>ҳисобкунии сатр охирин ҷойгир карда шавад [generated|counter]: </li><li>: агар навъи ҳисобкунак, контексти навъи функсияи ҳисобкуниро таъмин кунад </li><li>:[backreference|contained]</li><li> истинод ба ҳисоб: параметр ба префикси функсияи ҳисоб </li><li>: префикси пешфарз, агар дар формати дарозии сатр </li><li> пешбинӣ нашуда бошад: шумораи қисмҳое, ки ба префикс </li></ul></p>дохил карда мешаванд."
 
@@ -29,6 +29,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} замимаҳо бо андозаи умумии ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -54,6 +55,7 @@ msgid "%s has no '%s' column."
 msgstr "%sсутуни '%s' надорад."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Бозгашт"
@@ -123,6 +125,10 @@ msgstr "*** Ин паём электронӣ ба таври худкор тав
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -140,7 +146,7 @@ msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" />Ба танзимоти 
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Хуш омадед ба SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -198,7 +204,7 @@ msgid "Account Type"
 msgstr "Намуди суратҳисоб"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -243,21 +249,21 @@ msgstr "Фаъол кардан"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Фаъол"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Шахси амалкунанда"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Илова намудан"
 
@@ -285,15 +291,19 @@ msgstr "Илова намудани Дубликат"
 msgid "Add Samples"
 msgstr "Илова намудани Намуна"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Илова намудани майдони қайдҳо ба ҳама таҳлилҳо"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "Илова намудани Қоидаҳои CSS-и фармоиши барои Лого, масалан, баландӣ: 15px; паҳно: 150px;"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "Илова кардани тамғакоғазҳои интихобшавандаи пешфарз 'по умолчанию'"
 
@@ -306,8 +316,11 @@ msgstr "Илова намудани Замимаи нав"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Илова намудани як ё якчанд замимаҳо барои тавсиф намудани намуна дар ин намуна ё дархости худро аник кунед."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Эзоҳҳо илова кунед"
 
@@ -371,13 +384,21 @@ msgstr "Ҳамаи хизматрасониҳои таҳлилии аккред�
 msgid "All Analyses of Service"
 msgstr "Ҳама таҳлилҳои хизматрасони"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Ҳама таҳлилҳо таъин карда мешаванд"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Ба таври дастӣ ворид намудани киммати Махдудияти Кашфкуни иҷозат диҳед"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -395,11 +416,11 @@ msgstr "Ба ҳамон истифодабаранда иҷозат диҳед, 
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Ба хамон истифодабаранда иҷозат диҳед, ки якчанд маротиба тафтиш кунад, аммо на пай дар пай"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Ба худтанзимкунии натиҷаҳо иҷозат диҳед"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -428,15 +449,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "аз ҷониби ... таҳлил карда шудааст"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Таҳлилҳо"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Таҳлилҳо дархост карда шудаанд"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -505,7 +542,7 @@ msgstr "Шарту шароитҳои таҳлил"
 msgid "Analysis conditions updated: {}"
 msgstr "Шарту шароитҳои таҳлил аз нав карда шуданд: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Мушаххасоти таҳлил, ки бевосита дар Намуна таҳрир карда мешаванд."
 
@@ -542,7 +579,7 @@ msgstr "аҳлилгар бояд муайян карда шавад."
 msgid "Any"
 msgstr "Ягон, дилхох"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "Намуди зоҳирӣ"
 
@@ -553,6 +590,10 @@ msgstr "Татбик намудан"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Шаблонро татбиқ кунед"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -566,19 +607,15 @@ msgstr "Рақами дороиҳо"
 msgid "Assign"
 msgstr "Таъин кунед"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "таъин шудааст"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Таъиншуда ба: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Супориш интизор аст"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -592,7 +629,7 @@ msgstr "Ба Намуна замима кунед"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr "Нишонҳои замимашуда"
 
@@ -680,11 +717,15 @@ msgstr "ба таври автомати хосил шудаи ID рафтор �
 msgid "Auto-Import Logs"
 msgstr "Сабтҳои автоворидот"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Ҳангоми қабул авто тақсимкунӣ"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Ба таври автомати кабул намудани намунаҳо"
 
@@ -692,15 +733,15 @@ msgstr "Ба таври автомати кабул намудани намун�
 msgid "Autofill"
 msgstr "Ба таври автомати пур кардани сатр"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Ба таври автомати баромадан"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr "Ба таври автомати тафтиш намудани намуна"
 
@@ -751,7 +792,7 @@ msgstr "Партия-даста"
 msgid "Batch Book"
 msgstr "Дафтари партия-даста"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "ID раками партия-даста"
 
@@ -781,6 +822,10 @@ msgstr "Огоҳ бошед, ки диапазонҳои дар файли ҷа�
 msgid "Bearing"
 msgstr "Дар назар ширифтан"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Суроғаи фиристодани ҳисоб"
@@ -801,7 +846,7 @@ msgstr "Бренд"
 msgid "Bulk Discount"
 msgstr "Тахфифи яклухт"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Тахфифи яклухт татбиқ мешавад"
@@ -819,19 +864,19 @@ msgstr "Раками телефони кори"
 msgid "Business address"
 msgstr "Сурогаи кори"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr "Аз руи афзоиши 'Намоиши арзиш'"
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr "Аз рӯи камшавии 'Намоиши арзиш'"
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr "Аз руи афзоиши 'Натичаи арзиш'"
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr "Аз руи камшавии 'Натичаи арзиш'"
 
@@ -839,12 +884,12 @@ msgstr "Аз руи камшавии 'Натичаи арзиш'"
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "Сурогахои Email-и дар нусха мондашаванда"
 
@@ -900,23 +945,23 @@ msgstr "Калибровкакунихо"
 msgid "Calibrator"
 msgstr "Калибровкакунанда"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Метавонед тафтиш кунед, аммо аз ҷониби истифодабарандаи ҷорӣ пешниҳод карда шудааст"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Метавонед тафтиш кунед, аммо аллакай аз ҷониби истифодабарандаи ҷорӣ тасдиқ карда шудааст"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Бекор кардан"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Бекор карда шуд"
 
@@ -936,15 +981,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr "Барои ${sample_id}: ${error} почтаи электронӣ фиристода намешавад"
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "Тасдиқ кардан ғайриимкон аст, охирин аз ҷониби истифодабарандаи ҷорӣ санҷида шудааст"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "Тасдиқ карда намешавад, аз ҷониби истифодабарандаи ҷорӣ пешниҳод шудааст"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "Тасдиқ кардан мумкин нест, аз ҷониби истифодабарндаи ҷорӣ тасдиқ карда шудааст"
 
@@ -970,7 +1015,7 @@ msgstr "Мундариҷаи Каталоги Махорат дар катало
 msgid "Catalogue Number"
 msgstr "Раками каталог"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Хизматҳои таҳлилиро гурӯҳбандӣ кунед"
 
@@ -1002,11 +1047,11 @@ msgid "Changes Saved"
 msgstr "Тағйирот сабт карда шуд"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "тагирот саб кард шуд."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "Тағирот ба қисмҳо паҳн карда мешаванд"
 
@@ -1043,31 +1088,31 @@ msgstr "Қуттии қайд"
 msgid "Choices"
 msgstr "Интихобҳо"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Навъи санҷиши чандкаратаро барои хамон як истифодабаранда интихоб кунед. Ин танзимот метавонад барои хамон як истифодабаранда беш аз як маротиба тафтишкунӣ/пайдарпай тафтишкуниро фаъол/хомӯш кунад."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1080,20 +1125,34 @@ msgstr "Шаҳр"
 msgid "Classic"
 msgstr "классикӣ"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "Интихобро тоза кунед"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Барои васеъ кардани ин категория клик кунед"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "Барои иваз кардани намуди зоҳирӣ клик кунед ё барои тағир додани тартиб кашола намуда партоед"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Муштарӣ"
@@ -1105,7 +1164,7 @@ msgstr "ID партияи муштарӣ"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID-и муштарӣ"
 
@@ -1117,7 +1176,7 @@ msgstr "Саҳифаи кушодани муштарӣ"
 msgid "Client Name"
 msgstr "Номи муштарӣ"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Номи муштарӣ"
 
@@ -1127,7 +1186,7 @@ msgstr "Номи муштарӣ"
 msgid "Client Order Number"
 msgstr "Рақами фармоиши муштарӣ"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Истиноди муштарӣ"
 
@@ -1136,7 +1195,7 @@ msgstr "Истиноди муштарӣ"
 msgid "Client Reference"
 msgstr "Истиноди муштарӣ"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID-и муштарӣ"
 
@@ -1229,7 +1288,7 @@ msgstr "Шарҳҳо"
 msgid "Comments or results interpretation"
 msgstr "Шарҳҳо ё тафсири натиҷаҳо"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "ID-и тиҷоратӣ"
@@ -1267,6 +1326,10 @@ msgstr "Конфигуратсия барои маълумоти сарлавҳ�
 msgid "Configuration restored to default values."
 msgstr "Конфигуратсия ба арзишҳои пешфарз-поумолчанию барқарор карда шуд."
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr "Сутунҳои ҷадвалро танзим кунед"
@@ -1285,7 +1348,7 @@ msgstr "Калидвожаро Тасдиқ Кунед"
 msgid "Considerations"
 msgstr "Мулоҳизаҳо"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Тамос"
@@ -1329,7 +1392,7 @@ msgstr "Контейнерхо"
 msgid "Contents of the file {}"
 msgstr "Таркиботи файли {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1362,15 +1425,15 @@ msgstr "Хизматҳои таҳлилро нусхабардорӣ намое�
 msgid "Copy from"
 msgstr "Нусхабардори намоед аз"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Ба нав нусхабардори намоед"
 
@@ -1380,6 +1443,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1398,11 +1465,11 @@ msgstr "Намунаҳоро ба ҳолати намунагирифташуд�
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1415,7 +1482,7 @@ msgstr "Давлат"
 msgid "Create Invoice PDF"
 msgstr "Тахияи ҳисобнома-фактураи PDF"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Таъсиси қисмҳо"
 
@@ -1423,7 +1490,7 @@ msgstr "Таъсиси қисмҳо"
 msgid "Create SENAITE Site"
 msgstr "Сохтани сайти SENAITE"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr "Варақаи корӣ таъсис дихед"
 
@@ -1435,7 +1502,7 @@ msgstr "Сомонаи нави SENAITE таъсис дихед"
 msgid "Create a new User"
 msgstr "Истифодабарандаи нав таъсис дихед"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr "Барои намунаҳои интихобшуда варақи нави корӣ таъсис дихед"
 
@@ -1465,7 +1532,7 @@ msgid "Created {} partitions: {}"
 msgstr "{} қисмҳои таъсисшуда: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Таъсисдиханда"
 
@@ -1474,7 +1541,7 @@ msgstr "Таъсисдиханда"
 msgid "Criteria"
 msgstr "Критерия"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Асъор"
 
@@ -1482,13 +1549,21 @@ msgstr "Асъор"
 msgid "Current"
 msgstr "Хозира"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Аломати даҳиро дуруст намо"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "DL"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1535,23 +1610,23 @@ msgstr "Таърихи руз тагйир дода шуд"
 msgid "Date Opened"
 msgstr "Таърихи руз кушрда шуд"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Таърихи руз нигох дошта шуд"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Таърихи руз чоп карда шуд"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Таърихи руз нашр карда шуд"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Таърихи руз кабул карда шуд"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Таърихи руз ба кайд гирифта шуд"
 
@@ -1563,11 +1638,11 @@ msgstr "Таърихи руз дархост карда мешавад"
 msgid "Date Sample Received"
 msgstr "Таърихи рузи кабули Намуна"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Таърихи рузи намунагири"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Таърихи руз тасдик карда шуд"
 
@@ -1609,7 +1684,7 @@ msgstr "Таърихи рузе, ки сертификати калибровк�
 msgid "Date when the certificate is valid"
 msgstr "Таърихи рузе, ки то он сертификат амал мекунад"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1632,11 +1707,11 @@ msgstr "То санҷиши навбатии калибровкакунӣ ғай
 msgid "Deactivate"
 msgstr "Гайрифаъол намоед"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Аломати даҳӣ барои истифода дар гузоришҳои ин муштарӣ."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1648,7 +1723,7 @@ msgstr "Контейнер по умолчанию"
 msgid "Default Department"
 msgstr "Шуъба по умолчанию"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Email-хои пешфарз ба CC нусхахои ҳамаи намунаҳои нашршуда барои ин муштарӣ"
 
@@ -1660,7 +1735,7 @@ msgstr "Асбоб по умалчанию"
 msgid "Default Method"
 msgstr "Тарзи тахлил по умолчанию"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1668,20 +1743,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Консервирование по умолчанию"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Шумораи пешфарзии Намуна барои илова кардан."
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Аломати даҳии пешфарз-поумолчанию"
 
@@ -1693,7 +1768,7 @@ msgstr "Асбоби пешфарз барои таҳлили ин намуд и
 msgid "Default large sticker"
 msgstr "Наклейкаи калони пешфарз"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Тарҳбандии пешфарз дар намуди варақаи корӣ"
 
@@ -1725,15 +1800,15 @@ msgstr "Натиҷаи пешфарз бояд яке аз имконоти зе
 msgid "Default result to display on result entry"
 msgstr "Натиҷаи пешфарз барои намоиш дар вуруди натиҷа"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Мӯҳлати нигоҳдории намунаи пешфарз"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Формати пешфарзии илмии гузоришҳо"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Формати пешфарзии илмӣ барои натиҷаҳо"
 
@@ -1745,7 +1820,7 @@ msgstr "Наклейкаи хурди пешфарз"
 msgid "Default timezone"
 msgstr "Минтақаи вақти пешфарз"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Вақти бозгашти пешфарз барои таҳлилҳо."
 
@@ -1754,7 +1829,7 @@ msgstr "Вақти бозгашти пешфарз барои таҳлилҳо."
 msgid "Default value"
 msgstr "Кимати пешфарз"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "Қимати пешфарзии \"Ҳисоби намуна\" вақте ки истифодабарандагон тугмаи \"ИЛОВА\" -ро пахш мекунанд, то Намунаҳои нав таъсис диханд"
 
@@ -1778,7 +1853,7 @@ msgstr "Ҳангоми табдил додани кимматҳо ба нишо�
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Намунагиреро муайян кунед, ки бояд намунаро дар санаи пешбинишуда иҷро кунад"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1790,8 +1865,17 @@ msgstr "Наклейкаҳоеро, ки барои ин навъи намуна
 msgid "Degrees"
 msgstr "Дараҷаҳо"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1820,9 +1904,9 @@ msgstr "Шуъбахо"
 msgid "Dependent Analyses"
 msgstr "Таҳлилҳои вобастагӣ"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Тавсиф"
 
@@ -1869,7 +1953,11 @@ msgstr "Гузаришҳои автоматиро гайрифаъол намо�
 msgid "Disable multi-verification for the same user"
 msgstr "Санҷиши бисёрҷонибаро барои хамон як истифодабаранда ғайрифаъол кунед"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Тахфиф"
@@ -1887,7 +1975,7 @@ msgstr "Фиристодан"
 msgid "Dispatch samples"
 msgstr "Намунаҳои фиристодан"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Фиристода шуд"
@@ -1912,15 +2000,23 @@ msgstr "Намоиши киммат бояд бе назир бошад"
 msgid "Display a Detection Limit selector"
 msgstr "Намоиши интихобкунандаи маҳдудияти муайянкунӣ"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr "Намоиши қисмҳои намуна ба муштариён"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Махфуз гардон"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Махфуз гардонида шуд"
 
@@ -1990,11 +2086,15 @@ msgstr "PDF-ро скачат кардан"
 msgid "Download selected reports"
 msgstr "Хисоботхои интихобшударо скачат кардан"
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Мухлат"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Мӯҳлати пардохт"
@@ -2011,7 +2111,7 @@ msgstr "Дубликат-такрори"
 msgid "Duplicate Analysis"
 msgstr "Таҳлили такрорӣ"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2059,6 +2159,7 @@ msgstr "масалан, SANAS, APLAC ва ғайра."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "Ҳар як интерфейси воридот метавонад папкаеро муайян кунад, ки дар он система файлҳои натиҷаҳоро ҷустуҷӯ мекунад дар вакти ба таври автомати ворид кардани натиҷаҳо ҳангоми <code> занг задан auto_import_results </code>-ро намоиш дехед."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Таҳрир"
@@ -2073,21 +2174,21 @@ msgstr "Баландӣ"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Сурогаи почтаи электрони Email"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2095,27 +2196,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "Дафтари кайди Email"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "Таркиби мактуби электронӣ барои огоҳиномаҳои беэътибории намуна"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr "Таркиби мактуби электронӣ барои огоҳиномаҳои радди намуна"
 
@@ -2128,17 +2229,21 @@ msgstr "Почтаи электронӣ бекор карда шуд"
 msgid "Email notification"
 msgstr "Огоҳинома бо почтаи электронӣ"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "Огоҳинома бо почтаи электронӣ дар бораи рад кардани намуна"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
 msgstr "Мактуби электрони фиристода шуд"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2148,27 +2253,27 @@ msgstr "Калидҳои холӣ дастгирӣ намешаванд"
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Истифодаи чандкаратаи асбобро дар варақаҳои корӣ фаъол созед."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Консерватсияи намунаро фаъол созед"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2176,8 +2281,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2201,7 +2314,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2214,7 +2327,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2238,7 +2351,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2250,15 +2363,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2270,7 +2383,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2280,7 +2393,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2306,7 +2419,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2314,7 +2427,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2401,7 +2514,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2415,6 +2528,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2431,11 +2556,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2458,13 +2583,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2472,7 +2601,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2505,7 +2634,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2519,7 +2648,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2532,8 +2661,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2557,7 +2698,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2565,7 +2706,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2585,15 +2726,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2601,7 +2742,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2641,7 +2782,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2672,11 +2813,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2873,7 +3014,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2894,13 +3035,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2963,15 +3104,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2983,7 +3124,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2995,9 +3136,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3012,6 +3153,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3057,8 +3202,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3067,7 +3212,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3075,13 +3220,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3094,7 +3239,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3106,7 +3251,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3118,11 +3263,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3168,15 +3313,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3200,7 +3345,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3227,6 +3372,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3291,7 +3444,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3315,7 +3468,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3339,7 +3492,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3368,7 +3521,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3383,7 +3536,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3418,15 +3571,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3434,7 +3587,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3465,7 +3618,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3476,7 +3629,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3494,7 +3647,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3525,6 +3678,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3538,11 +3695,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3578,13 +3735,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3594,6 +3755,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3636,6 +3801,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3684,6 +3853,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3728,12 +3901,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3750,6 +3937,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3778,7 +3969,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3794,11 +3985,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3819,7 +4010,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3831,7 +4022,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3847,16 +4038,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3866,6 +4057,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3884,11 +4079,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3896,13 +4091,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3910,8 +4105,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3939,7 +4142,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3961,11 +4164,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4062,11 +4265,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4079,6 +4282,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4098,12 +4302,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4142,31 +4350,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4199,7 +4407,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4216,11 +4424,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4248,7 +4456,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4257,7 +4465,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4279,11 +4487,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4296,7 +4504,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4320,7 +4528,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4329,7 +4537,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4337,7 +4545,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4346,8 +4554,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4362,6 +4574,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4383,6 +4599,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4409,7 +4633,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4421,30 +4645,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4495,11 +4723,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4525,9 +4757,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4543,7 +4775,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4604,8 +4836,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4641,11 +4881,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4657,7 +4897,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4666,7 +4906,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4682,8 +4922,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4691,15 +4943,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4724,15 +4977,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4740,7 +4993,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4756,16 +5009,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4773,7 +5030,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4797,7 +5054,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4833,6 +5090,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4858,6 +5119,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4867,7 +5129,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4881,7 +5143,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4918,7 +5180,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4938,7 +5200,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4965,7 +5227,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5026,7 +5288,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5038,8 +5300,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5056,6 +5318,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5065,7 +5339,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5073,7 +5363,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5086,7 +5376,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5094,14 +5384,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5116,7 +5415,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5133,6 +5432,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5141,7 +5444,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5231,11 +5534,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5247,11 +5550,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5259,31 +5562,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5295,7 +5606,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5307,11 +5618,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5333,7 +5644,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5347,7 +5658,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5375,7 +5686,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5423,28 +5734,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5467,11 +5790,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5492,7 +5815,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5508,6 +5831,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5534,7 +5865,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5542,7 +5873,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5559,17 +5890,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5578,7 +5909,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5618,7 +5953,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5626,7 +5965,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5668,7 +6007,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5694,7 +6033,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5776,7 +6115,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5784,7 +6123,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5812,7 +6151,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5820,11 +6163,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5861,11 +6204,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5905,7 +6248,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5929,11 +6272,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5985,11 +6328,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6013,11 +6356,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6049,8 +6392,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6077,34 +6420,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6117,7 +6468,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6139,7 +6490,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6164,6 +6515,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6172,7 +6527,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6184,6 +6539,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6216,8 +6572,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6234,12 +6594,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6250,7 +6614,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6258,7 +6622,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6296,7 +6660,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6304,15 +6668,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6320,7 +6684,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6567,8 +6931,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6577,10 +6941,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6595,6 +6967,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6630,6 +7010,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6642,19 +7026,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6705,9 +7089,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6716,6 +7108,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6800,6 +7196,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6904,8 +7304,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6970,7 +7379,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7137,46 +7546,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7188,19 +7597,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7221,16 +7630,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7255,12 +7669,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7270,7 +7684,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7373,6 +7787,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7402,6 +7829,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7548,12 +7982,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7806,7 +8240,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7814,163 +8248,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7978,47 +8412,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8027,20 +8461,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8048,32 +8482,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8081,21 +8515,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8251,6 +8685,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8563,7 +9001,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8624,7 +9062,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8740,52 +9178,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8855,12 +9293,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8870,7 +9308,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9166,7 +9604,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9291,12 +9729,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9506,7 +9944,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9516,12 +9954,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9579,6 +10017,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10755,87 +11209,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10888,6 +11342,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10938,12 +11397,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11021,6 +11488,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11255,13 +11727,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11348,6 +11825,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11593,222 +12075,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12062,7 +12544,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12105,7 +12587,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/th/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/th/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Thai (https://app.transifex.com/senaite/teams/87045/th/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/th/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/th/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Thai (https://app.transifex.com/senaite/teams/87045/th/)\n"

--- a/src/senaite/core/locales/th/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/th/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Thai (https://app.transifex.com/senaite/teams/87045/th/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: th\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} ที่แนบมา มีขนาด ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr "%s ไม่มีคอลัมน์ '%s' "
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; ย้อนกลับ"
@@ -122,6 +124,10 @@ msgstr "*** นี่คืออีเมลที่สร้างขึ้�
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> ยินดีต้อนรับสู่ระบบบริหารจัดการห้องปฏิบัติการ"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "ชนิดบัญชี"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr "Activate"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Active"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Actor"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Add"
 
@@ -284,15 +290,19 @@ msgstr "Add Duplicate"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Add a remarks field to all analyses"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr "Add new Attachment"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Add one or more attachments to describe the sample in this sample, or to specify your request."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,13 +383,21 @@ msgstr "All Accredited analysis services are listed here."
 msgid "All Analyses of Service"
 msgstr "All Analyses of Service"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "All analyses assigned"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Allow Manual Detection Limit input"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -394,11 +415,11 @@ msgstr "Allow same user to verify multiple times"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Allow same user to verify multiple times, but not consecutively"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Allow self-verification of results"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,15 +448,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Analysed by"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analyses"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Analyses requested"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Analysis specifications which are edited directly on the Sample."
 
@@ -541,7 +578,7 @@ msgstr "Analyst must be specified."
 msgid "Any"
 msgstr "Any"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr "Apply"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Apply template"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,19 +606,15 @@ msgstr "Asset Number"
 msgid "Assign"
 msgstr "Assign"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Assigned"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Assigned to: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "Assignment pending"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr "รายการบันทึกการนำเข้าอัตโนมัติ"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "Auto-partition on receive"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "Auto-receive samples"
 
@@ -691,15 +732,15 @@ msgstr "Auto-receive samples"
 msgid "Autofill"
 msgstr "Autofill"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Automatic log-off"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr "Batch"
 msgid "Batch Book"
 msgstr "สมุดกลุ่มตัวอย่าง"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Batch ID"
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Bearing"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Billing address"
@@ -800,7 +845,7 @@ msgstr "Brand"
 msgid "Bulk Discount"
 msgstr "Bulk Discount"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Bulk discount applies"
@@ -818,19 +863,19 @@ msgstr "Business Phone"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC Emails"
 
@@ -899,23 +944,23 @@ msgstr "การสอบเทียบต่างๆ"
 msgid "Calibrator"
 msgstr "Calibrator"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "Can verify, but submitted by current user"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "Can verify, but was already verified by current user"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Cancel"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "Cancelled"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "Cannot verify, last verified by current user"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "Cannot verify, submitted by current user"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "Cannot verify, was verified by current user"
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Catalogue Number"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "Categorise analysis services"
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr "Changes Saved"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "Changes saved."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,20 +1124,34 @@ msgstr "City"
 msgid "Classic"
 msgstr "Classic"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "Click to expand this category"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Client"
@@ -1104,7 +1163,7 @@ msgstr "Client Batch ID"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Client ID"
 
@@ -1116,7 +1175,7 @@ msgstr "Client Landing Page"
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Client Order"
 
@@ -1126,7 +1185,7 @@ msgstr "Client Order"
 msgid "Client Order Number"
 msgstr "Client Order Number"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Client Ref"
 
@@ -1135,7 +1194,7 @@ msgstr "Client Ref"
 msgid "Client Reference"
 msgstr "Client Reference"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Client SID"
 
@@ -1228,7 +1287,7 @@ msgstr "Comments"
 msgid "Comments or results interpretation"
 msgstr "Comments or results interpretation"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "Commercial ID"
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Confirm password"
 msgid "Considerations"
 msgstr "Considerations"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Contact"
@@ -1328,7 +1391,7 @@ msgstr "Containers"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr "Copy analysis services"
 msgid "Copy from"
 msgstr "Copy from"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "Copy to new"
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "Country"
 msgid "Create Invoice PDF"
 msgstr "สร้างใบแจ้งหนี้เป็น PDF"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "Create Partitions"
 
@@ -1422,7 +1489,7 @@ msgstr "Create Partitions"
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr "Create a new User"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr "Created {} partitions: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Creator"
 
@@ -1473,7 +1540,7 @@ msgstr "Creator"
 msgid "Criteria"
 msgstr "Criteria"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Currency"
 
@@ -1481,13 +1548,21 @@ msgstr "Currency"
 msgid "Current"
 msgstr "Current"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "Custom decimal mark"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "DL"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1534,23 +1609,23 @@ msgstr "Date Modified"
 msgid "Date Opened"
 msgstr "Date Opened"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Date Preserved"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "Date Printed"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Date Published"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Date Received"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "Date Registered"
 
@@ -1562,11 +1637,11 @@ msgstr "Date Requested"
 msgid "Date Sample Received"
 msgstr "Date Sample Received"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Date Sampled"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "Date Verified"
 
@@ -1608,7 +1683,7 @@ msgstr "Date when the calibration certificate was granted"
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr "De-activate until next calibration test"
 msgid "Deactivate"
 msgstr "Deactivate"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Decimal mark to use in the reports from this Client."
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr "Default Container"
 msgid "Default Department"
 msgstr "Default Department"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "Default Emails to CC all published Samples for this client"
 
@@ -1659,7 +1734,7 @@ msgstr "Default Instrument"
 msgid "Default Method"
 msgstr "Default Method"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Default Preservation"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "Default count of Sample to add."
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "Default decimal mark"
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr "Default large sticker"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "Default layout in worksheet view"
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Default sample retention period"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "Default scientific notation format for reports"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "Default scientific notation format for results"
 
@@ -1744,7 +1819,7 @@ msgstr "Default small sticker"
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "Default turnaround time for analyses."
 
@@ -1753,7 +1828,7 @@ msgstr "Default turnaround time for analyses."
 msgid "Default value"
 msgstr "Default value"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 
@@ -1777,7 +1852,7 @@ msgstr "Define the precision when converting values to exponent notation.  The d
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Define the sampler supposed to do the sample in the scheduled date"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr "Defines the stickers to use for this sample type."
 msgid "Degrees"
 msgstr "Degrees"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr "Departments"
 msgid "Dependent Analyses"
 msgstr "Dependent Analyses"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Description"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr "Disable multi-verification for the same user"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "Discount"
@@ -1886,7 +1974,7 @@ msgstr "Dispatch"
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Dispatched"
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr "Display a Detection Limit selector"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Dispose"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Disposed"
 
@@ -1989,11 +2085,15 @@ msgstr "Download PDF"
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Due"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Due Date"
@@ -2010,7 +2110,7 @@ msgstr "Duplicate"
 msgid "Duplicate Analysis"
 msgstr "ทำซ้ำการวิเคราะห์"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr "E.g. SANAS, APLAC, etc."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "แก้ไข"
@@ -2072,21 +2173,21 @@ msgstr "Elevation"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Email Address"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "Email Log"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "Email body for Sample Invalidation notifications"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr "Email cancelled"
 msgid "Email notification"
 msgstr "Email notification"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "Email notification on Sample rejection"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "Enable Multiple Use of Instrument in Worksheets."
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "Enable Sample Preservation"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "Enable Sample Specifications"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "Enable Sampling"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "Enable Sampling Scheduling"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,9 +2280,17 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr "Enable sampling workflow for the created sample"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "Enable the Results Report Printing workflow"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2200,7 +2313,7 @@ msgstr "Enter an email address. This is necessary in case the password is lost. 
 msgid "Enter discount percentage value"
 msgstr "Enter discount percentage value"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr "Enter percentage value eg. 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 
@@ -2237,7 +2350,7 @@ msgstr "Enter the details of each of the analysis services you want to copy."
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr "Environmental conditions"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "Evolution of Analyses"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "Evolution of Samples"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "Evolution of Worksheets"
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Exclude from invoice"
 
@@ -2279,7 +2392,7 @@ msgstr "Exclude from invoice"
 msgid "Expected Result"
 msgstr "Expected Result"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "Expected Sampling Date"
 
@@ -2305,7 +2418,7 @@ msgstr "Expiry Date"
 msgid "Exponential format precision"
 msgstr "Exponential format precision"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "Exponential format threshold"
 
@@ -2313,7 +2426,7 @@ msgstr "Exponential format threshold"
 msgid "Export"
 msgstr "ส่งออก"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "Failed to load sticker"
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "Filesize"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr "Firstname"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "Formatting Configuration"
 
@@ -2457,13 +2582,17 @@ msgstr "Friday"
 msgid "From"
 msgstr "From"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Full Name"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "Fullname"
 
@@ -2471,7 +2600,7 @@ msgstr "Fullname"
 msgid "Function"
 msgstr "Function"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "Future dated sample"
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Greeting title eg. Mr, Mrs, Dr"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "Group analysis services by category in the LIMS tables, helpful when the list is long"
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr "Hazardous"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Hidden"
@@ -2531,8 +2660,20 @@ msgstr "Hidden Field"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr "ID Server Values"
 
@@ -2584,15 +2725,15 @@ msgstr "If checked, a selection list will be displayed next to the analysis' res
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "If enabled, a free text field will be displayed close to each analysis in results entry view"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 
@@ -2600,7 +2741,7 @@ msgstr "If enabled, a user who submitted a result will also be able to verify it
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "If enabled, the name of the analysis will be written in italics."
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 
@@ -2640,7 +2781,7 @@ msgstr "If unchecked, Lab Managers won't be able to assign the same Instrument m
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr "In-lab calibration procedure"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Inactive"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "Include and display pricing information"
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr "Internal Certificate"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "Internal use"
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr "Interval"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Invalid"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr "Invoice To"
 msgid "Invoice {} created"
 msgstr "Invoice {} created"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "InvoiceBatch has no End Date"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "InvoiceBatch has no Start Date"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "InvoiceBatch has no Title"
 
@@ -2982,7 +3123,7 @@ msgstr "Job Title"
 msgid "Job title"
 msgstr "Job title"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr "Key"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Keyword"
 
@@ -3012,6 +3153,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Keywords"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3056,8 +3201,8 @@ msgstr "Lab Products"
 msgid "Lab URL"
 msgstr "Lab URL"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Label"
@@ -3066,7 +3211,7 @@ msgstr "Label"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr "Laboratory"
 msgid "Laboratory Accredited"
 msgstr "Laboratory Accredited"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "Laboratory Workdays"
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "สติ๊กเกอร์ดวงใหญ่"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr "Last Auto-Import Logs"
 msgid "Last Login Time"
 msgstr "Last Login Time"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Late"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Late Analyses"
 
@@ -3167,15 +3312,15 @@ msgstr "Link User"
 msgid "Link an existing User"
 msgstr "Link an existing User"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr "Load the certificate document here"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3227,6 +3372,14 @@ msgstr "Location Type"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "Location where the document set is shelved"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3290,7 +3443,7 @@ msgstr "Male"
 msgid "Manage Analyses"
 msgstr "Manage Analyses"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "Manage Form Fields"
 
@@ -3314,7 +3467,7 @@ msgstr "Manage Sample Form Fields"
 msgid "Manage linked User"
 msgstr "Manage linked User"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr "Manager Email"
 msgid "Manager Phone"
 msgstr "Manager Phone"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "Manual"
 
@@ -3367,7 +3520,7 @@ msgstr "Manufacturers"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr "Max Time"
 msgid "Max operator"
 msgstr "Max operator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr "Member Discount"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Member discount %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Member discount applies"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "Member registered and linked to the current Contact."
 
@@ -3433,7 +3586,7 @@ msgstr "Member registered and linked to the current Contact."
 msgid "Message sent to {}, "
 msgstr "Message sent to {}, "
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr "Middle initial"
 msgid "Middle name"
 msgstr "Middle name"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr "Min operator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr "Minimum 5 characters."
 msgid "Minimum Volume"
 msgstr "Minimum Volume"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Minimum number of results for QC stats calculations"
 
@@ -3524,6 +3677,10 @@ msgstr "Module"
 msgid "Monday"
 msgstr "Monday"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "Multi Verification type"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "Multi-verification required"
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "Name"
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3636,6 +3801,10 @@ msgstr ""
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "No action defined."
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3683,6 +3852,10 @@ msgstr "No changes made"
 msgid "No changes made."
 msgstr "No changes made."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "No date set"
@@ -3727,6 +3900,16 @@ msgstr "No items selected"
 msgid "No items selected."
 msgstr "No items selected."
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "No new items were created."
@@ -3734,6 +3917,10 @@ msgstr "No new items were created."
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "No partitions were created"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3750,6 +3937,10 @@ msgstr "No samples were rejected"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "No sampling workflow"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "None"
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr "Not defined"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "Not set"
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr "Num columns"
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "Number of Analyses"
 
@@ -3846,16 +4037,16 @@ msgstr "Number of copies"
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "Number of required verifications"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 
@@ -3895,13 +4090,13 @@ msgstr "Only laboratory workdays are considered for the analysis turnaround time
 msgid "Only to empty or zero fields"
 msgstr "Only to empty or zero fields"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Open"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,9 +4104,17 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "Open Source Web based Laboratory Information Management System"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3938,7 +4141,7 @@ msgstr "Other reasons"
 msgid "Other reasons:"
 msgstr "Other reasons:"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "Other status"
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "Please select a User from the list"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Point of Capture"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr "Precision as number of decimals"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "Preferred decimal mark for reports."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "Preferred decimal mark for results"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "Preferred scientific notation format for reports"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "Preferred scientific notation format for results"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr "Preserve"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Preserver"
 
@@ -4215,11 +4423,11 @@ msgstr "Preventive"
 msgid "Preventive maintenance procedure"
 msgstr "Preventive maintenance procedure"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "Preview"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr "Pricelist for"
 msgid "Pricelists"
 msgstr "Pricelists"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "Primary Sample"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr "Print date:"
 msgid "Print pricelist"
 msgstr "พิมพ์ค่าใช้จ่าย"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "Print stickers"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "Printed"
 
@@ -4295,7 +4503,7 @@ msgstr "Printed on"
 msgid "Priority"
 msgstr "Priority"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Profile"
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "Progress"
 
@@ -4328,7 +4536,7 @@ msgstr "Progress"
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "Protocol ID"
 
@@ -4336,7 +4544,7 @@ msgstr "Protocol ID"
 msgid "Province"
 msgstr "Province"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr "Publish"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Published"
@@ -4362,6 +4574,10 @@ msgstr "Published Date"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "ผลที่ตีพิมพ์แล้วต่างๆ"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4383,6 +4599,14 @@ msgstr "ผล QC ต่างๆ"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "QC Sample ID"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4408,7 +4632,7 @@ msgstr "Re-enter the password. Make sure the passwords are identical."
 msgid "Reasons for rejection"
 msgstr "Reasons for rejection"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "Reassign"
 
@@ -4420,30 +4644,34 @@ msgstr "Reassignable Slot"
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Receive"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Received"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "Reception pending"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "Recipients"
 
@@ -4494,11 +4722,15 @@ msgstr "Reference Values"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Reference sample values are zero or 'blank'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Register"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr "ปฏิเสธการวิเคราะห์"
 msgid "Reject samples"
 msgstr "Reject samples"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "Rejected"
 
@@ -4542,7 +4774,7 @@ msgstr "Rejected sample"
 msgid "Rejected {} samples: {}"
 msgstr "Rejected {} samples: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr "Remote IP"
 msgid "Remove"
 msgstr "Remove"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr "Report ID"
 msgid "Report identification number"
 msgstr "Report identification number"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr "Report upload"
 msgid "Republish"
 msgstr "Republish"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "Republished after last print"
 
@@ -4665,7 +4905,7 @@ msgstr "Republished after last print"
 msgid "Request ID"
 msgstr "Request ID"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Request new analyses"
 
@@ -4681,8 +4921,20 @@ msgstr "Required Volume"
 msgid "Reset"
 msgstr "Reset"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr "Responsibles"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "Result in shoulder range"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Result out of range"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 
@@ -4755,16 +5008,20 @@ msgstr "Results"
 msgid "Results Interpretation"
 msgstr "Results Interpretation"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "Results have been withdrawn"
 
@@ -4772,7 +5029,7 @@ msgstr "Results have been withdrawn"
 msgid "Results interpretation"
 msgstr "Results interpretation"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "Results pending"
 
@@ -4796,7 +5053,7 @@ msgstr "Retested"
 msgid "Retract"
 msgstr "Retract"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr "Rollback"
 msgid "Routine Analyses"
 msgstr "Routine Analyses"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr "SENAITE LIMS front-page"
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr "SENAITE front-page"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "SMTP server disconnected. User creation aborted."
 
@@ -4880,7 +5142,7 @@ msgstr "Salutation"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Sample"
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "Sample ID"
 
@@ -4937,7 +5199,7 @@ msgstr "Sample Matrix"
 msgid "Sample Partitions"
 msgstr "Sample Partitions"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr "Sample Templates"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Sample Type"
@@ -5025,7 +5287,7 @@ msgstr "SampleType"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Sampler"
 
@@ -5037,8 +5299,8 @@ msgstr "Sampler for scheduled sampling"
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Samples"
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr "Samples of this type should be treated as hazardous"
 msgid "Samples rejection reporting form"
 msgstr "Samples rejection reporting form"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Sampling Date"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "Sampling Deviation"
@@ -5085,7 +5375,7 @@ msgstr "Sampling Deviations"
 msgid "Sampling Frequency"
 msgstr "Sampling Frequency"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "Sampling scheduled"
 
@@ -5093,14 +5383,23 @@ msgstr "Sampling scheduled"
 msgid "Saturday"
 msgstr "Saturday"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Save"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr "นัดหมาย"
 msgid "Schedule sampling"
 msgstr "Schedule sampling"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Scheduled sampling"
@@ -5132,6 +5431,10 @@ msgstr "Scientific name"
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Seconds"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Select template"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "Select the country the site will show by default"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Select the currency the site will use to display prices."
 
@@ -5246,11 +5549,11 @@ msgstr "Select the default container to be used for this analysis service. If th
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr "Select the types that this ID is used to identify."
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "Select this to activate the dashboard as a default front page."
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Select this to activate the sample collection workflow steps."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr "Select which Analyses should be included on the Worksheet"
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "Self-verification of results"
 
@@ -5306,11 +5617,11 @@ msgstr "Send"
 msgid "Send Analysis Reports via Email"
 msgstr "Send Analysis Reports via Email"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr "Separate Container"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr "Serial No"
 msgid "Service"
 msgstr "Service"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "Service cannot be deselected. Please click the info button for further details"
 
@@ -5374,7 +5685,7 @@ msgstr "Set the Sample Rejection workflow and the reasons"
 msgid "Set the maintenance task as closed."
 msgstr "Set the maintenance task as closed."
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr "Should the analyses be excluded from the invoice?"
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr "Site Code"
 msgid "Site Description"
 msgstr "Site Description"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "สติ๊กเกอร์ดวงเล็ก"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5508,6 +5831,14 @@ msgstr "Some analyses use out-of-date or uncalibrated instruments. Results editi
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "Sort Key"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "Specifications"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr "Start Date"
 msgid "Start date must be before End Date"
 msgstr "Start date must be before End Date"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "State"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Status"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "สตื๊กเกอร์"
@@ -5577,7 +5908,11 @@ msgstr "สตื๊กเกอร์"
 msgid "Stickers preview"
 msgstr "แสดงสตื๊กเกอร์"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "Storage Location"
@@ -5617,7 +5952,11 @@ msgstr "Submit"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "Submitted and verified by the same user: {}"
 
@@ -5625,7 +5964,7 @@ msgstr "Submitted and verified by the same user: {}"
 msgid "Submitter"
 msgstr "Submitter"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Subtotal"
@@ -5667,7 +6006,7 @@ msgstr "Switch to dashboard"
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "System default"
 
@@ -5693,7 +6032,7 @@ msgstr "Taxes"
 msgid "Technical description and instructions intended for analysts"
 msgstr "Technical description and instructions intended for analysts"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr "The date when the sample was preserved"
 msgid "The date when the sample was received"
 msgstr "The date when the sample was received"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "The decimal mark selected in Bika Setup will be used."
 
@@ -5783,7 +6122,7 @@ msgstr "The decimal mark selected in Bika Setup will be used."
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 
@@ -5811,7 +6150,11 @@ msgstr "The following partitions have been created from this Sample:"
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "The height or depth at which the sample has to be taken"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 
@@ -5904,7 +6247,7 @@ msgstr "The reference code issued to the lab by the accreditation body"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr "The sample is a mix of sub samples"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "The serial number that uniquely identifies the instrument"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "The service's analytical protocol ID"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "The service's commercial ID for accounting purposes"
 
@@ -5984,11 +6327,11 @@ msgstr "This is a Secondary Sample of"
 msgid "This is a detached partition from Sample"
 msgstr "This is a detached partition from Sample"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr "Time"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Tip. Attached documents will not be loaded unless they are present in the instance."
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Title"
@@ -6076,34 +6419,42 @@ msgstr "Title of the site"
 msgid "To"
 msgstr "To"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "To Be Preserved"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "To Be Sampled"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "To be displayed below each Analysis Category section on results reports."
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "To be preserved"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "To be printed"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "To be sampled"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "To be verified"
@@ -6116,7 +6467,7 @@ msgstr "To test the calculation, enter values here for all calculation parameter
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Total"
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr "Tuesday"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Type"
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr "Unable to load the template"
 msgid "Unassign"
 msgstr "Unassign"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Unassigned"
@@ -6215,9 +6571,13 @@ msgstr "Unknown IBAN country %s"
 msgid "Unlink User"
 msgstr "Unlink User"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
 msgstr "Unlinked User"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6233,13 +6593,17 @@ msgstr "Unrecognized file format ${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr "Unrecognized file format ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "Unsassigned"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Update Attachments"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "Use Analysis Profile Price"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "Use Dashboard as default front page"
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "User linked to this Contact"
 
@@ -6303,15 +6667,15 @@ msgstr "User linked to this Contact"
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr "VAT"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "VAT %"
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Verified"
@@ -6576,11 +6940,19 @@ msgstr "Verified"
 msgid "Verified By"
 msgstr "Verified By"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "Verify"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6594,6 +6966,14 @@ msgstr "แสดง"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "Wednesday"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "Weeks To Expire"
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,10 +7088,18 @@ msgstr "Worksheet Templates"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Worksheets"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6716,6 +7108,10 @@ msgstr ""
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Wrong IBAN length by %s: %sshort by %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr "days"
 msgid "deactivate"
 msgstr "deactivate"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr "minutes"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "monthly"
@@ -10937,13 +11396,21 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "of"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "overview"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "verification(s) pending"
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/th/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/th/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Thai (https://app.transifex.com/senaite/teams/87045/th/)\n"

--- a/src/senaite/core/locales/th_TH/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/th_TH/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Thai (Thailand) (https://app.transifex.com/senaite/teams/87045/th_TH/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/th_TH/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/th_TH/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Thai (Thailand) (https://app.transifex.com/senaite/teams/87045/th_TH/)\n"

--- a/src/senaite/core/locales/th_TH/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/th_TH/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Thai (Thailand) (https://app.transifex.com/senaite/teams/87045/th_TH/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: th_TH\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/th_TH/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/th_TH/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Thai (Thailand) (https://app.transifex.com/senaite/teams/87045/th_TH/)\n"

--- a/src/senaite/core/locales/tr/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/tr/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Turkish (https://app.transifex.com/senaite/teams/87045/tr/)\n"

--- a/src/senaite/core/locales/tr/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/tr/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Turkish (https://app.transifex.com/senaite/teams/87045/tr/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/tr/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/tr/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Turkish (https://app.transifex.com/senaite/teams/87045/tr/)\n"

--- a/src/senaite/core/locales/tr/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/tr/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Turkish (https://app.transifex.com/senaite/teams/87045/tr/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: tr\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/tr_TR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/tr_TR/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Turkish (Turkey) (https://app.transifex.com/senaite/teams/87045/tr_TR/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/tr_TR/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/tr_TR/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Turkish (Turkey) (https://app.transifex.com/senaite/teams/87045/tr_TR/)\n"

--- a/src/senaite/core/locales/tr_TR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/tr_TR/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Turkish (Turkey) (https://app.transifex.com/senaite/teams/87045/tr_TR/)\n"

--- a/src/senaite/core/locales/tr_TR/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/tr_TR/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Turkish (Turkey) (https://app.transifex.com/senaite/teams/87045/tr_TR/)\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: tr_TR\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -28,6 +28,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -53,6 +54,7 @@ msgid "%s has no '%s' column."
 msgstr "%s için '%s' kolonu bulunamadı."
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -122,6 +124,10 @@ msgstr ""
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -139,7 +145,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -197,7 +203,7 @@ msgid "Account Type"
 msgstr "Hesap Tipi"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -242,21 +248,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Etkin"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Ekle"
 
@@ -284,15 +290,19 @@ msgstr "Tekerrür Ekle"
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Tüm analizler için açıklama alanı ekle"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -305,8 +315,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -370,12 +383,20 @@ msgstr "Tüm akredite analiz hizmetleri burada listelenmiştir."
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Tüm analizler sevk edildi"
 
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
+
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -394,11 +415,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -427,14 +448,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Analizler"
 
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -504,7 +541,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -541,7 +578,7 @@ msgstr "Analist belirtilmelidir."
 msgid "Any"
 msgstr "Herhangi"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -552,6 +589,10 @@ msgstr "Uygula"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Şablonu uygula"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -565,19 +606,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Sevk Edildi"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "Sevk edildiği ID: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr ""
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -591,7 +628,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -679,11 +716,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -691,15 +732,15 @@ msgstr ""
 msgid "Autofill"
 msgstr "Otomatik tamamla"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "Otomatik oturum kapatma"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -750,7 +791,7 @@ msgstr "Toplu İş"
 msgid "Batch Book"
 msgstr "Toplu İş Kitabı"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "Toplu İş ID"
 
@@ -780,6 +821,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "Etki"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "Fatura adresi"
@@ -800,7 +845,7 @@ msgstr "Markası"
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "Toplu indirim uygulanır"
@@ -818,19 +863,19 @@ msgstr "İş Telefonu"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -838,12 +883,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "CC E-Posta"
 
@@ -899,23 +944,23 @@ msgstr "Kalibrasyonlar"
 msgid "Calibrator"
 msgstr "Kalibrasyonu yapan"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "İptal edildi"
 
@@ -935,15 +980,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -969,7 +1014,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr "Katalog Numarası"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1001,11 +1046,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1042,31 +1087,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1079,12 +1124,26 @@ msgstr "Şehir"
 msgid "Classic"
 msgstr "Klasik"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1092,7 +1151,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Müşteri"
@@ -1104,7 +1163,7 @@ msgstr "Müşteri Toplu İş ID"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "Müşteri ID"
 
@@ -1116,7 +1175,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Müşteri Siparişi"
 
@@ -1126,7 +1185,7 @@ msgstr "Müşteri Siparişi"
 msgid "Client Order Number"
 msgstr "Müşteri Sipariş Numarası"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Müşteri Referansı"
 
@@ -1135,7 +1194,7 @@ msgstr "Müşteri Referansı"
 msgid "Client Reference"
 msgstr "Müşteri Referansı"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "Müşteri SID"
 
@@ -1228,7 +1287,7 @@ msgstr "Yorumlar"
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "Ticari Kimlik"
@@ -1266,6 +1325,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1284,7 +1347,7 @@ msgstr "Şifreyi onayla"
 msgid "Considerations"
 msgstr "Dikkat Edilecek Hususlar"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Yetkili"
@@ -1328,7 +1391,7 @@ msgstr "Numune Kapları"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1361,15 +1424,15 @@ msgstr "Analiz Servislerini Kopyala"
 msgid "Copy from"
 msgstr "Şuradan kopyala"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1379,6 +1442,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1397,11 +1464,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1414,7 +1481,7 @@ msgstr "Ülke"
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1422,7 +1489,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1434,7 +1501,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1464,7 +1531,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "Oluşturan"
 
@@ -1473,7 +1540,7 @@ msgstr "Oluşturan"
 msgid "Criteria"
 msgstr "Kriter"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "Para birimi"
 
@@ -1481,12 +1548,20 @@ msgstr "Para birimi"
 msgid "Current"
 msgstr "Geçerli"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1534,23 +1609,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Açılma Tarihi"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "Muhafaza Tarihi"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Yayınlanma Tarihi"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Teslim Alma Tarihi"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1562,11 +1637,11 @@ msgstr "Talep Edilme Tarihi"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Numune Alınma Tarihi"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1608,7 +1683,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1631,11 +1706,11 @@ msgstr "Bir sonraki kalibrasyon testine kadar devre dışı bırak"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1647,7 +1722,7 @@ msgstr "Varsayılan Numune Kabı"
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1659,7 +1734,7 @@ msgstr "Varsayılan Araç"
 msgid "Default Method"
 msgstr "Varsayılan Metod"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1667,20 +1742,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "Varsayılan Muhafaza Yöntemi"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1692,7 +1767,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1724,15 +1799,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Varsayılan numune işlem periyodu"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1744,7 +1819,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1753,7 +1828,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Varsayılan değer"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1777,7 +1852,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1789,8 +1864,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Derece"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1819,9 +1903,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Bağımlı Analizler"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "Tanım"
 
@@ -1868,7 +1952,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1886,7 +1974,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Gönderildi"
@@ -1911,15 +1999,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "İstek Yapıldı"
 
@@ -1989,11 +2085,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "Beklenti"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Beklenen Tarih"
@@ -2010,7 +2110,7 @@ msgstr "Tekerrür"
 msgid "Duplicate Analysis"
 msgstr "Tekerrür Analizi"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2058,6 +2158,7 @@ msgstr "Ör: SANAS, APLAC, vb."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2072,21 +2173,21 @@ msgstr "Yükseltme"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "E-Posta"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "E-Posta Adresi"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2094,27 +2195,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2127,16 +2228,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2147,27 +2252,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2175,8 +2280,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2200,7 +2313,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr "İndirim yüzdesini girin"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2213,7 +2326,7 @@ msgstr "İndirim yüzdesini girin Ör: 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Yüzde değer giriniz ör. 14.0. Girilen değer tüm sisteme uygulanacaktır, ancak bireysel maddelerde değişiklik yapabilirsiniz."
 
@@ -2237,7 +2350,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2249,15 +2362,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2269,7 +2382,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "Faturadan hariç tut"
 
@@ -2279,7 +2392,7 @@ msgstr "Faturadan hariç tut"
 msgid "Expected Result"
 msgstr "Beklenen Sonuç"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2305,7 +2418,7 @@ msgstr "Son Kullanma Tarihi"
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2313,7 +2426,7 @@ msgstr ""
 msgid "Export"
 msgstr "Dışa aktar"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2400,7 +2513,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2414,6 +2527,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2430,11 +2555,11 @@ msgstr "Adı"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2457,13 +2582,17 @@ msgstr ""
 msgid "From"
 msgstr "Kimden"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Adı Soyadı"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2471,7 +2600,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "İleri tarihli numune"
 
@@ -2504,7 +2633,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Karşılama ünvanı örn. Bay, Bayan, Dr"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2518,7 +2647,7 @@ msgid "Hazardous"
 msgstr "Tehlikeli"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "Gizli"
@@ -2531,8 +2660,20 @@ msgstr "Gizli alan"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2556,7 +2697,7 @@ msgstr "IBN"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2564,7 +2705,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2584,15 +2725,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2600,7 +2741,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2640,7 +2781,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2671,11 +2812,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "Etkin değil"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2872,7 +3013,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2893,13 +3034,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2962,15 +3103,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2982,7 +3123,7 @@ msgstr ""
 msgid "Job title"
 msgstr "İş Ünvanı"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2994,9 +3135,9 @@ msgstr "Anahtar"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Anahtar kelime"
 
@@ -3012,6 +3153,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Anahtar kelimeler"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3056,8 +3201,8 @@ msgstr "Lab Ürünleri"
 msgid "Lab URL"
 msgstr "Lab Linki"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "Etiket"
@@ -3066,7 +3211,7 @@ msgstr "Etiket"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3074,13 +3219,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3093,7 +3238,7 @@ msgstr "Laboratuvar"
 msgid "Laboratory Accredited"
 msgstr "Akredite Laboratuvar"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3105,7 +3250,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "Geniş Etiket"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3117,11 +3262,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Geç Kalmış"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Geç Kalmış Analizler"
 
@@ -3167,15 +3312,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3199,7 +3344,7 @@ msgstr "Sertifika belgesini buraya yükle"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3226,6 +3371,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3290,7 +3443,7 @@ msgstr "Erkek"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3314,7 +3467,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3338,7 +3491,7 @@ msgstr "Yönetici E-postası"
 msgid "Manager Phone"
 msgstr "Yönetici Telefon Numarası"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3367,7 +3520,7 @@ msgstr "Üreticiller"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3382,7 +3535,7 @@ msgstr "Max Süre"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3417,15 +3570,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "Üye indirimi %"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Uygulanan üye indirimi"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3433,7 +3586,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3464,7 +3617,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3475,7 +3628,7 @@ msgstr "Min"
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3493,7 +3646,7 @@ msgstr "En az 5 karakter."
 msgid "Minimum Volume"
 msgstr "Minimum Hacim"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "QC değerlerini hesaplamak için gereken minimum sonuç sayısı."
 
@@ -3524,6 +3677,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3537,11 +3694,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3577,13 +3734,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "İsim"
 
@@ -3593,6 +3754,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3635,6 +3800,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3683,6 +3852,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3727,12 +3900,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3749,6 +3936,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3777,7 +3968,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "Hiçbiri"
 
@@ -3793,11 +3984,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3818,7 +4009,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3830,7 +4021,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3846,16 +4037,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3865,6 +4056,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3883,11 +4078,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3895,13 +4090,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Açık"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3909,8 +4104,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3938,7 +4141,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3960,11 +4163,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4061,11 +4264,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4078,6 +4281,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4097,12 +4301,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Alınma Noktası"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4141,31 +4349,31 @@ msgstr "Ondalık sayı olarak hassasiyet"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4198,7 +4406,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "Muhafaza eden"
 
@@ -4215,11 +4423,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4247,7 +4455,7 @@ msgstr "Fiyat listesi"
 msgid "Pricelists"
 msgstr "Fiyat listeleri"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4256,7 +4464,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4278,11 +4486,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr "Fiyat Listesini yazdır"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4295,7 +4503,7 @@ msgstr ""
 msgid "Priority"
 msgstr "Öncelik"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Profil"
 
@@ -4319,7 +4527,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4328,7 +4536,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4336,7 +4544,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4345,8 +4553,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Yayınlandı"
@@ -4362,6 +4574,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Yayınlanan Sonuçlar"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4382,6 +4598,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4408,7 +4632,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4420,30 +4644,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Teslim alma"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Alındı"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4494,11 +4722,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Referans örnek değerleri sıfır ya da 'kör' olan"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Kayıt"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4524,9 +4756,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4542,7 +4774,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4603,8 +4835,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4640,11 +4880,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4656,7 +4896,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "Talep eden ID"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Yeni analizler talep et"
 
@@ -4681,8 +4921,20 @@ msgstr "Gerekli Hacim"
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4690,15 +4942,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4723,15 +4976,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Sonuç aralık dışında kaldı"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4739,7 +4992,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4755,16 +5008,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4772,7 +5029,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4796,7 +5053,7 @@ msgstr "Tekrar analiz edildi"
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4832,6 +5089,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4857,6 +5118,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4866,7 +5128,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4880,7 +5142,7 @@ msgstr "Hitap"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "Numune"
 
@@ -4917,7 +5179,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "Numune ID"
 
@@ -4937,7 +5199,7 @@ msgstr "Numune Matrisi"
 msgid "Sample Partitions"
 msgstr "Numune bölümlemeleri"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4964,7 +5226,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Numune Türü"
@@ -5025,7 +5287,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "Numuneyi Alan"
 
@@ -5037,8 +5299,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Numuneler"
@@ -5055,6 +5317,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5064,7 +5338,23 @@ msgstr "Bu tip numuneler tehlikeli olarak ele alınmalıdır."
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5072,7 +5362,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "Numune Alma Tarihi"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5085,7 +5375,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr "Numune Alma Sıklığı"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5093,14 +5383,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Kaydet"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5115,7 +5414,7 @@ msgstr "Planlama"
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5132,6 +5431,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5140,7 +5443,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "Saniye"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5230,11 +5533,11 @@ msgstr ""
 msgid "Select template"
 msgstr "Şablon seç"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "Görüntülenecek döviz cinsini seçin."
 
@@ -5246,11 +5549,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5258,31 +5561,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "Numune toplama detaylı iş akışını etkinleştirmek için bu kutucuğu işaretleyin."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5294,7 +5605,7 @@ msgstr "Hangi analizlerin çalışmada yer alacağını seçin."
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5306,11 +5617,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5332,7 +5643,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5346,7 +5657,7 @@ msgstr "Seri No"
 msgid "Service"
 msgstr "Hizmet"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5374,7 +5685,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5422,28 +5733,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5466,11 +5789,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5491,7 +5814,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Küçük Etiket"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5507,6 +5830,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5533,7 +5864,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "Özellikler"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5541,7 +5872,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5558,17 +5889,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Durum"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "Durum"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Etiket"
@@ -5577,7 +5908,11 @@ msgstr "Etiket"
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5617,7 +5952,11 @@ msgstr "Gönder"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5625,7 +5964,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Aratoplam"
@@ -5667,7 +6006,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5693,7 +6032,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr "Analistlere yönelik teknik açıklama ve talimatlar"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5775,7 +6114,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5783,7 +6122,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5811,7 +6150,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5819,11 +6162,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Numune alınması gereken yükseklik veya derinlik"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5860,11 +6203,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5904,7 +6247,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5928,11 +6271,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5984,11 +6327,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6012,11 +6355,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6048,8 +6391,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Başlık"
@@ -6076,34 +6419,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "Muhafazaya Alınacak"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "Numune Alınacak"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "Doğrulanacak"
@@ -6116,7 +6467,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Toplam"
 
@@ -6138,7 +6489,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Tür"
@@ -6163,6 +6514,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6171,7 +6526,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6183,6 +6538,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sevk edilmedi."
@@ -6215,8 +6571,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6233,12 +6593,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6249,7 +6613,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6257,7 +6621,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6295,7 +6659,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6303,15 +6667,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6319,7 +6683,7 @@ msgstr "KDV"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "KDV %"
 
@@ -6566,8 +6930,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Doğrulandı"
@@ -6576,10 +6940,18 @@ msgstr "Doğrulandı"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6594,6 +6966,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6629,6 +7009,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6641,19 +7025,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6704,10 +7088,18 @@ msgstr "Çalışma Şablonları"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Çalışmalar"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6715,6 +7107,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6799,6 +7195,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6903,8 +7303,17 @@ msgstr ""
 msgid "deactivate"
 msgstr "Pasifleştir"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6969,7 +7378,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7136,46 +7545,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7187,19 +7596,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7220,16 +7629,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7254,12 +7668,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7269,7 +7683,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7372,6 +7786,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7401,6 +7828,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7547,12 +7981,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7805,7 +8239,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7813,163 +8247,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7977,47 +8411,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8026,20 +8460,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8047,32 +8481,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8080,21 +8514,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8250,6 +8684,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8562,7 +9000,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8623,7 +9061,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8739,52 +9177,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8854,12 +9292,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8869,7 +9307,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9165,7 +9603,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9290,12 +9728,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9505,7 +9943,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9515,12 +9953,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9578,6 +10016,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10754,87 +11208,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10887,6 +11341,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10937,12 +11396,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11020,6 +11487,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11254,13 +11726,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11347,6 +11824,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11592,222 +12074,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12061,7 +12543,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12104,7 +12586,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/uk_UA/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/uk_UA/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Ukrainian (Ukraine) (https://app.transifex.com/senaite/teams/87045/uk_UA/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/uk_UA/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/uk_UA/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Ukrainian (Ukraine) (https://app.transifex.com/senaite/teams/87045/uk_UA/)\n"

--- a/src/senaite/core/locales/uk_UA/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/uk_UA/LC_MESSAGES/senaite.core.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Ukrainian (Ukraine) (https://app.transifex.com/senaite/teams/87045/uk_UA/)\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: uk_UA\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -30,6 +30,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} додатків загальним розміром ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -55,6 +56,7 @@ msgid "%s has no '%s' column."
 msgstr "%s не має колонки \"%s\""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Назад"
@@ -124,6 +126,10 @@ msgstr "*** Цей e-mail генеровано автоматично, будь-
 msgid "+-"
 msgstr "+-"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -141,7 +147,7 @@ msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Перейти до н�
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" />Ласкаво просимо до SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -199,7 +205,7 @@ msgid "Account Type"
 msgstr "Тип рахунку"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -244,21 +250,21 @@ msgstr "Активувати"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "Активний"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "Діяч"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "Додати"
 
@@ -286,15 +292,19 @@ msgstr "Додати повторний"
 msgid "Add Samples"
 msgstr "Додати Зразки"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "Додати поле \"Замітки\" до всіх аналізів"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "Додати довільне CSS правило для Логотипу, наприклад height:15px; width:150px;"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "Додати вибрані за замовчуванням мітки"
 
@@ -307,8 +317,11 @@ msgstr "Додати нове вкладення"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "Додати одне або більше вкладень для опису зразка, або для уточнення вашого запросу."
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "Додати помітки"
 
@@ -372,13 +385,21 @@ msgstr "Всі акредитовані аналізи наведені тут."
 msgid "All Analyses of Service"
 msgstr "Всі аналізи служби"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "Всі аналізи призначено"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Дозволити ручне визначення межі входу"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -396,11 +417,11 @@ msgstr "Дозволити одному і тому самому користу�
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Дозволити одному і тому самому користувачу перевіряти кілька разів, але не послідовно"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "Дозволити самоперевірку результатів"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -429,15 +450,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "Проаналізовано - "
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Аналізи"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "Запитані аналізи"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -506,7 +543,7 @@ msgstr "Умови аналізів"
 msgid "Analysis conditions updated: {}"
 msgstr "Умови аналізів оновлені: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "Специфікації аналізу, які редагуються напряму в Зразку"
 
@@ -543,7 +580,7 @@ msgstr "Потрібно вказати виконавця випробуван�
 msgid "Any"
 msgstr "Будь-який"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "Вигляд"
 
@@ -554,6 +591,10 @@ msgstr "Прийняти"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Прийняти шаблон"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -567,18 +608,14 @@ msgstr "Ідентифікаційний номер"
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -593,7 +630,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -681,11 +718,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -693,15 +734,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -752,7 +793,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -782,6 +823,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -802,7 +847,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -820,19 +865,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -840,12 +885,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -901,23 +946,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -937,15 +982,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -971,7 +1016,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1003,11 +1048,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1044,31 +1089,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1081,12 +1126,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1094,7 +1153,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1106,7 +1165,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "ID клієнта"
 
@@ -1118,7 +1177,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "Замовлення клієнта"
 
@@ -1128,7 +1187,7 @@ msgstr "Замовлення клієнта"
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "Пос. клієнта"
 
@@ -1137,7 +1196,7 @@ msgstr "Пос. клієнта"
 msgid "Client Reference"
 msgstr "Посилання клієнта"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "SID клієнта"
 
@@ -1230,7 +1289,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1268,6 +1327,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1286,7 +1349,7 @@ msgstr "Підтвердіть пароль"
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Контакт"
@@ -1330,7 +1393,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1363,15 +1426,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1381,6 +1444,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1399,11 +1466,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1416,7 +1483,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1424,7 +1491,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1436,7 +1503,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1466,7 +1533,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1475,7 +1542,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1483,12 +1550,20 @@ msgstr ""
 msgid "Current"
 msgstr "Дійсний"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1536,23 +1611,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Дата відкриття"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "Дата публікації"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "Дата отримання"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1564,11 +1639,11 @@ msgstr "Дата запиту"
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "Дата взяття зразка"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1610,7 +1685,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1633,11 +1708,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1649,7 +1724,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1661,7 +1736,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1669,20 +1744,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1694,7 +1769,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1726,15 +1801,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "Стандартний період зберігання зразків"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1746,7 +1821,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1755,7 +1830,7 @@ msgstr ""
 msgid "Default value"
 msgstr "Стандартне значення"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1779,7 +1854,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1791,8 +1866,17 @@ msgstr ""
 msgid "Degrees"
 msgstr "Градуси"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1821,9 +1905,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1870,7 +1954,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1888,7 +1976,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1913,15 +2001,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1991,11 +2087,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2012,7 +2112,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2060,6 +2160,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2074,21 +2175,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2096,27 +2197,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2129,16 +2230,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2149,27 +2254,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2177,8 +2282,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2202,7 +2315,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2215,7 +2328,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2239,7 +2352,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2251,15 +2364,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2271,7 +2384,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2281,7 +2394,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2307,7 +2420,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2315,7 +2428,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2402,7 +2515,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2416,6 +2529,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2432,11 +2557,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2459,13 +2584,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2473,7 +2602,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2506,7 +2635,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2520,7 +2649,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2533,8 +2662,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2558,7 +2699,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2566,7 +2707,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2586,15 +2727,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2602,7 +2743,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2642,7 +2783,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2673,11 +2814,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2874,7 +3015,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2895,13 +3036,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2964,15 +3105,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2984,7 +3125,7 @@ msgstr ""
 msgid "Job title"
 msgstr "Заголовок роботи"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2996,9 +3137,9 @@ msgstr "Ключ"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Ключове слово"
 
@@ -3014,6 +3155,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Ключові слова"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3058,8 +3203,8 @@ msgstr "Продукти лабораторії"
 msgid "Lab URL"
 msgstr "URL лабораторії"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3068,7 +3213,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3076,13 +3221,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3095,7 +3240,7 @@ msgstr "Лабораторія"
 msgid "Laboratory Accredited"
 msgstr "Лабораторію акредитовано"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3107,7 +3252,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3119,11 +3264,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "Пізно"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "Запізнілі аналізи"
 
@@ -3169,15 +3314,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3201,7 +3346,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3228,6 +3373,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3292,7 +3445,7 @@ msgstr "Пошта"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3316,7 +3469,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3340,7 +3493,7 @@ msgstr "Електронна адреса керівника"
 msgid "Manager Phone"
 msgstr "Телефон керівника"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3369,7 +3522,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3384,7 +3537,7 @@ msgstr "Макс. час"
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3419,15 +3572,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "% членської знижки"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "Членська знижка застосовується"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3435,7 +3588,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3466,7 +3619,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3477,7 +3630,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3495,7 +3648,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Мінімальна кількість результатів для обрахування статистики СЯ"
 
@@ -3526,6 +3679,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3539,11 +3696,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3579,13 +3736,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3595,6 +3756,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3637,6 +3802,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3685,6 +3854,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3729,12 +3902,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3751,6 +3938,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3779,7 +3970,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3795,11 +3986,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3820,7 +4011,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3832,7 +4023,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3848,16 +4039,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3867,6 +4058,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3885,11 +4080,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3897,13 +4092,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3911,8 +4106,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3940,7 +4143,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3962,11 +4165,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4063,11 +4266,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4080,6 +4283,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4099,12 +4303,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4143,31 +4351,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4200,7 +4408,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4217,11 +4425,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4249,7 +4457,7 @@ msgstr "Прайс-лист для"
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4258,7 +4466,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4280,11 +4488,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4297,7 +4505,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "Профіль"
 
@@ -4321,7 +4529,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4330,7 +4538,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4338,7 +4546,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4347,8 +4555,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Опубліковано"
@@ -4363,6 +4575,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4384,6 +4600,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4410,7 +4634,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4422,30 +4646,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Отримано"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4496,11 +4724,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "Зареєструвати"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4526,9 +4758,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4544,7 +4776,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4605,8 +4837,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4642,11 +4882,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4658,7 +4898,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4667,7 +4907,7 @@ msgstr ""
 msgid "Request ID"
 msgstr "ID запиту"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "Запитати нові аналізи"
 
@@ -4683,8 +4923,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4692,15 +4944,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4725,15 +4978,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "Результат виходить за межі"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4741,7 +4994,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4757,16 +5010,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4774,7 +5031,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4798,7 +5055,7 @@ msgstr "Досліджено повторно"
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4834,6 +5091,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4859,6 +5120,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4868,7 +5130,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4882,7 +5144,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4919,7 +5181,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4939,7 +5201,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4966,7 +5228,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5027,7 +5289,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5039,8 +5301,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5057,6 +5319,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5066,7 +5340,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5074,7 +5364,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5087,7 +5377,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5095,14 +5385,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5117,7 +5416,7 @@ msgstr "Розклад"
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5134,6 +5433,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5142,7 +5445,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5232,11 +5535,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5248,11 +5551,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5260,31 +5563,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5296,7 +5607,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5308,11 +5619,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5334,7 +5645,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5348,7 +5659,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5376,7 +5687,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5424,28 +5735,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5468,11 +5791,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5493,7 +5816,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "Маленький стікер"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5509,6 +5832,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5535,7 +5866,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5543,7 +5874,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5560,17 +5891,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Стікер"
@@ -5579,7 +5910,11 @@ msgstr "Стікер"
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5619,7 +5954,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5627,7 +5966,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5669,7 +6008,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5695,7 +6034,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5777,7 +6116,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5785,7 +6124,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5813,7 +6152,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5821,11 +6164,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5862,11 +6205,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5906,7 +6249,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5930,11 +6273,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5986,11 +6329,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6014,11 +6357,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6050,8 +6393,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Заголовок"
@@ -6078,34 +6421,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "На перевірку"
@@ -6118,7 +6469,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "Всього"
 
@@ -6140,7 +6491,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Тип"
@@ -6165,6 +6516,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6173,7 +6528,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6185,6 +6540,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6217,8 +6573,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6235,12 +6595,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6251,7 +6615,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6259,7 +6623,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6297,7 +6661,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6305,15 +6669,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6321,7 +6685,7 @@ msgstr "ПДВ"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "% ПДВ"
 
@@ -6568,8 +6932,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Перевірено"
@@ -6578,10 +6942,18 @@ msgstr "Перевірено"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6596,6 +6968,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6631,6 +7011,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6643,19 +7027,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6706,10 +7090,18 @@ msgstr "Шаблони журналу"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Журнали"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6717,6 +7109,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6801,6 +7197,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6905,8 +7305,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6971,7 +7380,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7138,46 +7547,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7189,19 +7598,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7222,16 +7631,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7256,12 +7670,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7271,7 +7685,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7374,6 +7788,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7403,6 +7830,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7549,12 +7983,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7807,7 +8241,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7815,163 +8249,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7979,47 +8413,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8028,20 +8462,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8049,32 +8483,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8082,21 +8516,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8252,6 +8686,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8564,7 +9002,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8625,7 +9063,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8741,52 +9179,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8856,12 +9294,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8871,7 +9309,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9167,7 +9605,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9292,12 +9730,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9507,7 +9945,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9517,12 +9955,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9580,6 +10018,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10756,87 +11210,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10889,6 +11343,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10939,12 +11398,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11022,6 +11489,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11256,13 +11728,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11349,6 +11826,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11594,222 +12076,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12063,7 +12545,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12106,7 +12588,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/uk_UA/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/uk_UA/LC_MESSAGES/senaite.core.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Ukrainian (Ukraine) (https://app.transifex.com/senaite/teams/87045/uk_UA/)\n"

--- a/src/senaite/core/locales/ur/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ur/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Urdu (https://app.transifex.com/senaite/teams/87045/ur/)\n"

--- a/src/senaite/core/locales/ur/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ur/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Urdu (https://app.transifex.com/senaite/teams/87045/ur/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/ur/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ur/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Urdu (https://app.transifex.com/senaite/teams/87045/ur/)\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: ur\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -27,6 +27,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -52,6 +53,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -121,6 +123,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -138,7 +144,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -196,7 +202,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -241,21 +247,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -283,15 +289,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -304,8 +314,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -369,12 +382,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -393,11 +414,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -426,14 +447,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -503,7 +540,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -540,7 +577,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -550,6 +587,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -564,18 +605,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -590,7 +627,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -678,11 +715,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -690,15 +731,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -749,7 +790,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -779,6 +820,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -799,7 +844,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -817,19 +862,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -837,12 +882,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -898,23 +943,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -934,15 +979,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -968,7 +1013,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -1000,11 +1045,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1041,31 +1086,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1078,12 +1123,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1091,7 +1150,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1103,7 +1162,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1115,7 +1174,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1125,7 +1184,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1134,7 +1193,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1227,7 +1286,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1265,6 +1324,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1283,7 +1346,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1327,7 +1390,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1360,15 +1423,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1378,6 +1441,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1396,11 +1463,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1413,7 +1480,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1421,7 +1488,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1433,7 +1500,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1463,7 +1530,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1472,7 +1539,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1480,12 +1547,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1533,23 +1608,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1561,11 +1636,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1607,7 +1682,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1630,11 +1705,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1646,7 +1721,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1658,7 +1733,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1666,20 +1741,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1691,7 +1766,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1723,15 +1798,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1743,7 +1818,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1752,7 +1827,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1776,7 +1851,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1788,8 +1863,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1818,9 +1902,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1867,7 +1951,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1885,7 +1973,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1910,15 +1998,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1988,11 +2084,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2009,7 +2109,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2057,6 +2157,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2071,21 +2172,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2093,27 +2194,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2126,16 +2227,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2146,27 +2251,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2174,8 +2279,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2199,7 +2312,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2212,7 +2325,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2236,7 +2349,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2248,15 +2361,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2268,7 +2381,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2278,7 +2391,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr "مطلوبہ نتیجہ"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2304,7 +2417,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2312,7 +2425,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2399,7 +2512,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2413,6 +2526,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2429,11 +2554,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2456,13 +2581,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2470,7 +2599,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2503,7 +2632,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2517,7 +2646,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2530,8 +2659,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2555,7 +2696,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2563,7 +2704,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2583,15 +2724,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2599,7 +2740,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2639,7 +2780,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2670,11 +2811,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2871,7 +3012,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2892,13 +3033,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2961,15 +3102,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2981,7 +3122,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2993,9 +3134,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3010,6 +3151,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3055,8 +3200,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3065,7 +3210,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3073,13 +3218,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3092,7 +3237,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3104,7 +3249,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3116,11 +3261,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3166,15 +3311,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3198,7 +3343,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3225,6 +3370,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3289,7 +3442,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3313,7 +3466,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3337,7 +3490,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3366,7 +3519,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3381,7 +3534,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3416,15 +3569,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3432,7 +3585,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3463,7 +3616,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3474,7 +3627,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3492,7 +3645,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3523,6 +3676,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3536,11 +3693,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3576,13 +3733,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3592,6 +3753,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3634,6 +3799,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3682,6 +3851,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3726,12 +3899,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3748,6 +3935,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3776,7 +3967,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3792,11 +3983,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3817,7 +4008,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3829,7 +4020,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3845,16 +4036,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3864,6 +4055,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3882,11 +4077,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3894,13 +4089,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3908,8 +4103,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3937,7 +4140,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3959,11 +4162,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4060,11 +4263,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4077,6 +4280,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4096,12 +4300,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4140,31 +4348,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4197,7 +4405,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4214,11 +4422,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4246,7 +4454,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4255,7 +4463,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4277,11 +4485,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4294,7 +4502,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4318,7 +4526,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4327,7 +4535,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4335,7 +4543,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4344,8 +4552,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4360,6 +4572,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4381,6 +4597,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4407,7 +4631,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4419,30 +4643,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4493,11 +4721,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4523,9 +4755,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4541,7 +4773,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4602,8 +4834,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4639,11 +4879,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4655,7 +4895,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4664,7 +4904,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4680,8 +4920,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4689,15 +4941,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4722,15 +4975,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4738,7 +4991,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4754,16 +5007,20 @@ msgstr "نتائج"
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4771,7 +5028,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4795,7 +5052,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4831,6 +5088,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4856,6 +5117,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4865,7 +5127,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4879,7 +5141,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4916,7 +5178,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4936,7 +5198,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4963,7 +5225,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5024,7 +5286,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5036,8 +5298,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5054,6 +5316,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5063,7 +5337,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5071,7 +5361,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5084,7 +5374,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5092,14 +5382,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5114,7 +5413,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5131,6 +5430,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5139,7 +5442,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5229,11 +5532,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5245,11 +5548,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5257,31 +5560,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5293,7 +5604,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5305,11 +5616,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5331,7 +5642,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5345,7 +5656,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5373,7 +5684,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5421,28 +5732,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5465,11 +5788,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5490,7 +5813,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5506,6 +5829,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5532,7 +5863,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5540,7 +5871,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5557,17 +5888,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5576,7 +5907,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5616,7 +5951,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5624,7 +5963,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5666,7 +6005,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5692,7 +6031,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5774,7 +6113,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5782,7 +6121,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5810,7 +6149,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5818,11 +6161,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5859,11 +6202,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5903,7 +6246,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5927,11 +6270,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5983,11 +6326,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6011,11 +6354,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6047,8 +6390,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6075,34 +6418,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6115,7 +6466,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6137,7 +6488,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6162,6 +6513,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6170,7 +6525,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6182,6 +6537,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6214,8 +6570,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6232,12 +6592,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6248,7 +6612,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6256,7 +6620,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6294,7 +6658,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6302,15 +6666,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6318,7 +6682,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6565,8 +6929,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6575,10 +6939,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6593,6 +6965,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6628,6 +7008,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6640,19 +7024,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6703,9 +7087,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6714,6 +7106,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6798,6 +7194,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6902,8 +7302,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6968,7 +7377,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7135,46 +7544,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7186,19 +7595,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7219,16 +7628,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7253,12 +7667,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7268,7 +7682,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7371,6 +7785,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7400,6 +7827,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7546,12 +7980,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7804,7 +8238,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7812,163 +8246,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7976,47 +8410,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8025,20 +8459,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8046,32 +8480,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8079,21 +8513,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8249,6 +8683,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8561,7 +8999,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8622,7 +9060,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8738,52 +9176,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8853,12 +9291,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8868,7 +9306,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9164,7 +9602,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9289,12 +9727,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9504,7 +9942,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9514,12 +9952,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9577,6 +10015,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10753,87 +11207,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10886,6 +11340,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10936,12 +11395,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11019,6 +11486,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11253,13 +11725,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11346,6 +11823,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11591,222 +12073,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12060,7 +12542,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12103,7 +12585,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/ur/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ur/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2025\n"
 "Language-Team: Urdu (https://app.transifex.com/senaite/teams/87045/ur/)\n"

--- a/src/senaite/core/locales/vi/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/vi/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Vietnamese (https://app.transifex.com/senaite/teams/87045/vi/)\n"

--- a/src/senaite/core/locales/vi/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/vi/LC_MESSAGES/plone.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Vietnamese (https://app.transifex.com/senaite/teams/87045/vi/)\n"
@@ -901,6 +901,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/vi/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/vi/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Vietnamese (https://app.transifex.com/senaite/teams/87045/vi/)\n"

--- a/src/senaite/core/locales/vi/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/vi/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Vietnamese (https://app.transifex.com/senaite/teams/87045/vi/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: vi\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -25,6 +25,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -50,6 +51,7 @@ msgid "%s has no '%s' column."
 msgstr ""
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr ""
@@ -119,6 +121,10 @@ msgstr ""
 msgid "+-"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -136,7 +142,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -194,7 +200,7 @@ msgid "Account Type"
 msgstr ""
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -239,21 +245,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr ""
 
@@ -281,15 +287,19 @@ msgstr ""
 msgid "Add Samples"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr ""
 
@@ -302,8 +312,11 @@ msgstr ""
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr ""
 
@@ -367,12 +380,20 @@ msgstr ""
 msgid "All Analyses of Service"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
+msgstr ""
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
@@ -391,11 +412,11 @@ msgstr ""
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -424,14 +445,30 @@ msgstr ""
 msgid "Analysed by"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
@@ -501,7 +538,7 @@ msgstr ""
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr ""
 
@@ -538,7 +575,7 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -548,6 +585,10 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
 msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
@@ -562,18 +603,14 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
 msgstr ""
 
 #: bika/lims/validators.py:465
@@ -588,7 +625,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -676,11 +713,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr ""
 
@@ -688,15 +729,15 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -747,7 +788,7 @@ msgstr ""
 msgid "Batch Book"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr ""
 
@@ -777,6 +818,10 @@ msgstr ""
 msgid "Bearing"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr ""
@@ -797,7 +842,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr ""
@@ -815,19 +860,19 @@ msgstr ""
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -835,12 +880,12 @@ msgstr ""
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr ""
 
@@ -896,23 +941,23 @@ msgstr ""
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr ""
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr ""
 
@@ -932,15 +977,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr ""
 
@@ -966,7 +1011,7 @@ msgstr ""
 msgid "Catalogue Number"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr ""
 
@@ -998,11 +1043,11 @@ msgid "Changes Saved"
 msgstr ""
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr ""
 
@@ -1039,31 +1084,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1076,12 +1121,26 @@ msgstr ""
 msgid "Classic"
 msgstr ""
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1089,7 +1148,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr ""
@@ -1101,7 +1160,7 @@ msgstr ""
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr ""
 
@@ -1113,7 +1172,7 @@ msgstr ""
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr ""
 
@@ -1123,7 +1182,7 @@ msgstr ""
 msgid "Client Order Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr ""
 
@@ -1132,7 +1191,7 @@ msgstr ""
 msgid "Client Reference"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr ""
 
@@ -1225,7 +1284,7 @@ msgstr ""
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr ""
@@ -1263,6 +1322,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr ""
@@ -1281,7 +1344,7 @@ msgstr ""
 msgid "Considerations"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr ""
@@ -1325,7 +1388,7 @@ msgstr ""
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1358,15 +1421,15 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr ""
 
@@ -1376,6 +1439,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1394,11 +1461,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1411,7 +1478,7 @@ msgstr ""
 msgid "Create Invoice PDF"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr ""
 
@@ -1419,7 +1486,7 @@ msgstr ""
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1431,7 +1498,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1461,7 +1528,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr ""
 
@@ -1470,7 +1537,7 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr ""
 
@@ -1478,12 +1545,20 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1531,23 +1606,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr ""
 
@@ -1559,11 +1634,11 @@ msgstr ""
 msgid "Date Sample Received"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1680,7 @@ msgstr ""
 msgid "Date when the certificate is valid"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1628,11 +1703,11 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1644,7 +1719,7 @@ msgstr ""
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr ""
 msgid "Default Method"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1664,20 +1739,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1689,7 +1764,7 @@ msgstr ""
 msgid "Default large sticker"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr ""
 
@@ -1721,15 +1796,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr ""
 
@@ -1741,7 +1816,7 @@ msgstr ""
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1750,7 +1825,7 @@ msgstr ""
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1774,7 +1849,7 @@ msgstr ""
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1786,8 +1861,17 @@ msgstr ""
 msgid "Degrees"
 msgstr ""
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1816,9 +1900,9 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr ""
 
@@ -1865,7 +1949,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1883,7 +1971,7 @@ msgstr ""
 msgid "Dispatch samples"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
@@ -1908,15 +1996,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
 
@@ -1986,11 +2082,15 @@ msgstr ""
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr ""
@@ -2007,7 +2107,7 @@ msgstr ""
 msgid "Duplicate Analysis"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2055,6 +2155,7 @@ msgstr ""
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr ""
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr ""
@@ -2069,21 +2170,21 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2091,27 +2192,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2124,16 +2225,20 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
+msgstr ""
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
 msgstr ""
 
 #: bika/lims/validators.py:456
@@ -2144,27 +2249,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr ""
 
@@ -2172,8 +2277,16 @@ msgstr ""
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
 msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
@@ -2197,7 +2310,7 @@ msgstr ""
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2210,7 +2323,7 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
@@ -2234,7 +2347,7 @@ msgstr ""
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2246,15 +2359,15 @@ msgstr ""
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2266,7 +2379,7 @@ msgstr ""
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr ""
 
@@ -2276,7 +2389,7 @@ msgstr ""
 msgid "Expected Result"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2302,7 +2415,7 @@ msgstr ""
 msgid "Exponential format precision"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr ""
 
@@ -2310,7 +2423,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2397,7 +2510,7 @@ msgstr ""
 msgid "Filesize"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2411,6 +2524,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2427,11 +2552,11 @@ msgstr ""
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2454,13 +2579,17 @@ msgstr ""
 msgid "From"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr ""
 
@@ -2468,7 +2597,7 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr ""
 
@@ -2501,7 +2630,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr ""
 
@@ -2515,7 +2644,7 @@ msgid "Hazardous"
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr ""
@@ -2528,8 +2657,20 @@ msgstr ""
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2553,7 +2694,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2561,7 +2702,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2581,15 +2722,15 @@ msgstr ""
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2597,7 +2738,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
 
@@ -2637,7 +2778,7 @@ msgstr ""
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2668,11 +2809,11 @@ msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr ""
 
@@ -2869,7 +3010,7 @@ msgid "Internal Certificate"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr ""
 
@@ -2890,13 +3031,13 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2959,15 +3100,15 @@ msgstr ""
 msgid "Invoice {} created"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
@@ -2979,7 +3120,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2991,9 +3132,9 @@ msgstr ""
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr ""
 
@@ -3008,6 +3149,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
@@ -3053,8 +3198,8 @@ msgstr ""
 msgid "Lab URL"
 msgstr ""
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr ""
@@ -3063,7 +3208,7 @@ msgstr ""
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3071,13 +3216,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr ""
 
@@ -3090,7 +3235,7 @@ msgstr ""
 msgid "Laboratory Accredited"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3102,7 +3247,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3114,11 +3259,11 @@ msgstr ""
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr ""
 
@@ -3164,15 +3309,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3196,7 +3341,7 @@ msgstr ""
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3223,6 +3368,14 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
@@ -3287,7 +3440,7 @@ msgstr ""
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3311,7 +3464,7 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3335,7 +3488,7 @@ msgstr ""
 msgid "Manager Phone"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr ""
 
@@ -3364,7 +3517,7 @@ msgstr ""
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3379,7 +3532,7 @@ msgstr ""
 msgid "Max operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3414,15 +3567,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3430,7 +3583,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3461,7 +3614,7 @@ msgstr ""
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3472,7 +3625,7 @@ msgstr ""
 msgid "Min operator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3490,7 +3643,7 @@ msgstr ""
 msgid "Minimum Volume"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
@@ -3521,6 +3674,10 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3534,11 +3691,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3574,13 +3731,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr ""
 
@@ -3590,6 +3751,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3632,6 +3797,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3680,6 +3849,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3724,12 +3897,26 @@ msgstr ""
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr ""
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3746,6 +3933,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3774,7 +3965,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr ""
 
@@ -3790,11 +3981,11 @@ msgstr ""
 msgid "Not defined"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3815,7 +4006,7 @@ msgstr ""
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3827,7 +4018,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr ""
 
@@ -3843,16 +4034,16 @@ msgstr ""
 msgid "Number of prominent columns"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -3862,6 +4053,10 @@ msgstr ""
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3880,11 +4075,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3892,13 +4087,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3906,8 +4101,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3935,7 +4138,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3957,11 +4160,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4058,11 +4261,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4075,6 +4278,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr ""
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4094,12 +4298,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4138,31 +4346,31 @@ msgstr ""
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4195,7 +4403,7 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr ""
 
@@ -4212,11 +4420,11 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4244,7 +4452,7 @@ msgstr ""
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4253,7 +4461,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4275,11 +4483,11 @@ msgstr ""
 msgid "Print pricelist"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr ""
 
@@ -4292,7 +4500,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr ""
 
@@ -4316,7 +4524,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr ""
 
@@ -4325,7 +4533,7 @@ msgstr ""
 msgid "Prominent fields"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr ""
 
@@ -4333,7 +4541,7 @@ msgstr ""
 msgid "Province"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4342,8 +4550,12 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr ""
@@ -4358,6 +4570,10 @@ msgstr ""
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
@@ -4379,6 +4595,14 @@ msgstr ""
 #: bika/lims/browser/analyses/qc.py:55
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
@@ -4405,7 +4629,7 @@ msgstr ""
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr ""
 
@@ -4417,30 +4641,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr ""
 
@@ -4491,11 +4719,15 @@ msgstr ""
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4521,9 +4753,9 @@ msgstr ""
 msgid "Reject samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr ""
 
@@ -4539,7 +4771,7 @@ msgstr ""
 msgid "Rejected {} samples: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4600,8 +4832,16 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4637,11 +4877,11 @@ msgstr ""
 msgid "Report identification number"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4653,7 +4893,7 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr ""
 
@@ -4662,7 +4902,7 @@ msgstr ""
 msgid "Request ID"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr ""
 
@@ -4678,8 +4918,20 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4687,15 +4939,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr ""
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4720,15 +4973,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr ""
 
@@ -4736,7 +4989,7 @@ msgstr ""
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
@@ -4752,16 +5005,20 @@ msgstr ""
 msgid "Results Interpretation"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4769,7 +5026,7 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr ""
 
@@ -4793,7 +5050,7 @@ msgstr ""
 msgid "Retract"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4829,6 +5086,10 @@ msgstr ""
 msgid "Routine Analyses"
 msgstr ""
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4854,6 +5115,7 @@ msgstr ""
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4863,7 +5125,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
@@ -4877,7 +5139,7 @@ msgstr ""
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr ""
 
@@ -4914,7 +5176,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr ""
 
@@ -4934,7 +5196,7 @@ msgstr ""
 msgid "Sample Partitions"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4961,7 +5223,7 @@ msgid "Sample Templates"
 msgstr ""
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr ""
@@ -5022,7 +5284,7 @@ msgstr ""
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr ""
 
@@ -5034,8 +5296,8 @@ msgstr ""
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr ""
@@ -5052,6 +5314,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5061,7 +5335,23 @@ msgstr ""
 msgid "Samples rejection reporting form"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5069,7 +5359,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr ""
@@ -5082,7 +5372,7 @@ msgstr ""
 msgid "Sampling Frequency"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr ""
 
@@ -5090,14 +5380,23 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
 msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
@@ -5112,7 +5411,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5129,6 +5428,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5137,7 +5440,7 @@ msgstr ""
 msgid "Seconds"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5227,11 +5530,11 @@ msgstr ""
 msgid "Select template"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
@@ -5243,11 +5546,11 @@ msgstr ""
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5255,31 +5558,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr ""
 
@@ -5291,7 +5602,7 @@ msgstr ""
 msgid "Selection list"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr ""
 
@@ -5303,11 +5614,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5329,7 +5640,7 @@ msgstr ""
 msgid "Separate Container"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5343,7 +5654,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5371,7 +5682,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5419,28 +5730,40 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
 msgstr ""
 
 #: bika/lims/content/labcontact.py:46
@@ -5463,11 +5786,11 @@ msgstr ""
 msgid "Site Description"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5488,7 +5811,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5504,6 +5827,14 @@ msgstr ""
 #: bika/lims/content/analysiscategory.py:82
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
 msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
@@ -5530,7 +5861,7 @@ msgstr ""
 msgid "Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5555,17 +5886,17 @@ msgstr ""
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr ""
@@ -5574,7 +5905,11 @@ msgstr ""
 msgid "Stickers preview"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr ""
@@ -5614,7 +5949,11 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr ""
 
@@ -5622,7 +5961,7 @@ msgstr ""
 msgid "Submitter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr ""
@@ -5664,7 +6003,7 @@ msgstr ""
 msgid "Switch to transposed view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr ""
 
@@ -5690,7 +6029,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5772,7 +6111,7 @@ msgstr ""
 msgid "The date when the sample was received"
 msgstr ""
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
@@ -5780,7 +6119,7 @@ msgstr ""
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr ""
 
@@ -5808,7 +6147,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr ""
 
@@ -5816,11 +6159,11 @@ msgstr ""
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5857,11 +6200,11 @@ msgstr ""
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr ""
 
@@ -5901,7 +6244,7 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5925,11 +6268,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5981,11 +6324,11 @@ msgstr ""
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6009,11 +6352,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6045,8 +6388,8 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr ""
@@ -6073,34 +6416,42 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
 msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr ""
@@ -6113,7 +6464,7 @@ msgstr ""
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr ""
 
@@ -6135,7 +6486,7 @@ msgid "Tuesday"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr ""
@@ -6160,6 +6511,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6168,7 +6523,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6180,6 +6535,7 @@ msgstr ""
 msgid "Unassign"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
@@ -6212,8 +6568,12 @@ msgstr ""
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6230,12 +6590,16 @@ msgstr ""
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
 msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
@@ -6246,7 +6610,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr ""
 
@@ -6292,7 +6656,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6300,15 +6664,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6316,7 +6680,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr ""
 
@@ -6563,8 +6927,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr ""
@@ -6573,10 +6937,18 @@ msgstr ""
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
 msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
@@ -6591,6 +6963,14 @@ msgstr ""
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
 msgstr ""
 
 #: senaite/core/registry/schema.py:213
@@ -6626,6 +7006,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr ""
@@ -6638,19 +7022,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6701,9 +7085,17 @@ msgstr ""
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
 msgstr ""
 
 #: senaite/core/content/supplier.py:166
@@ -6712,6 +7104,10 @@ msgstr ""
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
@@ -6796,6 +7192,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6900,8 +7300,17 @@ msgstr ""
 msgid "deactivate"
 msgstr ""
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6966,7 +7375,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7133,46 +7542,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7184,19 +7593,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7217,16 +7626,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7251,12 +7665,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7266,7 +7680,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7369,6 +7783,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7398,6 +7825,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7544,12 +7978,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7802,7 +8236,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7810,163 +8244,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7974,47 +8408,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8023,20 +8457,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8044,32 +8478,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8077,21 +8511,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8247,6 +8681,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8559,7 +8997,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8620,7 +9058,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8736,52 +9174,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8851,12 +9289,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8866,7 +9304,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9162,7 +9600,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9287,12 +9725,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9502,7 +9940,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9512,12 +9950,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9575,6 +10013,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10751,87 +11205,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10884,6 +11338,11 @@ msgstr ""
 msgid "minutes"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr ""
@@ -10934,12 +11393,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11017,6 +11484,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11251,13 +11723,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11344,6 +11821,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11589,222 +12071,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12058,7 +12540,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12101,7 +12583,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 

--- a/src/senaite/core/locales/zh/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/zh/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: erikking, 2023\n"
 "Language-Team: Chinese (https://app.transifex.com/senaite/teams/87045/zh/)\n"
@@ -903,6 +903,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/zh/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/zh/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: erikking, 2023\n"
 "Language-Team: Chinese (https://app.transifex.com/senaite/teams/87045/zh/)\n"

--- a/src/senaite/core/locales/zh/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/zh/LC_MESSAGES/senaite.core.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Chinese (https://app.transifex.com/senaite/teams/87045/zh/)\n"

--- a/src/senaite/core/locales/zh/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/zh/LC_MESSAGES/senaite.core.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Chinese (https://app.transifex.com/senaite/teams/87045/zh/)\n"
@@ -22,7 +22,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: zh\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr " <p>ID服务器基于每种内容类型指定的格式，为样品和工作表等对象提供唯一的顺序Id。</p><p>该格式的构造类似于Python格式语法，使用每个内容类型的预定义变量，并通过序列号，'seq'及其填充作为数字推进Id，例如从001到999的Id序列的'03d'。</p><p>Id的字母数字前缀按格式包含，例如 WS-{seq:03d}中的工作表的WS生成顺序工作表Id：WS-001、WS-002、WS-003等。</p><p>对于字母数字和顺序Id的动态生成，可以使用通配符{alpha}。 例如WS-{alpha:2a3d}生产WS-AA001、WS-AA002、WS-AB034, 等。</p><p>可以使用的变量包括：<table><tr><th style='width:150px'>内容类型</th><th>变量</th></tr><tr><td>客户ID</td><td>{clientId}</td></tr><tr><td>年</td><td>{year}</td></tr><tr><td>样品ID</td><td>{sampleId}</td></tr><tr><td>样品类型</td><td>{sampletype}</td></tr><tr><td>采样日期</td><td>{samplingdate}</td></tr><tr><td>抽样日期</td><td>{datesampled}</Td></tr></table></p><p>配置设置：<ul><li>格式：<ul><li>从预定义变量，如样品id，客户id, 样品类型等构建的python格式字符串。</li><li>特殊变量'seq'必须在格式字符串中最后定位</li></ul></li><li>序列类型：[生成|计数器]</li><li>上下文：如果类型计数器，提供上下文计数函数</li><li>计数器类型：[backreference|contained]</li><li>计数器引用：计数函数的参数</li><li>前缀：如果格式字符串中没有提供，则默认前缀</li><li>分割长度：部件数量要包括在前缀里</li></ul></p>"
 
@@ -31,6 +31,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} 附件总大小为 ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link}"
@@ -56,6 +57,7 @@ msgid "%s has no '%s' column."
 msgstr "%s 没有 '%s' 列。"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; 返回"
@@ -125,6 +127,10 @@ msgstr "*** 这是一封自动生成的电子邮件，请不要回复此邮件�
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -142,7 +148,7 @@ msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> 转到工作表模板�
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> 欢迎来到SENAITE LIMS"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -200,7 +206,7 @@ msgid "Account Type"
 msgstr "帐户类型"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -245,21 +251,21 @@ msgstr "启用"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "正在进行"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "角色"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "添加"
 
@@ -287,15 +293,19 @@ msgstr "添加重复样"
 msgid "Add Samples"
 msgstr "添加样本"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "添加备注字段到所有检验项目"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "为Logo添加自定义的CSS规则，例如，高度：15px；宽度：150px"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "添加默认可选标签"
 
@@ -308,8 +318,11 @@ msgstr "添加新附件"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "添加一个或多个附件以描述此示例中的样本，或指定您的请检要求。"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "添加备注"
 
@@ -373,13 +386,21 @@ msgstr "所有已认证的分析服务均列于此."
 msgid "All Analyses of Service"
 msgstr "所有检验项目服务"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "所有检验项目已分派"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "允许手动输入检测极限值"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -397,11 +418,11 @@ msgstr "允许同一个用户进行多次复核"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "允许同一个用户进行多次非连续复核"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "允许对结果进行自我复核"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -430,15 +451,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "检验人员"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "检验项目"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "项目已请检"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -507,7 +544,7 @@ msgstr "检验条件"
 msgid "Analysis conditions updated: {}"
 msgstr "检验条件已更新: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "直接在样本上编辑的检验标准。"
 
@@ -544,7 +581,7 @@ msgstr "必须指定检验人员。"
 msgid "Any"
 msgstr "任何"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "外观"
 
@@ -555,6 +592,10 @@ msgstr "应用"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "应用模板"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -568,19 +609,15 @@ msgstr "资产编号"
 msgid "Assign"
 msgstr "分派"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "已分派"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "分派到: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "等待分配"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -594,7 +631,7 @@ msgstr "附加到样本"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr "附加标签"
 
@@ -682,11 +719,15 @@ msgstr "灵活内容自动生成ID"
 msgid "Auto-Import Logs"
 msgstr "自动导入日志"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "接收时自动分装样本"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "自动接收样本"
 
@@ -694,15 +735,15 @@ msgstr "自动接收样本"
 msgid "Autofill"
 msgstr "自动填充"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "自动注销"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr "自动验证样本"
 
@@ -753,7 +794,7 @@ msgstr "批次"
 msgid "Batch Book"
 msgstr "批处理簿"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "批次编号"
 
@@ -783,6 +824,10 @@ msgstr "请注意，电子表格文件中提供的动态规格范围可能会覆
 msgid "Bearing"
 msgstr "持有"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "账单地址"
@@ -803,7 +848,7 @@ msgstr "品牌"
 msgid "Bulk Discount"
 msgstr "批量折扣"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "已使用大宗折扣"
@@ -821,19 +866,19 @@ msgstr "办公电话"
 msgid "Business address"
 msgstr "业务地址"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr "按“显示值”升序"
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr "按“显示值”降序"
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr "按“结果值”升序"
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr "按“结果值”降序"
 
@@ -841,12 +886,12 @@ msgstr "按“结果值”降序"
 msgid "CBID"
 msgstr ""
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "抄送多个邮件"
 
@@ -902,23 +947,23 @@ msgstr "校准"
 msgid "Calibrator"
 msgstr "校准物质"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "可以复核，但由当前用户提交"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "可以复核，但已经由当前用户复核"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "撤回"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "已取消"
 
@@ -938,15 +983,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr "不能为${sample_id}发送邮件：${error}"
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "无法复核，当前用户已最后复核"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "无法复核，当前用户已提交过"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "无法复核，已被当前用户复核"
 
@@ -972,7 +1017,7 @@ msgstr "将灵活性内容归类到多目录"
 msgid "Catalogue Number"
 msgstr "类别号码"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "检验项目归类"
 
@@ -1004,11 +1049,11 @@ msgid "Changes Saved"
 msgstr "已保存更改"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "已保存更改。"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "变更会应用于分装样本"
 
@@ -1045,31 +1090,31 @@ msgstr "勾选框"
 msgid "Choices"
 msgstr "选项"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "为同一用户选择多重复核的类型。此设置可以为同一用户启用/禁用多次复核/连续复核。"
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1082,20 +1127,34 @@ msgstr "城市"
 msgid "Classic"
 msgstr "典型的"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "取消选定"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "单击以展开此类别"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "单击以切换可见性或拖放以更改顺序"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "客户"
@@ -1107,7 +1166,7 @@ msgstr "客户批次编号"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "客户编号"
 
@@ -1119,7 +1178,7 @@ msgstr "客户登录页面"
 msgid "Client Name"
 msgstr "客户名"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "客户订单"
 
@@ -1129,7 +1188,7 @@ msgstr "客户订单"
 msgid "Client Order Number"
 msgstr "客户订单号"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "客户参阅"
 
@@ -1138,7 +1197,7 @@ msgstr "客户参阅"
 msgid "Client Reference"
 msgstr "客户参阅"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "客户样品编号"
 
@@ -1231,7 +1290,7 @@ msgstr "备注"
 msgid "Comments or results interpretation"
 msgstr "评论或结果解读"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "商品ID"
@@ -1269,6 +1328,10 @@ msgstr "样本信息字段配置"
 msgid "Configuration restored to default values."
 msgstr "配置恢复为默认值"
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr "配置表列"
@@ -1287,7 +1350,7 @@ msgstr "确认密码"
 msgid "Considerations"
 msgstr "考虑"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "联系方式"
@@ -1331,7 +1394,7 @@ msgstr "容器"
 msgid "Contents of the file {}"
 msgstr "文件内容 {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1364,15 +1427,15 @@ msgstr "复制检验项目"
 msgid "Copy from"
 msgstr "拷贝自"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "复制到新的"
 
@@ -1382,6 +1445,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1400,11 +1467,11 @@ msgstr "无法将样本转换为已采样状态"
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1417,7 +1484,7 @@ msgstr "国家"
 msgid "Create Invoice PDF"
 msgstr "创建PDF票据"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "样本分装"
 
@@ -1425,7 +1492,7 @@ msgstr "样本分装"
 msgid "Create SENAITE Site"
 msgstr "创建新的站点"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr "创建工作表"
 
@@ -1437,7 +1504,7 @@ msgstr "创建新的站点"
 msgid "Create a new User"
 msgstr "创建新用户"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr "为所选样本创建新工作表"
 
@@ -1467,7 +1534,7 @@ msgid "Created {} partitions: {}"
 msgstr "创建了{}分装: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "创建者"
 
@@ -1476,7 +1543,7 @@ msgstr "创建者"
 msgid "Criteria"
 msgstr "标准"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "现金"
 
@@ -1484,13 +1551,21 @@ msgstr "现金"
 msgid "Current"
 msgstr "当前"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "自定义小数点标记"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "报告限"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1537,23 +1612,23 @@ msgstr "修改日期"
 msgid "Date Opened"
 msgstr "建立日期"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "保存时间"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "打印日期"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "发布日期"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "接收日期"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "登记日期"
 
@@ -1565,11 +1640,11 @@ msgstr "请求日期"
 msgid "Date Sample Received"
 msgstr "样品接收日期"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "采样日期"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "复核日期"
 
@@ -1611,7 +1686,7 @@ msgstr "校准证书被授予的日期"
 msgid "Date when the certificate is valid"
 msgstr "证书有效期至"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1634,11 +1709,11 @@ msgstr "停用至下次校准测试"
 msgid "Deactivate"
 msgstr "停用"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "客户报告中使用的小数点标记。"
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1650,7 +1725,7 @@ msgstr "默认容器"
 msgid "Default Department"
 msgstr "默认部门"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "为当前客户的所有已发布样本设置报告抄送邮件为默认邮箱"
 
@@ -1662,7 +1737,7 @@ msgstr "默认仪器"
 msgid "Default Method"
 msgstr "默认方法"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1670,20 +1745,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "默认保存方式"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "要添加的样本的默认数量。"
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "默认小数点标记"
 
@@ -1695,7 +1770,7 @@ msgstr "用于此类型检验的默认仪器"
 msgid "Default large sticker"
 msgstr "默认大标签"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "工作表视图默认布局"
 
@@ -1727,15 +1802,15 @@ msgstr "默认结果必须是以下结果选项之一：{}"
 msgid "Default result to display on result entry"
 msgstr "在结果输入时显示的默认结果"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "默认样品保留周期"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "在报告中默认使用科学计数法格式"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "在报告中默认使用科学计数法格式"
 
@@ -1747,7 +1822,7 @@ msgstr "默认小标签"
 msgid "Default timezone"
 msgstr "默认时区"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "默认检验周期。"
 
@@ -1756,7 +1831,7 @@ msgstr "默认检验周期。"
 msgid "Default value"
 msgstr "默认价值"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "当用户单击“添加”按钮创建新样本时，“样本数量”的默认值"
 
@@ -1780,7 +1855,7 @@ msgstr "定义将值转换为指数值表示时的精度。默认值是7。"
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "定义应该在预定日期进行采样的采样人"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1792,8 +1867,17 @@ msgstr "定义用于此样本类型的标签。"
 msgid "Degrees"
 msgstr "度"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1822,9 +1906,9 @@ msgstr "部门"
 msgid "Dependent Analyses"
 msgstr "依赖检验项目"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "描述"
 
@@ -1871,7 +1955,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr "禁用同一用户的多重验证"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "折扣"
@@ -1889,7 +1977,7 @@ msgstr "发送"
 msgid "Dispatch samples"
 msgstr "发送样本"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "已发送"
@@ -1914,15 +2002,23 @@ msgstr "显示值必须唯一"
 msgid "Display a Detection Limit selector"
 msgstr "显示检出限选择器"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr "向客户展示分装样品"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "销毁"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "已处置"
 
@@ -1992,11 +2088,15 @@ msgstr "下载PDF"
 msgid "Download selected reports"
 msgstr "下载选定报告"
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "逾期"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "截止期"
@@ -2013,7 +2113,7 @@ msgstr "重复样"
 msgid "Duplicate Analysis"
 msgstr "复制检验项目"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2061,6 +2161,7 @@ msgstr "如 SANAS, APLAC 等"
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "每个导入接口都可以定义一个为文件夹，系统在其中查找结果文件，同时在调用<code>auto_import_results</code>视图时自动导入结果."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "编辑"
@@ -2075,21 +2176,21 @@ msgstr "评估"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "Email"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "Email地址"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2097,27 +2198,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "电子邮件日志"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "样品失效通知的电子邮件正文"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr "拒收样品通知的电子邮件正文"
 
@@ -2130,17 +2231,21 @@ msgstr "电子邮件已取消"
 msgid "Email notification"
 msgstr "电子邮件通知"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "样本拒收时进行电子邮件通知"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
 msgstr "发送电子邮件"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2150,27 +2255,27 @@ msgstr "不支持空键"
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "在工作表中启用多次使用仪器。"
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "启用样本保存"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "启用样本检验标准"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "启用采样"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "启用采样计划"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr "启用全局审计日志"
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr "启用全局审计日志"
 
@@ -2178,9 +2283,17 @@ msgstr "启用全局审计日志"
 msgid "Enable sampling workflow for the created sample"
 msgstr "为创建的样本启用采样工作流程"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "启用结果报告打印工作流程"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2203,7 +2316,7 @@ msgstr "输入电子邮件地址。 如果密码丢失，这是必需的。 我�
 msgid "Enter discount percentage value"
 msgstr "输入折扣百分数值, 如7折就输30"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2216,7 +2329,7 @@ msgstr "输入百分数值, 如14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "输入百分比值，如14.0 。这一比例仅在检验套餐应用，覆盖系统的增值稅（VAT）"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "输入百分数值, 如14.0. 这个百分数值将作为系统值使用,但对于单个项目可以重新定义."
 
@@ -2240,7 +2353,7 @@ msgstr "输入要复制的检验服务的每一个细节。"
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "在此处输入实验室服务认证的详细信息。可以使用以下字段：lab_is_accredited，lab_name，lab_country，confidence，accreditation_body_name，accreditation_standard，accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr "用十进制或科学符号输入结果，如0.00005或1e-5，10000或1e5"
 
@@ -2252,15 +2365,15 @@ msgstr "环境条件"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr "错误结果发布来自样本：${sample_id}"
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "检验评价"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "样本评价"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "工作表评价"
 
@@ -2272,7 +2385,7 @@ msgstr "示例计划任务每10分钟执行一次自动导入"
 msgid "Example content"
 msgstr "示例内容"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "从结算中排除"
 
@@ -2282,7 +2395,7 @@ msgstr "从结算中排除"
 msgid "Expected Result"
 msgstr "预期结果"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "预期采样日期"
 
@@ -2308,7 +2421,7 @@ msgstr "过期日期"
 msgid "Exponential format precision"
 msgstr "指数格式精度"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "指数格式阈值"
 
@@ -2316,7 +2429,7 @@ msgstr "指数格式阈值"
 msgid "Export"
 msgstr "导出"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "标签加载失败"
 
@@ -2403,7 +2516,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "文件大小"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2417,6 +2530,18 @@ msgstr "按检验项目模板筛选"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2433,11 +2558,11 @@ msgstr "名"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "浮点值从0.0 - 1000.0表示排序顺序。 重复值按字母顺序排序。"
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "格式化配置"
 
@@ -2460,13 +2585,17 @@ msgstr "星期五"
 msgid "From"
 msgstr "自"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "全名"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "全名"
 
@@ -2474,7 +2603,7 @@ msgstr "全名"
 msgid "Function"
 msgstr "函数"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "已预约时间的样品"
 
@@ -2507,7 +2636,7 @@ msgstr "转到实例"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "称谓, 如先生,女士, 博士"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "当列表很长时，使用LIMS表格中对检验项目进行类别分组很有帮助"
 
@@ -2521,7 +2650,7 @@ msgid "Hazardous"
 msgstr "危险品"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "隐藏"
@@ -2534,8 +2663,20 @@ msgstr "隐藏字段"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2559,7 +2700,7 @@ msgstr "国际银行号码"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2567,7 +2708,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr "ID服务器值"
 
@@ -2587,15 +2728,15 @@ msgstr "如果选中，结果条目视图中检验项目的结果字段旁边将
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "如果勾选，该仪器将不可用，直到下一个有效的校准。此复选框将自动被选中。"
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "如果启用，将在结果输入视图中的每个检验项目附近显示一个空白文本字段"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "如果启用，则提交此检验结果的用户也可以对其进行复核。此设置对分配了角色的用户生效，允许他们复核结果（默认情况下，管理员，实验室管理员和复核者）。此处设置的选项优先于全局设置中设置的选项"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "如果启用，提交结果的用户也将能够复核它。此设置仅对分配了角色的用户生效，这些用户可以复核结果（默认情况下，管理员，实验室管理员和复核者）。对于检验项目编辑视图中的给定项目，此设置可以被覆盖。默认情况下，禁用。"
 
@@ -2603,7 +2744,7 @@ msgstr "如果启用，提交结果的用户也将能够复核它。此设置仅
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "如果启用，检验项目的名称将用斜体表示。"
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "如果启用，则默认情况下不会在报告中显示此检验项目及其结果。检验套餐或样本中可以覆盖此设置"
 
@@ -2643,7 +2784,7 @@ msgstr "如果未选中，实验室管理员将无法在创建工作表时为同
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "如果您的公式需要外部Python库中的特殊函数，您可以在此处导入。例如，如果你想使用Python'math'模块中的'floor'函数，你可以在Module字段中添加'math'，在函数字段中添加'floor'。等同于Python中语句“from math import floor”。在你的计算公式中可以使用'floor（[Ca] + [Mg]）'. "
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr "立即输入结果"
 
@@ -2674,11 +2815,11 @@ msgstr "实验室内部校准操作方法"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "停用"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "包含并显示价格信息"
 
@@ -2875,7 +3016,7 @@ msgid "Internal Certificate"
 msgstr "内部证书"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "内部使用"
 
@@ -2896,13 +3037,13 @@ msgstr "解释模板"
 msgid "Interval"
 msgstr "间隔"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "无效"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2965,15 +3106,15 @@ msgstr "开票给"
 msgid "Invoice {} created"
 msgstr "已创建发票{}"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "发票批次无结束日期"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "发票批次无开始日期"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "发票批次无标题"
 
@@ -2985,7 +3126,7 @@ msgstr "工作职位"
 msgid "Job title"
 msgstr "工作职位"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr "保持以上顺序"
 
@@ -2997,9 +3138,9 @@ msgstr "关键"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "关键词"
 
@@ -3015,6 +3156,10 @@ msgstr "需要关键词"
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "关键词"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3059,8 +3204,8 @@ msgstr "实验室产品"
 msgid "Lab URL"
 msgstr "实验室网址"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "标签"
@@ -3069,7 +3214,7 @@ msgstr "标签"
 msgid "Label configuration"
 msgstr "标签配置"
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr "标签名必须唯一"
 
@@ -3077,13 +3222,13 @@ msgstr "标签名必须唯一"
 msgid "Label schema extender"
 msgstr "标签衍生字段"
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr "被标签对象"
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr "标签"
 
@@ -3096,7 +3241,7 @@ msgstr "实验室"
 msgid "Laboratory Accredited"
 msgstr "实验室认证"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "实验室工作日"
 
@@ -3108,7 +3253,7 @@ msgstr "语言"
 msgid "Large Sticker"
 msgstr "大标签"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3120,11 +3265,11 @@ msgstr "上一次自动导入日志"
 msgid "Last Login Time"
 msgstr "最后一次登录时间"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "逾期"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "逾期检验项目"
 
@@ -3170,15 +3315,15 @@ msgstr "关联用户"
 msgid "Link an existing User"
 msgstr "关联现有用户"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr "列举所有有标签的对象"
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr "可能的最终结果列表。设置后，结果条目上不允许有自定义结果，用户必须从这些值中进行选择"
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3202,7 +3347,7 @@ msgstr "从这里加载证书文件"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3230,6 +3375,14 @@ msgstr "地点类型"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "文件保存位置"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3293,7 +3446,7 @@ msgstr "男性"
 msgid "Manage Analyses"
 msgstr "管理检验项目"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "管理表单字段"
 
@@ -3317,7 +3470,7 @@ msgstr "管理样本表单字段"
 msgid "Manage linked User"
 msgstr "管理关联用户"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3341,7 +3494,7 @@ msgstr "经理Email"
 msgid "Manager Phone"
 msgstr "经理电话"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "手动"
 
@@ -3370,7 +3523,7 @@ msgstr "制造商"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "将样本标记为仅供内部使用。这意味着只能由实验室人员访问，而不能由客户访问。"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3385,7 +3538,7 @@ msgstr "最大时间"
 msgid "Max operator"
 msgstr "最大运算符"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3420,15 +3573,15 @@ msgid "Member Discount"
 msgstr "会员折扣"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "会员折扣%"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "会员折扣可用"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "会员已注册并关联到当前联系人。"
 
@@ -3436,7 +3589,7 @@ msgstr "会员已注册并关联到当前联系人。"
 msgid "Message sent to {}, "
 msgstr "消息发送到{}， "
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3467,7 +3620,7 @@ msgstr "中间名缩写"
 msgid "Middle name"
 msgstr "中间名"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3478,7 +3631,7 @@ msgstr "最小"
 msgid "Min operator"
 msgstr "最小运算符"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3496,7 +3649,7 @@ msgstr "最少5个"
 msgid "Minimum Volume"
 msgstr "最小体积"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "质量控制统计计算的最小结果数目"
 
@@ -3527,6 +3680,10 @@ msgstr "组件"
 msgid "Monday"
 msgstr "星期一"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3540,11 +3697,11 @@ msgstr "灵活内容的多目录行为"
 msgid "Multi Results"
 msgstr "合并结果"
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "多次复核类型"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "需要多次复核"
 
@@ -3580,13 +3737,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "银行编码"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "名称"
 
@@ -3597,6 +3758,10 @@ msgstr ""
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
 msgstr "新范围不会应用在新检验项目或当前检验项目。 如果要应用最新变更，请重新赋予检验标准。"
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
@@ -3639,6 +3804,10 @@ msgstr "没有子组"
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "没有定义行动。"
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3686,6 +3855,10 @@ msgstr "没有变更"
 msgid "No changes made."
 msgstr "没有变更。"
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "没有设定日期"
@@ -3730,6 +3903,16 @@ msgstr "没有选择项目"
 msgid "No items selected."
 msgstr "没有选择项目。"
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "没有创建新项目。"
@@ -3737,6 +3920,10 @@ msgstr "没有创建新项目。"
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "没有创建分装"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3753,6 +3940,10 @@ msgstr "没有样本被拒绝"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "无采样工作流"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3780,7 +3971,7 @@ msgstr "该样本没有设置检验项目"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "没有"
 
@@ -3796,11 +3987,11 @@ msgstr "不允许更新条件：{}"
 msgid "Not defined"
 msgstr "未定义"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "没有设置"
@@ -3821,7 +4012,7 @@ msgstr "注意：设置是全局的，适用于所有样本视图。"
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "提示：您还可以拖放附件行以更改它们在报告中显示的顺序。"
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr "通知"
 
@@ -3833,7 +4024,7 @@ msgstr "列数"
 msgid "Number"
 msgstr "数量"
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "检验项目数量"
 
@@ -3849,16 +4040,16 @@ msgstr "复制数量"
 msgid "Number of prominent columns"
 msgstr "突出列数"
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "复核次数"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "在给定结果被视为“已复核”之前所需的复核数量。对于检验项目服务编辑视图中的任何检验项目，都可以覆盖此设置。默认情况下：1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "在将此检验项目的给定结果视为“已复核”之前，来自具有足够权限的不同用户所需的复核次数。此处设置的选项优先于站点设置中设置的选项"
 
@@ -3868,6 +4059,10 @@ msgstr "标准数列"
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3886,11 +4081,11 @@ msgstr "只有影像类型文件可以在报告中渲染"
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "对于分析周转时间计算，仅考虑实验室工作日 "
 
@@ -3898,13 +4093,13 @@ msgstr "对于分析周转时间计算，仅考虑实验室工作日 "
 msgid "Only to empty or zero fields"
 msgstr "只有空或零字段"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "启用中"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3912,9 +4107,17 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "基于开源的云实验室信息管理系统"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "打开电子邮件表格，将选定的报告发送给收件人。成功发送电子邮件后，还将发布报告中包含的样本。"
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3941,7 +4144,7 @@ msgstr "其他原因"
 msgid "Other reasons:"
 msgstr "其他原因："
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "其他状态"
 
@@ -3963,11 +4166,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4064,11 +4267,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "请从列表中选择一个用户"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4081,6 +4284,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr "请选择要创建的分装数量，然后按预览按钮"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr "请具体说明原因"
 
@@ -4100,12 +4304,16 @@ msgstr "请使用以下格式选择选项：key1:value1 |key2:value2 |…|keyn:v
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr "请在发送所列样本时写一条评论"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "捕获点"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4144,31 +4352,31 @@ msgstr "小数精度"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "精度为根据不确定性的有效位数。小数位置将由不确定性中不同于零的第一个数字给出，在该位置系统将对不确定性和结果进行舍入。例如，结果为5.243，不确定度为0.22，系统将正确显示为5.2 ±0.2。如果没有为结果设置不确定性范围，系统将使用固定精度设置。"
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr "预定义结果"
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "首选报告小数点标记。"
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "首选结果小数点标记"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "“工作表”视图中结果条目表的首选布局。经典布局在行中显示样品，在列中显示检验项目。转置布局显示列中的样本和行中的检验项目。"
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "首选的报告科学计数法格式"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "首选的结果科学计数法格式"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4201,7 +4409,7 @@ msgstr "每种样本类型的保存"
 msgid "Preserve"
 msgstr "保存"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "保管人"
 
@@ -4218,11 +4426,11 @@ msgstr "预防"
 msgid "Preventive maintenance procedure"
 msgstr "预防性维护程序"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "预览"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4250,7 +4458,7 @@ msgstr "价格列表:"
 msgid "Pricelists"
 msgstr "价格表"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4259,7 +4467,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "主样品"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4281,11 +4489,11 @@ msgstr "打印日期"
 msgid "Print pricelist"
 msgstr "打印价目表"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "打印标签"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "已打印"
 
@@ -4298,7 +4506,7 @@ msgstr "已打印在"
 msgid "Priority"
 msgstr "优先级"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "套餐"
 
@@ -4322,7 +4530,7 @@ msgstr "套餐名字"
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "进度"
 
@@ -4331,7 +4539,7 @@ msgstr "进度"
 msgid "Prominent fields"
 msgstr "突出字段"
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "操作规程ID"
 
@@ -4339,7 +4547,7 @@ msgstr "操作规程ID"
 msgid "Province"
 msgstr "省"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4348,8 +4556,12 @@ msgstr ""
 msgid "Publish"
 msgstr "发布报告"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "已发布"
@@ -4365,6 +4577,10 @@ msgstr "发布日期"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "已发布报告"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4386,6 +4602,14 @@ msgstr "QC结果"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "质控样品ID"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4411,7 +4635,7 @@ msgstr "重新輸入密碼，確保密碼是相同的。"
 msgid "Reasons for rejection"
 msgstr "拒收理由"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "重新分派"
 
@@ -4423,30 +4647,34 @@ msgstr "可重新分派的位置"
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "接收"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "已接收"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "待接收"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "收件人"
 
@@ -4497,11 +4725,15 @@ msgstr "参考值"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "样品参考值为0或'空白'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "登记"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4527,9 +4759,9 @@ msgstr "剔除分析"
 msgid "Reject samples"
 msgstr "拒收样本"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "拒收"
 
@@ -4545,7 +4777,7 @@ msgstr "已拒收的样本"
 msgid "Rejected {} samples: {}"
 msgstr "已拒收 {} 样本: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4606,8 +4838,16 @@ msgstr "远程IP"
 msgid "Remove"
 msgstr "移除"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4643,11 +4883,11 @@ msgstr "报告ID"
 msgid "Report identification number"
 msgstr "报告识别码"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4659,7 +4899,7 @@ msgstr "报告上传"
 msgid "Republish"
 msgstr "重新发布"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "最后一次打印后重新发布"
 
@@ -4668,7 +4908,7 @@ msgstr "最后一次打印后重新发布"
 msgid "Request ID"
 msgstr "请检单编号"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "请检新检验项目"
 
@@ -4684,24 +4924,37 @@ msgstr "要求的体积"
 msgid "Reset"
 msgstr "重置"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr "重置列"
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
 msgstr "职责"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr "恢复"
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4726,15 +4979,15 @@ msgstr "结果值必须是数字"
 msgid "Result Value must be unique"
 msgstr "结果值必须唯一"
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "结果超出正常范围"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "结果超出上下限范围"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr "结果范围与检验标准不同：{}"
 
@@ -4742,7 +4995,7 @@ msgstr "结果范围与检验标准不同：{}"
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "结果中显示的数值小数点后有效数字位数不少于这个值，同时使用科学计数法，用\"e\"表示指数符号。精确度可以在各个检验项目中进行配置。"
 
@@ -4758,16 +5011,20 @@ msgstr "结果"
 msgid "Results Interpretation"
 msgstr "结果解析"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "结果被撤回"
 
@@ -4775,7 +5032,7 @@ msgstr "结果被撤回"
 msgid "Results interpretation"
 msgstr "结果解析"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "等待结果"
 
@@ -4799,7 +5056,7 @@ msgstr "复检"
 msgid "Retract"
 msgstr "撤回"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4835,6 +5092,10 @@ msgstr "回滚"
 msgid "Routine Analyses"
 msgstr "常规检验项目"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4860,6 +5121,7 @@ msgstr "LIMS站点首页"
 msgid "SENAITE Registry"
 msgstr "站点注册表"
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4869,7 +5131,7 @@ msgstr "站点设置"
 msgid "SENAITE front-page"
 msgstr "站点首页"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "SMTP服务器断开连接，用户创建已中止。"
 
@@ -4883,7 +5145,7 @@ msgstr "称呼"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "样本"
 
@@ -4920,7 +5182,7 @@ msgid "Sample Header"
 msgstr "样品标题"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "样品编号"
 
@@ -4940,7 +5202,7 @@ msgstr "样品基质"
 msgid "Sample Partitions"
 msgstr "样品区块"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4967,7 +5229,7 @@ msgid "Sample Templates"
 msgstr "样本模板"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "样品类型"
@@ -5028,7 +5290,7 @@ msgstr "样品类型"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "取样人"
 
@@ -5040,8 +5302,8 @@ msgstr "计划采样的采样人"
 msgid "Sampler required for sample %s"
 msgstr "样本 %s 需要采样人"
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "样本"
@@ -5058,6 +5320,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5067,7 +5341,23 @@ msgstr "该类型的样本需要作为\"危险废弃物\"处理"
 msgid "Samples rejection reporting form"
 msgstr "样本拒收报告表"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5075,7 +5365,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "采样日期"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "取样差异"
@@ -5088,7 +5378,7 @@ msgstr "取样差异"
 msgid "Sampling Frequency"
 msgstr "取样频率"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "采样计划"
 
@@ -5096,15 +5386,24 @@ msgstr "采样计划"
 msgid "Saturday"
 msgstr "星期六"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "保存"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
 msgstr "保存并复制"
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5118,7 +5417,7 @@ msgstr "计划/日程表"
 msgid "Schedule sampling"
 msgstr "计划采样"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "已计划采样"
@@ -5135,6 +5434,10 @@ msgstr "科学名称/学名"
 msgid "Search"
 msgstr "搜索"
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5143,7 +5446,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "秒"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5233,11 +5536,11 @@ msgstr ""
 msgid "Select template"
 msgstr "选择模板"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "选择该网站默认显示的国家"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "选择用于网站显示价格的货币种类."
 
@@ -5249,11 +5552,11 @@ msgstr "选择要用于此检验项目的默认容器。如果要使用的容器
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "选择默认登录页面。当客户端用户登录系统时，或在客户文件夹列表中选择客户时，将应用此选项。"
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5261,31 +5564,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr "选择此ID用于标识的类型。"
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "选择此选项可在拒绝样本时自动通过电子邮件通知客户。"
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "选择此选项可将仪表板为默认首页。"
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "此选项启用采样工作流程。"
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "选择此项以允许取样协调员安排采样。此功能仅在“采样工作流程”处于启用状态时生效"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "选择此选项可在实验室人员创建且采样工作流程被禁用时自动接收样本。客户联系人创建的样本将不会被自动接收"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr "选择向客户联系人显示分装样品。如果停用，分装将不会包含在列表中，并且没有与初级样品链接的信息会显示给客户联系人。"
 
@@ -5297,7 +5608,7 @@ msgstr "选择工作表中需要包含的分析"
 msgid "Selection list"
 msgstr "选择列表"
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "结果自我复核"
 
@@ -5309,11 +5620,11 @@ msgstr "发送"
 msgid "Send Analysis Reports via Email"
 msgstr "通过电子邮件发送检验报告单"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5335,7 +5646,7 @@ msgstr "发送至"
 msgid "Separate Container"
 msgstr "单独的容器"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5349,7 +5660,7 @@ msgstr "序列号"
 msgid "Service"
 msgstr "服务"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "检验项目无法取消选择。请单击信息按钮以获取更多详细信息"
 
@@ -5377,7 +5688,7 @@ msgstr "设置样品拒收工作流程和原因"
 msgid "Set the maintenance task as closed."
 msgstr "设置维护任务为关闭状态."
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr "设置要发送的电子邮件正文的文本，如果样本的客户联系人中设置启用了“电子邮件通知拒绝样本”选项，您可以使用保留关键字： $sample_id, $sample_link, $reasons, $lab_address"
 
@@ -5425,29 +5736,41 @@ msgstr "这些检验项目是否应从发票中排除？"
 msgid "Should the default example content be added to the site?"
 msgstr "是否应该将默认示例内容添加到站点中？"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr "显示上次自动导入日志"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr "显示更多"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
 msgstr "显示标准字段"
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5469,11 +5792,11 @@ msgstr "站点编码"
 msgid "Site Description"
 msgstr "站点描述"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr "网站Logo"
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr "网站logo CSS"
 
@@ -5494,7 +5817,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "小标签"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5511,6 +5834,14 @@ msgstr "一些分析使用过时或未校准的仪器，结果不允许发布。
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "排序关键字"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5536,7 +5867,7 @@ msgstr "检验标准范围在分派后进行了变更"
 msgid "Specifications"
 msgstr "检验标准"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5544,7 +5875,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "指定工作表的大小，例如对应于特定仪器的托盘尺寸。然后选择每个工作表位置的分析'类型'。选择质控样品时，还要选择应使用哪个参考样品。如果选择了复制分析，请指出它应该是哪个样品位置"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5561,17 +5892,17 @@ msgstr "开始日期"
 msgid "Start date must be before End Date"
 msgstr "开始日期必须早于结束日期"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "状态"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "状态"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "标签"
@@ -5580,7 +5911,11 @@ msgstr "标签"
 msgid "Stickers preview"
 msgstr "标签预览"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "存储位置"
@@ -5620,7 +5955,11 @@ msgstr "提交"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr "提交包含安装记录的有效Open XML（.XLSX）文件以继续."
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "由同一用户提交并复核：{}"
 
@@ -5628,7 +5967,7 @@ msgstr "由同一用户提交并复核：{}"
 msgid "Submitter"
 msgstr "提交人"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "子项总计"
@@ -5670,7 +6009,7 @@ msgstr "切换到进度仪表板"
 msgid "Switch to transposed view"
 msgstr "切换到转置视图"
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "系统默认"
 
@@ -5696,7 +6035,7 @@ msgstr "税"
 msgid "Technical description and instructions intended for analysts"
 msgstr "为分析员准备的技术描述和说明"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5778,7 +6117,7 @@ msgstr "样本保存的日期"
 msgid "The date when the sample was received"
 msgstr "收到样本的日期"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "将使用在站点设置中选择的小数点。"
 
@@ -5786,7 +6125,7 @@ msgstr "将使用在站点设置中选择的小数点。"
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr "站点默认时区设置。 如果在日期和时间设置中定义了可用时区，用户将能够设置他们自己的时区。"
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "输入折扣的百分数, 该折扣将用于标为'会员'的用户,通常企业或协会会员将得到该折扣"
 
@@ -5814,7 +6153,11 @@ msgstr "已从此样品创建以下分装："
 msgid "The following sample(s) will be dispatched"
 msgstr "将分发以下样本"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr "全局审计日志显示系统的所有修改。当启用时，所有的实体将被索引在一个单独的目录中。这将增加对象被创建或修改的时间。"
 
@@ -5822,11 +6165,11 @@ msgstr "全局审计日志显示系统的所有修改。当启用时，所有的
 msgid "The height or depth at which the sample has to be taken"
 msgstr "取样高度或深度"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5863,11 +6206,11 @@ msgstr "检验需要的最小样品量，如：10mL或者1Kg。"
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "样品有效天数, 过期的样品将不能分析. 该设置可以在样品类型设置中为具体样品类型重置."
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "用户登录后能够停留的分钟数, 超过此数用户会被自动注销. 0表示不会自动注销"
 
@@ -5907,7 +6250,7 @@ msgstr "认证机构向实验室发放的参考码"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "计算结果将覆盖检测值。在计算此值之前，您需要保存计算。"
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5931,11 +6274,11 @@ msgstr "该样本是子样品的混合物"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "仪器唯一序列号"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "检验项目的分析流程ID"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "用于财务检验项目商业化ID"
 
@@ -5987,11 +6330,11 @@ msgstr "该二级样本归属于"
 msgid "This is a detached partition from Sample"
 msgstr "这是分装后的样本"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "这是执行分析所允许的默认最长时间。仅用于分析服务未指定检验的检验项目。只考虑实验室工作日。"
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6015,11 +6358,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr "在您的SENAITE网站上显示自定义Logo。"
 
@@ -6051,8 +6394,8 @@ msgstr "时间"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "提示：附加文件将不会加载除非他们在样本呈现。"
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "标题"
@@ -6079,34 +6422,42 @@ msgstr "站点名称"
 msgid "To"
 msgstr "至"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "待保存"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "待取样"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "在结果报告的每个检验项目类别部分的下方显示。"
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "待保存"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "待打印"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "待取样"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "待复核"
@@ -6119,7 +6470,7 @@ msgstr "要测试计算，请在此处输入所有计算参数的值。 这包�
 msgid "Toggle visibility of standard sample header fields"
 msgstr "切换标准示例标题字段的可见性"
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "总计"
 
@@ -6141,7 +6492,7 @@ msgid "Tuesday"
 msgstr "星期二"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "类型"
@@ -6166,6 +6517,10 @@ msgstr "容器类型"
 msgid "Type to filter ..."
 msgstr "键入以筛选..."
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr "支持直接标签的类型。<br/>注意：在集群设置中，需要手动重启其他实例才能更改有效！"
@@ -6174,7 +6529,7 @@ msgstr "支持直接标签的类型。<br/>注意：在集群设置中，需要�
 msgid "Types with labels"
 msgstr "带标签的类型"
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6186,6 +6541,7 @@ msgstr "无法加载模板"
 msgid "Unassign"
 msgstr "未分配"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "未分配"
@@ -6218,9 +6574,13 @@ msgstr "未知国际银行账号国家%s"
 msgid "Unlink User"
 msgstr "取消关联用户"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
 msgstr "已取消关联的用户"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6236,13 +6596,17 @@ msgstr "无法识别文件格式 ${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr "无法识别文件格式 ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "未分派"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "更新附件"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6252,7 +6616,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "上传一个用于打印分析报告的签名扫描件. 理想尺寸为250像素宽, 150像素高"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6260,7 +6624,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "使用检验套餐价格目录"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "使用仪表进度板作为默认首页"
 
@@ -6298,7 +6662,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "用户关联该联系人"
 
@@ -6306,15 +6670,15 @@ msgstr "用户关联该联系人"
 msgid "User name"
 msgstr "用户名"
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "取样点太少时分析结果无意义. 请在质量控制统计处理前设置可接受的最小样品量."
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6322,7 +6686,7 @@ msgstr "增值税"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "增值税%"
 
@@ -6569,8 +6933,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "可在此处输入的值将覆盖在计算临时字段指定的默认值。"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "已复核"
@@ -6579,11 +6943,19 @@ msgstr "已复核"
 msgid "Verified By"
 msgstr "复核人"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "复核"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6598,6 +6970,14 @@ msgstr "查看"
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
 msgstr "浏览LIMS站点"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr ""
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -6632,6 +7012,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "星期三"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "几周后过期"
@@ -6644,19 +7028,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr "欢迎来到LIMS"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr "启用后，一旦复核所有结果，就会自动验证样本。 否则，具有足够权限的用户必须手动复核样本。 默认值：启用"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6707,10 +7091,18 @@ msgstr "工作表模板"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "工作表"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6719,6 +7111,10 @@ msgstr ""
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "错误的IBAN账号长度%s: %s 用短的 %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6802,6 +7198,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6906,8 +7306,17 @@ msgstr "天"
 msgid "deactivate"
 msgstr "停用"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6972,7 +7381,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7139,46 +7548,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7190,19 +7599,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7223,16 +7632,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7257,12 +7671,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7272,7 +7686,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7375,6 +7789,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7404,6 +7831,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7550,12 +7984,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7808,7 +8242,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7816,163 +8250,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7980,47 +8414,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8029,20 +8463,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8050,32 +8484,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8083,21 +8517,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8253,6 +8687,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8565,7 +9003,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8626,7 +9064,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8742,52 +9180,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8857,12 +9295,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8872,7 +9310,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9168,7 +9606,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9293,12 +9731,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9508,7 +9946,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr "保存"
 
@@ -9518,12 +9956,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9581,6 +10019,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10757,87 +11211,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10890,6 +11344,11 @@ msgstr ""
 msgid "minutes"
 msgstr "分钟"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "每月"
@@ -10940,13 +11399,21 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "的"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "概览"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11023,6 +11490,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11257,13 +11729,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11350,6 +11827,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11595,222 +12077,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12064,7 +12546,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "待复核"
 
@@ -12107,7 +12589,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr "{} (已超时)"
 

--- a/src/senaite/core/locales/zh_CN/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/zh_CN/LC_MESSAGES/plone.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Raymond Yu <cl_yu@hotmail.com>, 2024\n"
 "Language-Team: Chinese (China) (https://app.transifex.com/senaite/teams/87045/zh_CN/)\n"

--- a/src/senaite/core/locales/zh_CN/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/zh_CN/LC_MESSAGES/plone.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: Raymond Yu <cl_yu@hotmail.com>, 2024\n"
 "Language-Team: Chinese (China) (https://app.transifex.com/senaite/teams/87045/zh_CN/)\n"
@@ -926,6 +926,11 @@ msgstr "需要一个帐户"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
 msgstr "没有文件"
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
+msgstr ""
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82

--- a/src/senaite/core/locales/zh_CN/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/zh_CN/LC_MESSAGES/senaite.core.po
@@ -14,7 +14,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Chinese (China) (https://app.transifex.com/senaite/teams/87045/zh_CN/)\n"

--- a/src/senaite/core/locales/zh_CN/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/zh_CN/LC_MESSAGES/senaite.core.po
@@ -14,7 +14,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Chinese (China) (https://app.transifex.com/senaite/teams/87045/zh_CN/)\n"
@@ -28,7 +28,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: zh_CN\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr " <p>ID服务器基于每种内容类型指定的格式，为样品和工作表等对象提供唯一的顺序Id。</p><p>该格式的构造类似于Python格式语法，使用每个内容类型的预定义变量，并通过序列号，'seq'及其填充作为数字推进Id，例如从001到999的Id序列的'03d'。</p><p>Id的字母数字前缀按格式包含，例如 WS-{seq:03d}中的工作表的WS生成顺序工作表Id：WS-001、WS-002、WS-003等。</p><p>对于字母数字和顺序Id的动态生成，可以使用通配符{alpha}。 例如WS-{alpha:2a3d}生产WS-AA001、WS-AA002、WS-AB034, 等。</p><p>可以使用的变量包括：<table><tr><th style='width:150px'>内容类型</th><th>变量</th></tr><tr><td>客户ID</td><td>{clientId}</td></tr><tr><td>年</td><td>{year}</td></tr><tr><td>样品ID</td><td>{sampleId}</td></tr><tr><td>样品类型</td><td>{sampletype}</td></tr><tr><td>采样日期</td><td>{samplingdate}</td></tr><tr><td>抽样日期</td><td>{datesampled}</Td></tr></table></p><p>配置设置：<ul><li>格式：<ul><li>从预定义变量，如样品id，客户id, 样品类型等构建的python格式字符串。</li><li>特殊变量'seq'必须在格式字符串中最后定位</li></ul></li><li>序列类型：[生成|计数器]</li><li>上下文：如果类型计数器，提供上下文计数函数</li><li>计数器类型：[backreference|contained]</li><li>计数器引用：计数函数的参数</li><li>前缀：如果格式字符串中没有提供，则默认前缀</li><li>分割长度：部件数量要包括在前缀里</li></ul></p>"
 
@@ -37,6 +37,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} 附件总的大小为 ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link} 返回链接"
@@ -62,6 +63,7 @@ msgid "%s has no '%s' column."
 msgstr "%s 没有 '%s' 列。"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; 返回"
@@ -131,6 +133,10 @@ msgstr "*** 这是一封自动生成的电子邮件，请不要回复此邮件�
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr "选择仪器"
@@ -148,7 +154,7 @@ msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" /> 转到工作表模板�
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> 欢迎来到SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -206,7 +212,7 @@ msgid "Account Type"
 msgstr "帐户类型"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr "会计"
 
@@ -251,21 +257,21 @@ msgstr "启用"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "活跃的"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "角色"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "添加"
 
@@ -293,15 +299,19 @@ msgstr "添加平行样"
 msgid "Add Samples"
 msgstr "添加样品"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "添加备注字段到所有检验项目"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr "为Logo添加自定义的CSS规则，例如，高度：15px；宽度：150px"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "添加默认可选标签"
 
@@ -314,8 +324,11 @@ msgstr "添加新附件"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "添加一个或多个附件以描述此示例中的样品，或指定您的请检要求。"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "添加备注"
 
@@ -379,13 +392,21 @@ msgstr "所有已认证的检验项目服务均列于此."
 msgid "All Analyses of Service"
 msgstr "所有检验项目服务"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "所有检验项目已分派"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "允许手动输入检测限"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -403,11 +424,11 @@ msgstr "允许用户进行多次自我复核"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "允许用户非连续性的多次自我复核"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "允许对结果进行自我复核"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -436,15 +457,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "检验人员"
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "检验项目"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "请检项目"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -513,7 +550,7 @@ msgstr "分析条件"
 msgid "Analysis conditions updated: {}"
 msgstr "分析条件已更新: {}"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "直接在样品上编辑的检验标准。"
 
@@ -550,7 +587,7 @@ msgstr "必须指定检验人员。"
 msgid "Any"
 msgstr "任何"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr "外观"
 
@@ -561,6 +598,10 @@ msgstr "应用"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "应用模板"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -574,19 +615,15 @@ msgstr "资产编号"
 msgid "Assign"
 msgstr "分派"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "已分派"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "分派到: ${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "任务待定"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -600,7 +637,7 @@ msgstr "附加到样品"
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr "附加标签"
 
@@ -688,11 +725,15 @@ msgstr "Dexterity 内容的自动生成 ID 行为"
 msgid "Auto-Import Logs"
 msgstr "自动导入日志"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "接收时自动分装样品"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "自动接收样品"
 
@@ -700,15 +741,15 @@ msgstr "自动接收样品"
 msgid "Autofill"
 msgstr "自动填充"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "自动登出"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr "自动验证样品"
 
@@ -759,7 +800,7 @@ msgstr "批"
 msgid "Batch Book"
 msgstr "批处理簿"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "批ID"
 
@@ -789,6 +830,10 @@ msgstr "请注意，电子表格文件中提供的动态规格范围可能会覆
 msgid "Bearing"
 msgstr "持有"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "账单地址"
@@ -809,7 +854,7 @@ msgstr "品牌"
 msgid "Bulk Discount"
 msgstr "批量折扣"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "已使用大宗折扣"
@@ -827,19 +872,19 @@ msgstr "业务电话"
 msgid "Business address"
 msgstr "业务地址"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr "按 “显示值” 升序排列"
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr "按 “显示值” 降序排列"
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr "按 “结果值” 升序排列"
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr "按 “结果值” 降序排列"
 
@@ -847,12 +892,12 @@ msgstr "按 “结果值” 降序排列"
 msgid "CBID"
 msgstr "CB ID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "抄送多个邮件"
 
@@ -908,23 +953,23 @@ msgstr "校准"
 msgid "Calibrator"
 msgstr "校准物质"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "可以验证，但需要通过当前用户提交"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "可以验证，但已经被当前用户验证"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "取消"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "已取消"
 
@@ -944,15 +989,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr "无法为样品编号${sample_id}发送邮件: ${error}"
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "无法验证，当前用户已最后验证"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "无法验证，当前用户已提交过"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "无法验证，已被当前用户验证"
 
@@ -978,7 +1023,7 @@ msgstr "多目录中的目录灵活性内容"
 msgid "Catalogue Number"
 msgstr "类别号码"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "检验服务归类"
 
@@ -1010,11 +1055,11 @@ msgid "Changes Saved"
 msgstr "保存更改"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "保存更改."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "变更会推送至分装样品"
 
@@ -1051,31 +1096,31 @@ msgstr "勾选框"
 msgid "Choices"
 msgstr "选项"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr "为同一用户选择多重验证的类型。此设置可以为同一用户启用/禁用多次验证/连续验证。"
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1088,20 +1133,34 @@ msgstr "城市"
 msgid "Classic"
 msgstr "典型的"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "取消选定"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
 msgstr "单击以展开此类别"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
+msgstr ""
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "单击以切换可见性或拖放以更改顺序"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "客户"
@@ -1113,7 +1172,7 @@ msgstr "客户批次ID"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "客户编号"
 
@@ -1125,7 +1184,7 @@ msgstr "客户登录页面"
 msgid "Client Name"
 msgstr "客户名"
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "客户订单"
 
@@ -1135,7 +1194,7 @@ msgstr "客户订单"
 msgid "Client Order Number"
 msgstr "客户订单号"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "客户参阅"
 
@@ -1144,7 +1203,7 @@ msgstr "客户参阅"
 msgid "Client Reference"
 msgstr "客户参阅"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "客户样品编号"
 
@@ -1237,7 +1296,7 @@ msgstr "评论"
 msgid "Comments or results interpretation"
 msgstr "评论或结果解释"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "商业ID"
@@ -1275,6 +1334,10 @@ msgstr "样品头信息的配置"
 msgid "Configuration restored to default values."
 msgstr "配置恢复为默认值"
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr "配置表列"
@@ -1293,7 +1356,7 @@ msgstr "确认密码"
 msgid "Considerations"
 msgstr "考虑"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "联系方式"
@@ -1337,7 +1400,7 @@ msgstr "容器"
 msgid "Contents of the file {}"
 msgstr "文件内容 {}"
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1370,15 +1433,15 @@ msgstr "复制检验服务"
 msgid "Copy from"
 msgstr "复制自"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr "将当前显示的列值复制到右侧的其他列"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr "将第一个样品的值复制到其他样品"
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "复制到新的"
 
@@ -1388,6 +1451,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1406,11 +1473,11 @@ msgstr "无法将样本转换为采样状态"
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1423,7 +1490,7 @@ msgstr "国家"
 msgid "Create Invoice PDF"
 msgstr "创建PDF票据"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "分装"
 
@@ -1431,7 +1498,7 @@ msgstr "分装"
 msgid "Create SENAITE Site"
 msgstr "创建SENAITE站点"
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr "创建工作表"
 
@@ -1443,7 +1510,7 @@ msgstr "创建新的站点"
 msgid "Create a new User"
 msgstr "创建新用户"
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr "为所选样品创建新工作表"
 
@@ -1473,7 +1540,7 @@ msgid "Created {} partitions: {}"
 msgstr "创建了{}分装: {}"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "创建者"
 
@@ -1482,7 +1549,7 @@ msgstr "创建者"
 msgid "Criteria"
 msgstr "准则"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "现金"
 
@@ -1490,13 +1557,21 @@ msgstr "现金"
 msgid "Current"
 msgstr "当前"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "自定义小数点标记"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
 msgstr "报告限"
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
+msgstr ""
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1543,23 +1618,23 @@ msgstr "修改日期"
 msgid "Date Opened"
 msgstr "打开日期"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "保留时间"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "打印日期"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "签发日期"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "接收日期"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "登记日期"
 
@@ -1571,11 +1646,11 @@ msgstr "请检日期"
 msgid "Date Sample Received"
 msgstr "样品接收日期"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "取样日期"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "复核日期"
 
@@ -1617,7 +1692,7 @@ msgstr "校准证书被授予的日期"
 msgid "Date when the certificate is valid"
 msgstr "证书有效期至"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1640,11 +1715,11 @@ msgstr "停用至下次校准测试"
 msgid "Deactivate"
 msgstr "停用"
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "该客户报告中使用的小数点标记。"
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1656,7 +1731,7 @@ msgstr "默认容器"
 msgid "Default Department"
 msgstr "默认部门"
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "对于这个客户，所有已发布的样品默认电子邮件发送到客户联系人"
 
@@ -1668,7 +1743,7 @@ msgstr "默认仪器"
 msgid "Default Method"
 msgstr "默认方法"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1676,20 +1751,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "默认保留"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr "要添加的样品的默认数量。"
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "默认小数点标记"
 
@@ -1701,7 +1776,7 @@ msgstr "用于此类型分析的默认仪器"
 msgid "Default large sticker"
 msgstr "默认大标签"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "工作表视图默认布局"
 
@@ -1733,15 +1808,15 @@ msgstr "默认结果必须是以下结果选项之一：{}"
 msgid "Default result to display on result entry"
 msgstr "在结果输入时显示的默认结果"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "默认样品保留效期"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "默认报告科学计数法格式"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "默认结果科学计数法格式"
 
@@ -1753,7 +1828,7 @@ msgstr "默认小标签"
 msgid "Default timezone"
 msgstr "默认时区"
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr "默认检验周期。"
 
@@ -1762,7 +1837,7 @@ msgstr "默认检验周期。"
 msgid "Default value"
 msgstr "默认值"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr "当用户单击“添加”按钮创建新样品时，“样品数量”的默认值"
 
@@ -1786,7 +1861,7 @@ msgstr "定义将值转换为指数值表示时的精度。默认值是7。"
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "定义应该在预定日期进行采样的采样人"
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1798,8 +1873,17 @@ msgstr "定义用于此样品类型的标签。"
 msgid "Degrees"
 msgstr "度"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1828,9 +1912,9 @@ msgstr "部门"
 msgid "Dependent Analyses"
 msgstr "依赖性分析"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "描述"
 
@@ -1877,7 +1961,11 @@ msgstr "禁用自动获取转换功能"
 msgid "Disable multi-verification for the same user"
 msgstr "禁用同一用户的多重验证"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr "折扣/优惠"
@@ -1895,7 +1983,7 @@ msgstr "派遣"
 msgid "Dispatch samples"
 msgstr "派送样品"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "已派送"
@@ -1920,15 +2008,23 @@ msgstr "显示值必须唯一"
 msgid "Display a Detection Limit selector"
 msgstr "显示检测限选择器"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr "向客户展示分装样品"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "销毁"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "已销毁"
 
@@ -1998,11 +2094,15 @@ msgstr "下载PDF"
 msgid "Download selected reports"
 msgstr "下载选定的报告"
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "截止"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "截止期"
@@ -2019,7 +2119,7 @@ msgstr "重复"
 msgid "Duplicate Analysis"
 msgstr "复制分析"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2067,6 +2167,7 @@ msgstr "如 SANAS, APLAC 等."
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "每个导入接口都可以定义一个为文件夹，系统在其中查找结果文件，同时在调用<code>auto_import_results</code>视图时自动导入结果."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "编辑"
@@ -2081,21 +2182,21 @@ msgstr "评估"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "电子邮件"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "电子邮件地址"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2103,27 +2204,27 @@ msgstr ""
 msgid "Email Log"
 msgstr "电子邮件日志"
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr "样品失效通知的电子邮件正文"
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr "拒收样品通知的电子邮件正文"
 
@@ -2136,17 +2237,21 @@ msgstr "电子邮件已取消"
 msgid "Email notification"
 msgstr "电子邮件通知"
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr "关于样品拒绝的电子邮件通"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
 msgstr "电子邮件已发送"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2156,27 +2261,27 @@ msgstr "不支持空键"
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "在工作表中启用多次使用仪器。"
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr "启用样品保存"
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr "启用样品检验标准"
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr "启用取样"
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr "启用取样计划"
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr "启用全局审计日志"
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr "启用全局审计日志"
 
@@ -2184,9 +2289,17 @@ msgstr "启用全局审计日志"
 msgid "Enable sampling workflow for the created sample"
 msgstr "为创建的样品启用采样工作流程"
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "启用结果报告打印工作流程"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2209,7 +2322,7 @@ msgstr "输入电子邮件地址。 如果密码丢失，这是必需的。 我�
 msgid "Enter discount percentage value"
 msgstr "输入折扣百分数值, 如7折就输30"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr "请针对每个样品为该字段输入单独的值"
 
@@ -2222,7 +2335,7 @@ msgstr "输入百分数值, 如14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "输入百分比值，如14.0 。这一比例仅在检验配置文件应用，覆盖系统的增值稅（VAT）"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "输入百分数, 如14.0. 这个百分数将作为系统值使用,但对于单个项目可以重新定义"
 
@@ -2246,7 +2359,7 @@ msgstr "输入要复制的检验服务的每一个细节。"
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "在此处输入实验室服务认证的详细信息。可以使用以下字段：lab_is_accredited，lab_name，lab_country，confidence，accreditation_body_name，accreditation_standard，accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr "用十进制或科学符号输入结果，如0.00005或1e-5，10000或1e5"
 
@@ -2258,15 +2371,15 @@ msgstr "环境条件"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr "样品编号为${sample_id}的结果发布有误"
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr "检验评价"
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr "样品评价"
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr "工作表评价"
 
@@ -2278,7 +2391,7 @@ msgstr "示例计划任务每10分钟执行一次自动导入"
 msgid "Example content"
 msgstr "示例内容"
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "从结算中排除"
 
@@ -2288,7 +2401,7 @@ msgstr "从结算中排除"
 msgid "Expected Result"
 msgstr "预期结果"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr "预期采样日期"
 
@@ -2314,7 +2427,7 @@ msgstr "过期日期"
 msgid "Exponential format precision"
 msgstr "指数格式精度"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "指数格式阈值"
 
@@ -2322,7 +2435,7 @@ msgstr "指数格式阈值"
 msgid "Export"
 msgstr "导出"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr "标签加载失败"
 
@@ -2409,7 +2522,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "文件大小"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2423,6 +2536,18 @@ msgstr "按模板服务进行筛选"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2439,11 +2564,11 @@ msgstr "名"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "浮点值从0.0 - 1000.0表示排序顺序。 重复值按字母顺序排序。"
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr "格式化配置"
 
@@ -2466,13 +2591,17 @@ msgstr "星期五"
 msgid "From"
 msgstr "自"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "全名"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "全名"
 
@@ -2480,7 +2609,7 @@ msgstr "全名"
 msgid "Function"
 msgstr "函数"
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "已预约取样时间"
 
@@ -2513,7 +2642,7 @@ msgstr "转到您的实例"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "称谓, 如先生,女士, 博士"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "当列表很长时，在LIMS表格中通过类别对服务进行分组对你很有帮助"
 
@@ -2527,7 +2656,7 @@ msgid "Hazardous"
 msgstr "危险物品"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "隐藏"
@@ -2540,8 +2669,20 @@ msgstr "隐藏字段"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2565,7 +2706,7 @@ msgstr "国际银行号码"
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2573,7 +2714,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr "ID服务器值"
 
@@ -2593,15 +2734,15 @@ msgstr "如果选中，结果条目视图中检验项目的结果字段旁边将
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "如果勾选，该仪器将不可用，直到下一个有效的校准。此复选框将自动被选中。"
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "如果启用，将在结果输入视图中的每个检验项目附近显示一个空白文本字段"
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "如果启用，则提交此检验结果的用户也可以对其进行验证。此设置对分配了角色的用户生效，允许他们复核结果（默认情况下，管理员，实验室管理员和复核者）。此处设置的选项优先于Bika Setup中设置的选项"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "如果启用，提交结果的用户也将能够验证它。此设置仅对分配了角色的用户生效，这些用户可以复核结果（默认情况下，管理员，实验室管理员和复核者）。对于Analysis Service编辑视图中的给定Analysis，此设置可以被覆盖。默认情况下，禁用。"
 
@@ -2609,7 +2750,7 @@ msgstr "如果启用，提交结果的用户也将能够验证它。此设置仅
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "如果启用，检验项目的名称将用斜体表示。"
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "如果启用，则默认情况下不会在报告中显示此检验项目及其结果。检验配置文件或样品中可以覆盖此设置"
 
@@ -2649,7 +2790,7 @@ msgstr "如果未选中，实验室管理员将无法在创建工作表时为同
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "如果您的公式需要外部Python库中的特殊函数，您可以在此处导入。例如，如果你想使用Python'math'模块中的'floor'函数，你可以在Module字段中添加'math'，在函数字段中添加'floor'。等同于Python中语句“from math import floor”。在你的计算公式中可以使用'floor（[Ca] + [Mg]）'. "
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr "立即输入结果"
 
@@ -2680,11 +2821,11 @@ msgstr "实验室内部校准操作方法"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "未激活的"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "包含并显示价格信息"
 
@@ -2881,7 +3022,7 @@ msgid "Internal Certificate"
 msgstr "内部证书"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "内部使用"
 
@@ -2902,13 +3043,13 @@ msgstr "解释模板"
 msgid "Interval"
 msgstr "间隔"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "无效"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2971,15 +3112,15 @@ msgstr "开发票"
 msgid "Invoice {} created"
 msgstr "已创建发票{}"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "发票批次无结束日期"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "发票批次无开始日期"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "发票批次无标题"
 
@@ -2991,7 +3132,7 @@ msgstr "工作岗位"
 msgid "Job title"
 msgstr "工作岗位"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr "保持以上顺序"
 
@@ -3003,9 +3144,9 @@ msgstr "关键"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "关键词"
 
@@ -3021,6 +3162,10 @@ msgstr "需要关键词"
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "多个关键词"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3065,8 +3210,8 @@ msgstr "实验物品"
 msgid "Lab URL"
 msgstr "实验室网址"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "标签"
@@ -3075,7 +3220,7 @@ msgstr "标签"
 msgid "Label configuration"
 msgstr "标签配置"
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr "标签名必须唯一"
 
@@ -3083,13 +3228,13 @@ msgstr "标签名必须唯一"
 msgid "Label schema extender"
 msgstr "标签扩展组件"
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr "带标签的对象"
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr "标签"
 
@@ -3102,7 +3247,7 @@ msgstr "实验室"
 msgid "Laboratory Accredited"
 msgstr "实验室认证"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr "实验室工作日"
 
@@ -3114,7 +3259,7 @@ msgstr "语言"
 msgid "Large Sticker"
 msgstr "大标签"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3126,11 +3271,11 @@ msgstr "最后日志自动导入"
 msgid "Last Login Time"
 msgstr "最后一次登陆时间"
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "超期"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "检验项目延期"
 
@@ -3176,15 +3321,15 @@ msgstr "链接用户"
 msgid "Link an existing User"
 msgstr "链接现有用户"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr "列出所有带标签的对象"
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr "可能的最终结果列表。设置后，结果条目上不允许有自定义结果，用户必须从这些值中进行选择"
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3208,7 +3353,7 @@ msgstr "从这里加载证书文件"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3236,6 +3381,14 @@ msgstr "地点类型"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "文件保存位置"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3299,7 +3452,7 @@ msgstr "男性"
 msgid "Manage Analyses"
 msgstr "管理检验项目"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr "管理表单字段"
 
@@ -3323,7 +3476,7 @@ msgstr "管理样品表单字段"
 msgid "Manage linked User"
 msgstr "管理链接用户"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3347,7 +3500,7 @@ msgstr "管理员电子邮件"
 msgid "Manager Phone"
 msgstr "管理员电话"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "手动"
 
@@ -3376,7 +3529,7 @@ msgstr "制造商"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr "将样品标记为仅供内部使用。这意味着只能由实验室人员访问，而不能由客户访问。"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3391,7 +3544,7 @@ msgstr "最大时间"
 msgid "Max operator"
 msgstr "最大运算符"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3426,15 +3579,15 @@ msgid "Member Discount"
 msgstr "会员折扣"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "会员折扣%"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "会员折扣可用"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr "会员已注册并链接到当前联系人。"
 
@@ -3442,7 +3595,7 @@ msgstr "会员已注册并链接到当前联系人。"
 msgid "Message sent to {}, "
 msgstr "消息发送到{}， "
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3473,7 +3626,7 @@ msgstr "中间初始"
 msgid "Middle name"
 msgstr "中间名字"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3484,7 +3637,7 @@ msgstr "最小"
 msgid "Min operator"
 msgstr "最小运算符"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3502,7 +3655,7 @@ msgstr "最少5个字符。"
 msgid "Minimum Volume"
 msgstr "最小体积"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "质量控制统计计算的最小结果数"
 
@@ -3533,6 +3686,10 @@ msgstr "模块/组件"
 msgid "Monday"
 msgstr "星期一"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3546,11 +3703,11 @@ msgstr "灵活内容的多目录行为"
 msgid "Multi Results"
 msgstr "多种结果"
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr "多次复核类型"
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr "需要多次复核"
 
@@ -3586,13 +3743,17 @@ msgstr "我的组织"
 msgid "My Profile"
 msgstr "我的个人资料"
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr "银行主要英文号码"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "名称"
 
@@ -3603,6 +3764,10 @@ msgstr ""
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
 msgstr "新范围不会应用在新检验项目或当前检验项目。 如果要应用最新变更，请重新赋予检验标准。"
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
+msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
@@ -3645,6 +3810,10 @@ msgstr "没有子组"
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
 msgstr "没有定义任何行动."
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
@@ -3692,6 +3861,10 @@ msgstr "没有变更"
 msgid "No changes made."
 msgstr "没有变更."
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr "没有设定日期"
@@ -3736,6 +3909,16 @@ msgstr "没有选择项目"
 msgid "No items selected."
 msgstr "没有选择项目。"
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "没有创建新项目。"
@@ -3743,6 +3926,10 @@ msgstr "没有创建新项目。"
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
 msgstr "没有分装"
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
+msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
@@ -3759,6 +3946,10 @@ msgstr "没有样品被拒绝"
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
 msgstr "未启用采样工作流程"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
@@ -3786,7 +3977,7 @@ msgstr "该样品没有明显的分析结果"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "没有"
 
@@ -3802,11 +3993,11 @@ msgstr "不允许更新条件：{}"
 msgid "Not defined"
 msgstr "未定义"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr "没有设置"
@@ -3827,7 +4018,7 @@ msgstr "注意:设置是全局的，适用于所有示例视图。"
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr "提示：您还可以拖放附件行以更改它们在报告中显示的顺序。"
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr "通知"
 
@@ -3839,7 +4030,7 @@ msgstr "列数"
 msgid "Number"
 msgstr "数量"
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "检验项目数量"
 
@@ -3855,16 +4046,16 @@ msgstr "复印数量"
 msgid "Number of prominent columns"
 msgstr "突出列数"
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "复核次数"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "在给定结果被视为“已复核”之前所需的复核数量。对于检验项目服务编辑视图中的任何检验项目，都可以覆盖此设置。默认情况下：1"
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "在将此检验项目的给定结果视为“已复核”之前，来自具有足够权限的不同用户所需的验证数。此处设置的选项优先于Bika Setup中设置的选项"
 
@@ -3875,6 +4066,10 @@ msgstr "标准数列"
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
 msgstr "数字"
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
+msgstr ""
 
 #: bika/lims/content/preservation.py:53
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
@@ -3892,11 +4087,11 @@ msgstr "只有图像可以直接在报告中呈现"
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr "只有配置了导入接口的仪器才会显示"
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr "对于分析周转时间计算，仅考虑实验室工作日 "
 
@@ -3904,13 +4099,13 @@ msgstr "对于分析周转时间计算，仅考虑实验室工作日 "
 msgid "Only to empty or zero fields"
 msgstr "只有空或零字段"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "打开"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr "待处理 / 待验证 / 已验证 / 总计"
 
@@ -3918,9 +4113,17 @@ msgstr "待处理 / 待验证 / 已验证 / 总计"
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "基于开源网页式的实验室信息管理系统"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
 msgstr "打开电子邮件表格，将选定的报告发送给收件人。成功发送电子邮件后，还将发布报告中包含的样品。"
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
+msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -3947,7 +4150,7 @@ msgstr "其他原因"
 msgid "Other reasons:"
 msgstr "其他原因："
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr "其他状态"
 
@@ -3969,11 +4172,11 @@ msgstr "覆盖已有的分析结果"
 msgid "Override non-empty analysis results, also with empty"
 msgstr "清空已有的分析结果"
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4070,11 +4273,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr "请从列表中选择一个用户"
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4087,6 +4290,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr "请选择要创建的分装数量，然后按预览按钮"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr "请说明原因"
 
@@ -4106,12 +4310,16 @@ msgstr "请使用以下格式选择选项：key1:value1 |key2:value2 |…|keyn:v
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr "请在发送所列样品的地方写一条评论"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "捕获点"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4150,31 +4358,31 @@ msgstr "小数位数"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "精度为根据不确定性的有效位数。小数位置将由不确定性中不同于零的第一个数字给出，在该位置系统将对不确定性和结果进行舍入。例如，结果为5.243，不确定度为0.22，系统将正确显示为5.2 ±0.2。如果没有为结果设置不确定性范围，系统将使用固定精度设置。"
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr "预定义结果"
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "首选报告小数点标记."
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "首选结果小数点标记"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr "“工作表”视图中结果条目表的首选布局。经典布局在行中显示样品，在列中显示检验项目。转置布局显示列中的样品和行中的检验项目。"
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "优先的报告科学计数法格式"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "优先的结果科学计数法格式"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4207,7 +4415,7 @@ msgstr "每种样品类型的保存"
 msgid "Preserve"
 msgstr "保留"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "保管人"
 
@@ -4224,11 +4432,11 @@ msgstr "预防"
 msgid "Preventive maintenance procedure"
 msgstr "预防性维护程序"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr "预览"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4256,7 +4464,7 @@ msgstr "价目表"
 msgid "Pricelists"
 msgstr "价目表"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4265,7 +4473,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "主样品"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4287,11 +4495,11 @@ msgstr "打印日期："
 msgid "Print pricelist"
 msgstr "打印价目表"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "打印标签"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "已打印"
 
@@ -4304,7 +4512,7 @@ msgstr "印有"
 msgid "Priority"
 msgstr "优先级"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "配置文件"
 
@@ -4328,7 +4536,7 @@ msgstr "配置文件名称"
 msgid "Profile keyword must be unique"
 msgstr "配置文件关键字必须是唯一的"
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "进度"
 
@@ -4337,7 +4545,7 @@ msgstr "进度"
 msgid "Prominent fields"
 msgstr "突出的领域"
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "操作规程ID"
 
@@ -4345,7 +4553,7 @@ msgstr "操作规程ID"
 msgid "Province"
 msgstr "省"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4354,8 +4562,12 @@ msgstr ""
 msgid "Publish"
 msgstr "发布"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "发布"
@@ -4371,6 +4583,10 @@ msgstr "发布日期"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "已发布结果"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4392,6 +4608,14 @@ msgstr "质控结果"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "质控样品ID"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4417,7 +4641,7 @@ msgstr "重新输入密码，确保密码是相同的。"
 msgid "Reasons for rejection"
 msgstr "拒收理由"
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "重新分派"
 
@@ -4429,30 +4653,34 @@ msgstr "可重新分派的跟踪任务"
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr "重新计算"
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "接收"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "已收到"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr "待接收"
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "收件人"
 
@@ -4503,11 +4731,15 @@ msgstr "参考值"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "样品参考值为0或'空白'"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "注册"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4533,9 +4765,9 @@ msgstr "剔除分析"
 msgid "Reject samples"
 msgstr "拒收样品"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "已拒收"
 
@@ -4551,7 +4783,7 @@ msgstr "已拒收样品"
 msgid "Rejected {} samples: {}"
 msgstr "已拒收 {} 样本: {}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4612,8 +4844,16 @@ msgstr "远程IP"
 msgid "Remove"
 msgstr "移除"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4649,11 +4889,11 @@ msgstr "报告ID"
 msgid "Report identification number"
 msgstr "报表编号"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4665,7 +4905,7 @@ msgstr "报告上传"
 msgid "Republish"
 msgstr "重新发布"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "最后一次打印后重新发布"
 
@@ -4674,7 +4914,7 @@ msgstr "最后一次打印后重新发布"
 msgid "Request ID"
 msgstr "请检单ID"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "请检新检验项目"
 
@@ -4690,24 +4930,37 @@ msgstr "需求体积"
 msgid "Reset"
 msgstr "重新设置"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr "重置列"
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
 msgstr "主管"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr "恢复"
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4732,15 +4985,15 @@ msgstr "结果值必须是数字"
 msgid "Result Value must be unique"
 msgstr "结果值必须唯一"
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "误差范围允许内的结果"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "结果超标"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr "结果范围与检验标准不同：{}"
 
@@ -4748,7 +5001,7 @@ msgstr "结果范围与检验标准不同：{}"
 msgid "Result type"
 msgstr "结果类型"
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "结果中显示的数值小数点后有效数字位数不少于这个值，同时使用科学计数法，用\"e\"表示指数符号。精确度可以在各个检验项目服务中进行配置。"
 
@@ -4764,16 +5017,20 @@ msgstr "结果"
 msgid "Results Interpretation"
 msgstr "结果说明"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "结果被撤销"
 
@@ -4781,7 +5038,7 @@ msgstr "结果被撤销"
 msgid "Results interpretation"
 msgstr "结果说明"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "结果待定"
 
@@ -4805,7 +5062,7 @@ msgstr "已复测"
 msgid "Retract"
 msgstr "撤销"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4841,6 +5098,10 @@ msgstr "回滚"
 msgid "Routine Analyses"
 msgstr "常规检验项目"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr "LIMS核心组件"
@@ -4866,6 +5127,7 @@ msgstr "SENAITE LIMS首页"
 msgid "SENAITE Registry"
 msgstr "SENAITE注册表"
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4875,7 +5137,7 @@ msgstr "SENAITE 设置"
 msgid "SENAITE front-page"
 msgstr "SENAITE 首页"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "SMTP服务器断开连接，用户创建已中止。"
 
@@ -4889,7 +5151,7 @@ msgstr "称呼"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "样品"
 
@@ -4926,7 +5188,7 @@ msgid "Sample Header"
 msgstr "样品标题"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "样品编号"
 
@@ -4946,7 +5208,7 @@ msgstr "样品基质"
 msgid "Sample Partitions"
 msgstr "样品分装"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4973,7 +5235,7 @@ msgid "Sample Templates"
 msgstr "样品模板集"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "样品类型"
@@ -5034,7 +5296,7 @@ msgstr "样品类型"
 msgid "SampleTypes"
 msgstr "样品类型"
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "取样人"
 
@@ -5046,8 +5308,8 @@ msgstr "采样人已分配给计划采样"
 msgid "Sampler required for sample %s"
 msgstr "样品 %s 所需采样人"
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "样品"
@@ -5064,6 +5326,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5073,7 +5347,23 @@ msgstr "该类型的样品需要作为\"危险废弃物\"处理"
 msgid "Samples rejection reporting form"
 msgstr "样品拒收报告表"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5081,7 +5371,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "取样日期"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "取样偏差"
@@ -5094,7 +5384,7 @@ msgstr "取样偏差"
 msgid "Sampling Frequency"
 msgstr "取样频率"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "取样计划"
 
@@ -5102,15 +5392,24 @@ msgstr "取样计划"
 msgid "Saturday"
 msgstr "星期六"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "保存"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
 msgstr "保存和复制"
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5124,7 +5423,7 @@ msgstr "计划/日程表"
 msgid "Schedule sampling"
 msgstr "计划取样"
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "已计划取样"
@@ -5141,6 +5440,10 @@ msgstr "科学名称/学名"
 msgid "Search"
 msgstr "搜索"
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5149,7 +5452,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "秒"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5239,11 +5542,11 @@ msgstr ""
 msgid "Select template"
 msgstr "选择模板"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "选择该网站默认显示的国家"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "选择用于网站显示价格的货币种类."
 
@@ -5255,11 +5558,11 @@ msgstr "选择要用于此分析服务的默认容器。如果要使用的容器
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "选择默认登录页面。当客户端用户登录系统时，或从客户端文件夹列表中选择客户端时，将使用此选项。"
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5267,31 +5570,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr "选择此ID用于标识的类型。"
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr "选择此选项可在拒绝样品时通过电子邮件激活自动通知客户。"
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "选择此选项可将仪表板激活为默认首页。"
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "选此激活取样作流程."
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "选择此项以允许取样协调员安排采样。此功能仅在“取样工作流程”处于活动状态时生效"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr "选择此项，可允许用户为已发布的分析请求设置额外的 “已打印” 状态。此功能默认禁用。"
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr "选择此选项可在实验室人员创建且采样工作流程被禁用时自动接收样品。客户联系人创建的样本将不会被自动接收"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr "选择向客户联系人显示分装样品。如果停用，分装将不会包含在列表中，并且没有与初级样品链接的信息会显示给客户联系人。"
 
@@ -5303,7 +5614,7 @@ msgstr "选择工作表中需要包含的检验项目"
 msgid "Selection list"
 msgstr "选择列表"
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "结果自我复核"
 
@@ -5315,11 +5626,11 @@ msgstr "发送"
 msgid "Send Analysis Reports via Email"
 msgstr "通过电子邮件发送检验报告单"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5341,7 +5652,7 @@ msgstr "发送至"
 msgid "Separate Container"
 msgstr "单独的容器"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5355,7 +5666,7 @@ msgstr "序列号"
 msgid "Service"
 msgstr "服务"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr "无法取消选择服务。请单击信息按钮以获取更多详细信息"
 
@@ -5383,7 +5694,7 @@ msgstr "设置样品拒收工作流程和原因"
 msgid "Set the maintenance task as closed."
 msgstr "设置维护任务为关闭状态."
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr "如果启用了“关于样品拒绝的电子邮件通知”选项，则设置电子邮件发送到样品的客户端联系人。你可以使用保留关键字:$sample_id, $sample_link, $reasons, $lab_address"
 
@@ -5431,29 +5742,41 @@ msgstr "这些检验项目是否应从发票中排除？"
 msgid "Should the default example content be added to the site?"
 msgstr "是否应该将默认示例内容添加到站点中？"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
 msgstr "显示所有"
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
+msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr "显示上次自动导入日志"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr "显示更多"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
 msgstr "显示标准字段"
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5475,11 +5798,11 @@ msgstr "站点编码"
 msgid "Site Description"
 msgstr "站点描述"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr "网站Logo"
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr "网站logo CSS"
 
@@ -5500,7 +5823,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "小标签"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5517,6 +5840,14 @@ msgstr "一些分析使用过时或未校准的仪器。结果发布不允许"
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "排序关键字"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5542,7 +5873,7 @@ msgstr "检验标准范围自分派后已变更"
 msgid "Specifications"
 msgstr "检验标准"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5550,7 +5881,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "指定工作表的大小，例如对应于特定仪器的托盘尺寸。然后选择每个工作表位置的分析'类型'。选择质控样品时，还要选择应使用哪个参考样品。如果选择了复制分析，请指出它应该是哪个样品位置"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5567,17 +5898,17 @@ msgstr "开始日期"
 msgid "Start date must be before End Date"
 msgstr "开始日期必须早于结束日期"
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "州/省"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "状态"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "标签"
@@ -5586,7 +5917,11 @@ msgstr "标签"
 msgid "Stickers preview"
 msgstr "标签预览"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "存储位置"
@@ -5626,7 +5961,11 @@ msgstr "提交"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr "提交包含安装记录的有效Open XML（.XLSX）文件以继续."
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "由同一用户提交并复核：{}"
 
@@ -5634,7 +5973,7 @@ msgstr "由同一用户提交并复核：{}"
 msgid "Submitter"
 msgstr "提交人"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "子项总计"
@@ -5676,7 +6015,7 @@ msgstr "切换到进度仪表板"
 msgid "Switch to transposed view"
 msgstr "切换到转置视图"
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "系统默认"
 
@@ -5702,7 +6041,7 @@ msgstr "税"
 msgid "Technical description and instructions intended for analysts"
 msgstr "针对检验人员的技术说明和说明"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5784,7 +6123,7 @@ msgstr "样品保存的日期"
 msgid "The date when the sample was received"
 msgstr "收到样品的日期"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "将使用在Bika Setup中选择的小数点。"
 
@@ -5792,7 +6131,7 @@ msgstr "将使用在Bika Setup中选择的小数点。"
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr "操控版的默认时区设置。 如果在日期和时间设置中定义了可用时区，用户将能够设置他们自己的时区。"
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "此处输入的折扣百分比适用于标记为“会员”的客户的价格，通常是合作成员或应享有此折扣的员工"
 
@@ -5820,7 +6159,11 @@ msgstr "已从此样品创建以下分装："
 msgid "The following sample(s) will be dispatched"
 msgstr "将分发以下样品"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr "全局审计日志显示系统的所有修改。当启用时，所有的实体将被索引在一个单独的目录中。这将增加对象被创建或修改的时间。"
 
@@ -5828,11 +6171,11 @@ msgstr "全局审计日志显示系统的所有修改。当启用时，所有的
 msgid "The height or depth at which the sample has to be taken"
 msgstr "取样时必须达到高度或深度"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr "该样品及分析项目的保存时间已过。继续进行分析可能会影响结果的可靠性。"
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr "该样品及其分析项目的保存时间即将到期。请尽快完成分析，以确保数据的准确性和可靠性。"
 
@@ -5869,11 +6212,11 @@ msgstr "检验需要的最小样品量，如：10mL或者1Kg。"
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "样品有效天数, 过期的样品将不能分析. 该设置可以在样品类型设置中为具体样品类型重置"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "用户登录后能够停留的分钟数, 超过此数用户会被自动注销. 0表示不会自动注销"
 
@@ -5913,7 +6256,7 @@ msgstr "认可机构向实验室发放的参考代码"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "计算结果与测试值一起进行。在计算此值之前，您需要保存计算。"
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr "分析结果是在超过保存时间限制后获取的。"
 
@@ -5937,11 +6280,11 @@ msgstr "样品是子样品的混合物"
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "仪器唯一序列号"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "分析服务的协议ID"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "用于会计服务的商业ID"
 
@@ -5993,11 +6336,11 @@ msgstr "本二级样本归属于"
 msgid "This is a detached partition from Sample"
 msgstr "这是分装后的独立样品"
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr "这是进行检验所允许的默认最长时间。它仅用于分析服务未指定检验的检验项目。只考虑实验室工作日。"
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6021,11 +6364,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr "为防止分析操作超出规定的分析保存时间，无法选择此服务。"
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr "这显示了您的SENAITE网站上的一个定制Logo"
 
@@ -6057,8 +6400,8 @@ msgstr "时间"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "提示：附加文件将不会加载除非他们在样本呈现。"
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "标题"
@@ -6085,34 +6428,42 @@ msgstr "站点名称"
 msgid "To"
 msgstr "至"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "需要保留"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "待取样"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "要在结果报告的每个“检验项目类别”部分的下方显示。"
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "需要保留"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "等待打印"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "等待取样"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "等待复核"
@@ -6125,7 +6476,7 @@ msgstr "要测试计算，请在此处输入所有计算参数的值。这包括
 msgid "Toggle visibility of standard sample header fields"
 msgstr "切换标准示例标题字段的可见性"
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "总计"
 
@@ -6147,7 +6498,7 @@ msgid "Tuesday"
 msgstr "星期二"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "类型"
@@ -6172,6 +6523,10 @@ msgstr "条件类型"
 msgid "Type to filter ..."
 msgstr "键入以筛选..."
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr "支持直接标签的类型。<br/>注意：在集群设置中，需要手动重启其他实例才能更改有效！"
@@ -6180,7 +6535,7 @@ msgstr "支持直接标签的类型。<br/>注意：在集群设置中，需要�
 msgid "Types with labels"
 msgstr "带标签的类型"
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6192,6 +6547,7 @@ msgstr "无法加载模板"
 msgid "Unassign"
 msgstr "取消分派"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "没有分派"
@@ -6224,9 +6580,13 @@ msgstr "未知国际银行账号国家%s"
 msgid "Unlink User"
 msgstr "取消关联用户"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
 msgstr "取消关联的用户"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
+msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
@@ -6242,13 +6602,17 @@ msgstr "无法识别文件格式 ${file_format}"
 msgid "Unrecognized file format ${format}"
 msgstr "无法识别文件格式 ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "未分派"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "更新附件"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6258,7 +6622,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "上传一个用于打印分析报告的签名扫描件. 理想尺寸为250像素宽, 150像素高"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6266,7 +6630,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "使用检验配置文件价格目录"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "使用仪表进度板作为默认首页"
 
@@ -6304,7 +6668,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr "用户链接到此联系人"
 
@@ -6312,15 +6676,15 @@ msgstr "用户链接到此联系人"
 msgid "User name"
 msgstr "用户名"
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "使用太少的数据点不具有统计意义。请在计算和绘制QC统计数据之前，设置可接受的最小结果数"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6328,7 +6692,7 @@ msgstr "增值税"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "增值税%"
 
@@ -6575,8 +6939,8 @@ msgstr "秒数的值必须在 0 到 59.9999 之间"
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "可在此处输入的值将覆盖在计算临时字段指定的默认值。"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "已复核"
@@ -6585,11 +6949,19 @@ msgstr "已复核"
 msgid "Verified By"
 msgstr "复核人"
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "复核"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6604,6 +6976,14 @@ msgstr "示图"
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
 msgstr "浏览LIMS"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr ""
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -6638,6 +7018,10 @@ msgstr "网站"
 msgid "Wednesday"
 msgstr "星期三"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "几周后过期"
@@ -6650,19 +7034,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr "欢迎来到LIMS"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr "启用后，一旦验证所有结果，就会自动验证样品。 否则，具有足够权限的用户必须随后手动验证样本。 默认值：启用"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6713,10 +7097,18 @@ msgstr "工作表模板"
 msgid "Worksheet printing templates order"
 msgstr "工作表打印模板顺序"
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "工作表"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6725,6 +7117,10 @@ msgstr "国际银行账户号码（IBAN）有误， %s：实际为 %s"
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "错误的IBAN账号长度%s: %s 用短的 %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6808,6 +7204,10 @@ msgstr "重复分析类型"
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6912,8 +7312,17 @@ msgstr "天"
 msgid "deactivate"
 msgstr "停用"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr "项目阶段"
 
@@ -6979,7 +7388,7 @@ msgstr "分析数据最长保留时间"
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 #, fuzzy
 msgid "description_analysis_results_options_sorting"
 msgstr "分析结果排序方式"
@@ -7155,27 +7564,27 @@ msgstr "批量处理客户端描述"
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 #, fuzzy
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr "允许手动捕获结果日期"
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 #, fuzzy
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr "总是在报告邮件中抄送负责人"
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr "说明 bika 设置分类样本分析"
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 #, fuzzy
 msgid "description_bikasetup_date_sampled_required"
 msgstr "系统中关于样品采集时间的描述"
@@ -7183,7 +7592,7 @@ msgstr "系统中关于样品采集时间的描述"
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 #, fuzzy
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr "说明 bika设置电子邮件正文样本发布"
@@ -7191,7 +7600,7 @@ msgstr "说明 bika设置电子邮件正文样本发布"
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 #, fuzzy
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr "Bika 设置说明 - 样品管理员邮箱"
@@ -7199,7 +7608,7 @@ msgstr "Bika 设置说明 - 样品管理员邮箱"
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 #, fuzzy
 msgid "description_bikasetup_immediateresultsentry"
 msgstr "描述 bika 设置立即输入结果"
@@ -7212,19 +7621,19 @@ msgstr "描述 bika 设置立即输入结果"
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7245,16 +7654,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7279,12 +7693,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7294,7 +7708,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7397,6 +7811,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7426,6 +7853,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7572,12 +8006,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7830,7 +8264,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7838,108 +8272,108 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr "描述senaite设置分类样本分析"
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 #, fuzzy
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr "描述 senaite设置立即输入结果"
@@ -7947,56 +8381,56 @@ msgstr "描述 senaite设置立即输入结果"
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 #, fuzzy
 msgid "description_senaitesetup_publication_email_text"
 msgstr "说明 senaite设置发布电子邮件文本"
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -8004,47 +8438,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8053,20 +8487,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8074,32 +8508,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8107,21 +8541,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8277,6 +8711,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8589,7 +9027,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8650,7 +9088,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8766,52 +9204,52 @@ msgid "label_batch_client"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr "标签bika设置分类和样本分析"
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr "标签 bika 设置电子邮件正文模板发布"
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr "标签 bika 设置立即结果条目"
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8881,12 +9319,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8896,7 +9334,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9192,7 +9630,7 @@ msgid "label_powered_by_plone"
 msgstr "标签由plone赞助"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9317,12 +9755,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9532,7 +9970,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr "标签保存"
 
@@ -9542,12 +9980,12 @@ msgid "label_senaite"
 msgstr "标签_senalte"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9605,6 +10043,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10781,87 +11235,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10914,6 +11368,11 @@ msgstr ""
 msgid "minutes"
 msgstr "分钟"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "每月"
@@ -10964,13 +11423,21 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
 msgstr "的"
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
+msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "概览"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11048,6 +11515,11 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
 msgstr "该样品已由"
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
+msgstr ""
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11281,13 +11753,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11374,6 +11851,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11619,222 +12101,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr "标题senaite设置分类 样本分析"
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr "标题senaite设置发布电子邮件文本"
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12088,7 +12570,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr "待复核"
 
@@ -12131,7 +12613,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr "{} (已超时)"
 

--- a/src/senaite/core/locales/zh_TW/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/zh_TW/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: ZZZ, 2024\n"
 "Language-Team: Chinese (Taiwan) (https://app.transifex.com/senaite/teams/87045/zh_TW/)\n"

--- a/src/senaite/core/locales/zh_TW/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/zh_TW/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: ZZZ, 2024\n"
 "Language-Team: Chinese (Taiwan) (https://app.transifex.com/senaite/teams/87045/zh_TW/)\n"
@@ -903,6 +903,11 @@ msgstr ""
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
+msgstr ""
+
+#. Default: "No image"
+#: senaite/core/z3cform/widgets/namedimage/display.pt:17
+msgid "no_image"
 msgstr ""
 
 #. Default: "Plain Text"

--- a/src/senaite/core/locales/zh_TW/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/zh_TW/LC_MESSAGES/senaite.core.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 09:17+0000\n"
+"POT-Creation-Date: 2026-07-19 12:29+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Chinese (Taiwan) (https://app.transifex.com/senaite/teams/87045/zh_TW/)\n"

--- a/src/senaite/core/locales/zh_TW/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/zh_TW/LC_MESSAGES/senaite.core.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-19 06:37+0000\n"
+"POT-Creation-Date: 2026-07-19 09:17+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Chinese (Taiwan) (https://app.transifex.com/senaite/teams/87045/zh_TW/)\n"
@@ -22,7 +22,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: zh_TW\n"
 
-#: bika/lims/content/bikasetup.py:1134
+#: bika/lims/content/bikasetup.py:1135
 msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
 msgstr ""
 
@@ -31,6 +31,7 @@ msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} 附件總的大小為 ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr ""
@@ -56,6 +57,7 @@ msgid "%s has no '%s' column."
 msgstr "%s 沒有「%s」欄。"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
+#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; 返回"
@@ -125,6 +127,10 @@ msgstr ""
 msgid "+-"
 msgstr "±"
 
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
 msgstr ""
@@ -142,7 +148,7 @@ msgstr ""
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> 歡迎來到 SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1181
+#: senaite/core/content/senaitesetup.py:1204
 msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
 msgstr ""
 
@@ -200,7 +206,7 @@ msgid "Account Type"
 msgstr "帳户類型"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1273
+#: senaite/core/content/senaitesetup.py:1296
 msgid "Accounting"
 msgstr ""
 
@@ -245,21 +251,21 @@ msgstr "激活"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:70
+#: senaite/core/browser/controlpanel/labels/view.py:71
 msgid "Active"
 msgstr "運作中"
 
-#: senaite/core/content/resultsreport.py:51
+#: senaite/core/content/resultsreport.py:52
 msgid "Actor"
 msgstr "操作人"
 
-#: senaite/core/content/resultsreport.py:56
+#: senaite/core/content/resultsreport.py:57
 msgid "Actor Fullname"
 msgstr ""
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:45
+#: senaite/core/browser/controlpanel/labels/view.py:46
 msgid "Add"
 msgstr "添加"
 
@@ -287,15 +293,19 @@ msgstr "添加重複樣"
 msgid "Add Samples"
 msgstr "新增樣本"
 
-#: bika/lims/content/bikasetup.py:460
+#: senaite/core/api/remarks.py:492
+msgid "Add a remark..."
+msgstr ""
+
+#: bika/lims/content/bikasetup.py:461
 msgid "Add a remarks field to all analyses"
 msgstr "在所有分析加入添加備註欄"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:321
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/controlpanel/labels/view.py:53
 msgid "Add default selectable labels"
 msgstr "新增預設可選標籤"
 
@@ -308,8 +318,11 @@ msgstr "新增附件"
 msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
 msgstr "附上一個或多個樣本或請求的說明文"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
-#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
+#: senaite/core/browser/samples/view.py:879
+msgid "Add or remove labels on the selected samples"
+msgstr ""
+
+#: senaite/core/api/remarks.py:477
 msgid "Add remarks"
 msgstr "添加備註"
 
@@ -373,13 +386,21 @@ msgstr "所有已認證的分析服務均列于此."
 msgid "All Analyses of Service"
 msgstr "所有現有的分析"
 
-#: senaite/core/browser/samples/view.py:585
+#: senaite/core/browser/samples/view.py:723
 msgid "All analyses assigned"
 msgstr "所有已分派分析"
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "容許手動輸入檢出限"
+
+#: bika/lims/content/abstractbaseanalysis.py:728
+msgid "Allow Manual Entry"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
@@ -397,11 +418,11 @@ msgstr "容許同一用戶多次審核"
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "容許同一用戶多次審核，單非連續審核"
 
-#: bika/lims/content/bikasetup.py:492
+#: bika/lims/content/bikasetup.py:493
 msgid "Allow self-verification of results"
 msgstr "允許審核自己的結果"
 
-#: bika/lims/content/bikasetup.py:189
+#: bika/lims/content/bikasetup.py:190
 msgid "Allow submission of results for unassigned analyses"
 msgstr ""
 
@@ -430,15 +451,31 @@ msgstr ""
 msgid "Analysed by"
 msgstr "分析師："
 
-#: senaite/core/browser/dashboard/dashboard.py:459
+#: senaite/core/browser/dashboard/dashboard.py:506
+#: senaite/core/browser/samples/view.py:248
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
-#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "分析"
+
+#: senaite/core/browser/dashboard/dashboard.py:485
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:498
+msgid "Analyses included in a published report"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:480
+msgid "Analyses not yet assigned to a worksheet"
+msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
 msgstr "已請求的分析"
+
+#: senaite/core/browser/dashboard/dashboard.py:494
+msgid "Analyses that have been verified"
+msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -507,7 +544,7 @@ msgstr "分析條件"
 msgid "Analysis conditions updated: {}"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:412
 msgid "Analysis specifications which are edited directly on the Sample."
 msgstr "直接為樣本編輯分析規格"
 
@@ -544,7 +581,7 @@ msgstr "必須指定分析師"
 msgid "Any"
 msgstr "任何"
 
-#: senaite/core/content/senaitesetup.py:1322
+#: senaite/core/content/senaitesetup.py:1345
 msgid "Appearance"
 msgstr ""
 
@@ -555,6 +592,10 @@ msgstr "應用"
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "應用樣板"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
@@ -568,19 +609,15 @@ msgstr "資產編號"
 msgid "Assign"
 msgstr "分派"
 
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:147
+#: senaite/core/browser/samples/view.py:443
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "已分派"
 
-#: bika/lims/browser/analyses/view.py:1665
+#: bika/lims/browser/analyses/view.py:1666
 msgid "Assigned to: ${worksheet_id}"
 msgstr "分派到：${worksheet_id}"
-
-#: senaite/core/browser/dashboard/dashboard.py:122
-msgid "Assignment pending"
-msgstr "待辦任務"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
@@ -594,7 +631,7 @@ msgstr ""
 msgid "Attached file '{filename}' to worksheet {worksheet}"
 msgstr ""
 
-#: senaite/core/extender/label.py:58
+#: senaite/core/extender/label.py:62
 msgid "Attached labels"
 msgstr ""
 
@@ -682,11 +719,15 @@ msgstr ""
 msgid "Auto-Import Logs"
 msgstr "自動導入記錄"
 
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
 msgstr "接收時自動分樣"
 
-#: senaite/core/content/senaitesetup.py:1007
+#: senaite/core/content/senaitesetup.py:1030
 msgid "Auto-receive samples"
 msgstr "自動接收樣本"
 
@@ -694,15 +735,15 @@ msgstr "自動接收樣本"
 msgid "Autofill"
 msgstr "自動填充"
 
-#: senaite/core/content/senaitesetup.py:1107
+#: senaite/core/content/senaitesetup.py:1130
 msgid "Automatic Sticker Printing"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:161
+#: bika/lims/content/bikasetup.py:162
 msgid "Automatic log-off"
 msgstr "自動登出"
 
-#: bika/lims/content/bikasetup.py:475
+#: bika/lims/content/bikasetup.py:476
 msgid "Automatic verification of samples"
 msgstr ""
 
@@ -753,7 +794,7 @@ msgstr "批次"
 msgid "Batch Book"
 msgstr "批量簿"
 
-#: senaite/core/browser/samples/view.py:174
+#: senaite/core/browser/samples/view.py:186
 msgid "Batch ID"
 msgstr "批次ID"
 
@@ -783,6 +824,10 @@ msgstr ""
 msgid "Bearing"
 msgstr "軸承"
 
+#: senaite/core/browser/dashboard/dashboard.py:139
+msgid "Biannual"
+msgstr ""
+
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
 msgstr "賬單地址"
@@ -803,7 +848,7 @@ msgstr "品牌"
 msgid "Bulk Discount"
 msgstr "批量折扣"
 
-#: bika/lims/content/client.py:75
+#: bika/lims/content/client.py:77
 #: bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
 msgstr "已使用大宗折扣"
@@ -821,19 +866,19 @@ msgstr "業務/辦公室電話"
 msgid "Business address"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:759
 msgid "By 'Display Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:757
+#: bika/lims/content/abstractbaseanalysis.py:760
 msgid "By 'Display Value' descending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:754
+#: bika/lims/content/abstractbaseanalysis.py:757
 msgid "By 'Result Value' ascending"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:755
+#: bika/lims/content/abstractbaseanalysis.py:758
 msgid "By 'Result Value' descending"
 msgstr ""
 
@@ -841,12 +886,12 @@ msgstr ""
 msgid "CBID"
 msgstr "CBID"
 
-#: bika/lims/content/client.py:129
+#: bika/lims/content/client.py:133
 msgid "CC Contacts"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:162
+#: bika/lims/content/client.py:166
 msgid "CC Emails"
 msgstr "抄送電郵地址"
 
@@ -902,23 +947,23 @@ msgstr "校準"
 msgid "Calibrator"
 msgstr "校準師"
 
-#: bika/lims/browser/analyses/view.py:1613
+#: bika/lims/browser/analyses/view.py:1614
 msgid "Can verify, but submitted by current user"
 msgstr "可以審核，但由當前用戶提交"
 
-#: bika/lims/browser/analyses/view.py:1637
+#: bika/lims/browser/analyses/view.py:1638
 msgid "Can verify, but was already verified by current user"
 msgstr "可以審核，但已由其它用戶審核"
 
+#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
-#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "取消"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/view.py:373
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/browser/samples/dispose_samples.py:70
+#: senaite/core/browser/samples/view.py:403
 msgid "Cancelled"
 msgstr "已取消"
 
@@ -938,15 +983,15 @@ msgstr ""
 msgid "Cannot send email for ${sample_id}: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1643
+#: bika/lims/browser/analyses/view.py:1644
 msgid "Cannot verify, last verified by current user"
 msgstr "無法審核，對上一次由當前用戶審核"
 
-#: bika/lims/browser/analyses/view.py:1619
+#: bika/lims/browser/analyses/view.py:1620
 msgid "Cannot verify, submitted by current user"
 msgstr "無法審核，由當前用戶提交"
 
-#: bika/lims/browser/analyses/view.py:1628
+#: bika/lims/browser/analyses/view.py:1629
 msgid "Cannot verify, was verified by current user"
 msgstr "無法審核，已由當前用戶審核"
 
@@ -972,7 +1017,7 @@ msgstr "將靈活內容歸類到多個目錄"
 msgid "Catalogue Number"
 msgstr "類别號碼"
 
-#: bika/lims/content/bikasetup.py:354
+#: bika/lims/content/bikasetup.py:355
 msgid "Categorise analysis services"
 msgstr "分類分析服務"
 
@@ -1004,11 +1049,11 @@ msgid "Changes Saved"
 msgstr "已保存更改"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:114
+#: senaite/core/browser/viewlets/sampleheader.py:125
 msgid "Changes saved."
 msgstr "已保存更改。"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
 msgid "Changes will be propagated to partitions"
 msgstr "所做的更動會應用到所有分樣"
 
@@ -1045,31 +1090,31 @@ msgstr "複選框"
 msgid "Choices"
 msgstr "選項"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1174
 msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1037
+#: bika/lims/content/bikasetup.py:1038
 msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1139
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1018
+#: bika/lims/content/bikasetup.py:1019
 msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:530
 msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:976
+#: bika/lims/content/bikasetup.py:977
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1108
+#: senaite/core/content/senaitesetup.py:1131
 msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
 msgstr ""
 
@@ -1082,12 +1127,26 @@ msgstr "城市"
 msgid "Classic"
 msgstr "典型的"
 
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing
+# search
+msgid "Clear search"
+msgstr ""
+
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
 msgid "Click to expand this category"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the
+# applied preset
+msgid "Click to release this filter"
 msgstr ""
 
 # senaite.app.listing: TableColumnConfig
@@ -1095,7 +1154,7 @@ msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "點擊以切換可見性或拖放以更改順序"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:191
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "客户"
@@ -1107,7 +1166,7 @@ msgstr "客戶批次ID"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:184
+#: senaite/core/browser/samples/view.py:196
 msgid "Client ID"
 msgstr "客户編號"
 
@@ -1119,7 +1178,7 @@ msgstr "客戶登錄頁面"
 msgid "Client Name"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:132
+#: senaite/core/browser/samples/view.py:144
 msgid "Client Order"
 msgstr "客户訂單"
 
@@ -1129,7 +1188,7 @@ msgstr "客户訂單"
 msgid "Client Order Number"
 msgstr "客户訂單號碼"
 
-#: senaite/core/browser/samples/view.py:189
+#: senaite/core/browser/samples/view.py:201
 msgid "Client Ref"
 msgstr "客户參考/參閱"
 
@@ -1138,7 +1197,7 @@ msgstr "客户參考/參閱"
 msgid "Client Reference"
 msgstr "客户參考/參閱"
 
-#: senaite/core/browser/samples/view.py:194
+#: senaite/core/browser/samples/view.py:206
 msgid "Client SID"
 msgstr "客户樣品編號"
 
@@ -1231,7 +1290,7 @@ msgstr "評論, 意見"
 msgid "Comments or results interpretation"
 msgstr "評論或解釋結果"
 
-#: bika/lims/content/abstractbaseanalysis.py:853
+#: bika/lims/content/abstractbaseanalysis.py:856
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
 msgstr "商業ID"
@@ -1269,6 +1328,10 @@ msgstr ""
 msgid "Configuration restored to default values."
 msgstr ""
 
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
 msgstr "配置表列"
@@ -1287,7 +1350,7 @@ msgstr "確定密碼"
 msgid "Considerations"
 msgstr "考慮"
 
-#: senaite/core/browser/samples/view.py:197
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "聯絡"
@@ -1331,7 +1394,7 @@ msgstr "多個容器"
 msgid "Contents of the file {}"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:223
+#: senaite/core/content/senaitesetup.py:224
 msgid "Context"
 msgstr ""
 
@@ -1364,15 +1427,15 @@ msgstr "複製分析服務"
 msgid "Copy from"
 msgstr "複製自"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
 msgid "Copy the currently displayed column value to the other columns on the right"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
 msgid "Copy the value of the first sample to the others"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:742
+#: senaite/core/browser/samples/view.py:901
 msgid "Copy to new"
 msgstr "複製到新的"
 
@@ -1382,6 +1445,10 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
 msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgstr ""
+
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
+msgid "Could not link User: ${error}"
 msgstr ""
 
 #: bika/lims/browser/workflow/client.py:52
@@ -1400,11 +1467,11 @@ msgstr ""
 msgid "Counter <span class=\"sort-indicator\" />"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:235
+#: senaite/core/content/senaitesetup.py:236
 msgid "Counter Ref"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:228
+#: senaite/core/content/senaitesetup.py:229
 msgid "Counter Type"
 msgstr ""
 
@@ -1417,7 +1484,7 @@ msgstr "國家"
 msgid "Create Invoice PDF"
 msgstr "創建PDF發票"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:256
+#: senaite/core/browser/samples/templates/partition_magic.pt:264
 msgid "Create Partitions"
 msgstr "樣本分裝"
 
@@ -1425,7 +1492,7 @@ msgstr "樣本分裝"
 msgid "Create SENAITE Site"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:716
+#: senaite/core/browser/samples/view.py:864
 msgid "Create Worksheet"
 msgstr ""
 
@@ -1437,7 +1504,7 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:720
+#: senaite/core/browser/samples/view.py:868
 msgid "Create a new worksheet for the selected samples"
 msgstr ""
 
@@ -1467,7 +1534,7 @@ msgid "Created {} partitions: {}"
 msgstr ""
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:136
+#: senaite/core/browser/samples/view.py:148
 msgid "Creator"
 msgstr "建立者"
 
@@ -1476,7 +1543,7 @@ msgstr "建立者"
 msgid "Criteria"
 msgstr "標準"
 
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/bikasetup.py:254
 msgid "Currency"
 msgstr "貨幣"
 
@@ -1484,12 +1551,20 @@ msgstr "貨幣"
 msgid "Current"
 msgstr "當前"
 
-#: bika/lims/content/client.py:237
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+#: bika/lims/content/client.py:241
 msgid "Custom decimal mark"
 msgstr "自定小數位標記"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:135
+msgid "Daily"
 msgstr ""
 
 #: bika/lims/content/instrument.py:222
@@ -1537,23 +1612,23 @@ msgstr "修改日期"
 msgid "Date Opened"
 msgstr "打開日期"
 
-#: senaite/core/browser/samples/view.py:155
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Preserved"
 msgstr "醃製/處理時間"
 
-#: senaite/core/content/resultsreport.py:208
+#: senaite/core/content/resultsreport.py:209
 msgid "Date Printed"
 msgstr "列印日期"
 
-#: senaite/core/browser/samples/view.py:171
+#: senaite/core/browser/samples/view.py:183
 msgid "Date Published"
 msgstr "發佈日期"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:173
 msgid "Date Received"
 msgstr "收到日期"
 
-#: senaite/core/browser/samples/view.py:141
+#: senaite/core/browser/samples/view.py:153
 msgid "Date Registered"
 msgstr "登記日期"
 
@@ -1565,11 +1640,11 @@ msgstr "請求日期"
 msgid "Date Sample Received"
 msgstr "樣本建立日期"
 
-#: senaite/core/browser/samples/view.py:149
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Sampled"
 msgstr "檢測日期"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:179
 msgid "Date Verified"
 msgstr "複核日期"
 
@@ -1611,7 +1686,7 @@ msgstr "校正證書授予日期"
 msgid "Date when the certificate is valid"
 msgstr "證書有效日期"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:210
 msgid "Date when the report was printed"
 msgstr ""
 
@@ -1634,11 +1709,11 @@ msgstr "停用直到下次校正"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:238
+#: bika/lims/content/client.py:242
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "小數標記從該客戶的報告中使用。"
 
-#: bika/lims/content/client.py:130
+#: bika/lims/content/client.py:134
 msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
 msgstr ""
 
@@ -1650,7 +1725,7 @@ msgstr "預設容器"
 msgid "Default Department"
 msgstr ""
 
-#: bika/lims/content/client.py:163
+#: bika/lims/content/client.py:167
 msgid "Default Emails to CC all published Samples for this client"
 msgstr "為目前客戶的所有已發布樣本設定報告副本郵件為預設郵箱"
 
@@ -1662,7 +1737,7 @@ msgstr "預設儀器"
 msgid "Default Method"
 msgstr "預設方法"
 
-#: senaite/core/content/senaitesetup.py:1162
+#: senaite/core/content/senaitesetup.py:1185
 msgid "Default Number of Copies"
 msgstr ""
 
@@ -1670,20 +1745,20 @@ msgstr ""
 msgid "Default Preservation"
 msgstr "默認保存"
 
-#: senaite/core/content/senaitesetup.py:1128
+#: senaite/core/content/senaitesetup.py:1151
 msgid "Default Sticker Template"
 msgstr ""
 
-#: bika/lims/content/client.py:95
+#: bika/lims/content/client.py:99
 msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1215
+#: bika/lims/content/bikasetup.py:1216
 msgid "Default count of Sample to add."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:311
-#: bika/lims/content/client.py:225
+#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/client.py:229
 msgid "Default decimal mark"
 msgstr "默認小數標記"
 
@@ -1695,7 +1770,7 @@ msgstr "用於此類分析的預設儀器"
 msgid "Default large sticker"
 msgstr "預設大標籤"
 
-#: bika/lims/content/bikasetup.py:573
+#: bika/lims/content/bikasetup.py:574
 msgid "Default layout in worksheet view"
 msgstr "工作表視圖預設佈局"
 
@@ -1727,15 +1802,15 @@ msgstr ""
 msgid "Default result to display on result entry"
 msgstr "在結果輸入時顯示的預設結果"
 
-#: senaite/core/content/senaitesetup.py:1050
+#: senaite/core/content/senaitesetup.py:1073
 msgid "Default sample retention period"
 msgstr "默認样品保留周期"
 
-#: bika/lims/content/bikasetup.py:325
+#: bika/lims/content/bikasetup.py:326
 msgid "Default scientific notation format for reports"
 msgstr "默認情況下，報告中科學記數法格式"
 
-#: bika/lims/content/bikasetup.py:559
+#: bika/lims/content/bikasetup.py:560
 msgid "Default scientific notation format for results"
 msgstr "默認情況下，結果科學記數法格式"
 
@@ -1747,7 +1822,7 @@ msgstr "預設小標籤"
 msgid "Default timezone"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1037
+#: senaite/core/content/senaitesetup.py:1060
 msgid "Default turnaround time for analyses."
 msgstr ""
 
@@ -1756,7 +1831,7 @@ msgstr ""
 msgid "Default value"
 msgstr "默認值"
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1217
 msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
 msgstr ""
 
@@ -1780,7 +1855,7 @@ msgstr "當轉換數值(values)去指數值(exponent notation)時, 要定義精�
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1089
+#: senaite/core/content/senaitesetup.py:1112
 msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 msgstr ""
 
@@ -1792,8 +1867,17 @@ msgstr "定義用於此樣本類型的標籤"
 msgid "Degrees"
 msgstr "度"
 
+#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+#: senaite/core/api/remarks.py:484
+msgid "Delete this remark?"
 msgstr ""
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
@@ -1822,9 +1906,9 @@ msgstr "系"
 msgid "Dependent Analyses"
 msgstr "以來分析"
 
-#: senaite/core/behaviors/label.py:111
+#: senaite/core/behaviors/label.py:119
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:62
+#: senaite/core/browser/controlpanel/labels/view.py:63
 msgid "Description"
 msgstr "描述"
 
@@ -1871,7 +1955,11 @@ msgstr ""
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
 msgstr ""
@@ -1889,7 +1977,7 @@ msgstr "發送"
 msgid "Dispatch samples"
 msgstr "發送樣品"
 
-#: senaite/core/browser/samples/view.py:361
+#: senaite/core/browser/samples/view.py:379
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "已發送"
@@ -1914,15 +2002,23 @@ msgstr ""
 msgid "Display a Detection Limit selector"
 msgstr "顯示檢測限選擇"
 
-#: bika/lims/content/bikasetup.py:721
+#: bika/lims/content/bikasetup.py:722
 msgid "Display sample partitions to clients"
 msgstr "向客戶展示分裝樣品"
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:15
+msgid "Dispose samples"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "已處置"
 
@@ -1992,11 +2088,15 @@ msgstr "報告下載"
 msgid "Download selected reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:309
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:327
 msgid "Due"
 msgstr "截止"
 
-#: senaite/core/browser/samples/view.py:164
+#: senaite/core/browser/samples/view.py:176
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "截止期"
@@ -2013,7 +2113,7 @@ msgstr "重複"
 msgid "Duplicate Analysis"
 msgstr "重複樣分析"
 
-#: senaite/core/content/senaitesetup.py:1406
+#: senaite/core/content/senaitesetup.py:1433
 msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
 msgstr ""
 
@@ -2061,6 +2161,7 @@ msgstr "如 SANAS, APLAC 等"
 msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
 msgstr "每個導入介面都可以定義一個為資料夾，系統在其中尋找結果文件，同時在使用<code>auto_import_results</code>視圖時自動導入結果."
 
+#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "編輯"
@@ -2075,21 +2176,21 @@ msgstr "評估"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
 #: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:115
+#: senaite/core/content/contact.py:147
 msgid "Email"
 msgstr "電郵"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:114
+#: senaite/core/content/resultsreport.py:115
 msgid "Email Address"
 msgstr "電郵地址"
 
-#: senaite/core/content/resultsreport.py:88
+#: senaite/core/content/resultsreport.py:89
 msgid "Email Attachments"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:83
+#: senaite/core/content/resultsreport.py:84
 msgid "Email Body"
 msgstr ""
 
@@ -2097,27 +2198,27 @@ msgstr ""
 msgid "Email Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:66
+#: senaite/core/content/resultsreport.py:67
 msgid "Email Recipients"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:72
+#: senaite/core/content/resultsreport.py:73
 msgid "Email Responsibles"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:61
+#: senaite/core/content/resultsreport.py:62
 msgid "Email Send Date"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:78
+#: senaite/core/content/resultsreport.py:79
 msgid "Email Subject"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1088
+#: senaite/core/content/senaitesetup.py:1111
 msgid "Email body for Sample Invalidation notifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1072
+#: senaite/core/content/senaitesetup.py:1095
 msgid "Email body for Sample Rejection notifications"
 msgstr ""
 
@@ -2130,17 +2231,21 @@ msgstr ""
 msgid "Email notification"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1062
+#: senaite/core/content/senaitesetup.py:1085
 msgid "Email notification on Sample rejection"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:258
 msgid "Email send log"
 msgstr ""
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
 msgstr "郵件發送"
+
+#: bika/lims/api/snapshot.py:585
+msgid "Empty"
+msgstr ""
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
@@ -2150,27 +2255,27 @@ msgstr ""
 msgid "Enable Multiple Use of Instrument in Worksheets."
 msgstr "在工作表中啟用儀器的多次使用"
 
-#: senaite/core/content/senaitesetup.py:1017
+#: senaite/core/content/senaitesetup.py:1040
 msgid "Enable Sample Preservation"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:410
+#: bika/lims/content/bikasetup.py:411
 msgid "Enable Sample Specifications"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:989
+#: senaite/core/content/senaitesetup.py:1012
 msgid "Enable Sampling"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:997
+#: senaite/core/content/senaitesetup.py:1020
 msgid "Enable Sampling Scheduling"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:223
+#: bika/lims/content/bikasetup.py:224
 msgid "Enable global Audit Log"
 msgstr "啟用全域審計日誌"
 
-#: senaite/core/content/senaitesetup.py:297
+#: senaite/core/content/senaitesetup.py:298
 msgid "Enable global Auditlog"
 msgstr "啟用全域審計日誌"
 
@@ -2178,9 +2283,17 @@ msgstr "啟用全域審計日誌"
 msgid "Enable sampling workflow for the created sample"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:979
+#: senaite/core/content/senaitesetup.py:980
 msgid "Enable the Results Report Printing workflow"
 msgstr "啟用結果報告列印工作流程"
+
+#: senaite/core/content/senaitesetup.py:1000
+msgid "Enable the Sample Dispatch workflow"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:990
+msgid "Enable the Sample Dispose workflow"
+msgstr ""
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
@@ -2203,7 +2316,7 @@ msgstr "輸入電子郵件地址。萬一密碼丟失，這是必要的。我們
 msgid "Enter discount percentage value"
 msgstr "輸入折扣百分比值"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
 msgid "Enter individual values for this field per sample"
 msgstr ""
 
@@ -2216,7 +2329,7 @@ msgstr "輸入百分比值，如。 14.0"
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "輸入百分比值，如。 14.0 。這一比例僅在分析檔案應用，覆蓋系統的增值稅"
 
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/bikasetup.py:298
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "輸入百分比值，如。 14.0 。此百分數應用於系統寬，但可超過寫入的物品"
 
@@ -2240,7 +2353,7 @@ msgstr "輸入每次你要複製的分析服務的細節。"
 msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1096
+#: bika/lims/browser/analyses/view.py:1097
 msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
 msgstr ""
 
@@ -2252,15 +2365,15 @@ msgstr "環境條件"
 msgid "Erroneous result publication: ${sample_id}"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:455
+#: senaite/core/browser/dashboard/dashboard.py:502
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:407
+#: senaite/core/browser/dashboard/dashboard.py:453
 msgid "Evolution of Samples"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:484
+#: senaite/core/browser/dashboard/dashboard.py:535
 msgid "Evolution of Worksheets"
 msgstr ""
 
@@ -2272,7 +2385,7 @@ msgstr "每 10 分鐘執行一次自動匯入的範例"
 msgid "Example content"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:601
+#: senaite/core/browser/samples/view.py:739
 msgid "Exclude from invoice"
 msgstr "從發票中排除"
 
@@ -2282,7 +2395,7 @@ msgstr "從發票中排除"
 msgid "Expected Result"
 msgstr "預期結果"
 
-#: senaite/core/browser/samples/view.py:145
+#: senaite/core/browser/samples/view.py:157
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2308,7 +2421,7 @@ msgstr "到期日"
 msgid "Exponential format precision"
 msgstr "指數格式的精度"
 
-#: bika/lims/content/bikasetup.py:425
+#: bika/lims/content/bikasetup.py:426
 msgid "Exponential format threshold"
 msgstr "指數格式門檻"
 
@@ -2316,7 +2429,7 @@ msgstr "指數格式門檻"
 msgid "Export"
 msgstr "導出"
 
-#: senaite/core/browser/stickers/view.py:273
+#: senaite/core/browser/stickers/view.py:283
 msgid "Failed to load sticker"
 msgstr ""
 
@@ -2403,7 +2516,7 @@ msgstr ""
 msgid "Filesize"
 msgstr "檔案大小"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
 msgid "Filter analyses by name..."
 msgstr ""
 
@@ -2417,6 +2530,18 @@ msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:601
+msgid "Filter samples by this analysis"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
 msgstr ""
 
 #: senaite/core/content/dynamicanalysisspec.py:75
@@ -2433,11 +2558,11 @@ msgstr "名"
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "0.0 - 1000.0 之間的浮點數值指示排序順序。 重複值按字母順序排序。"
 
-#: senaite/core/content/senaitesetup.py:211
+#: senaite/core/content/senaitesetup.py:212
 msgid "Format"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1180
+#: senaite/core/content/senaitesetup.py:1203
 msgid "Formatting Configuration"
 msgstr ""
 
@@ -2460,13 +2585,17 @@ msgstr "星期五"
 msgid "From"
 msgstr "自/由"
 
+#: senaite/core/browser/dashboard/dashboard.py:134
+msgid "From ${from} to ${to} (updated every 2 hours)"
+msgstr ""
+
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "全名"
 
-#: senaite/core/content/resultsreport.py:109
+#: senaite/core/content/resultsreport.py:110
 msgid "Fullname"
 msgstr "全名"
 
@@ -2474,7 +2603,7 @@ msgstr "全名"
 msgid "Function"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:598
+#: senaite/core/browser/samples/view.py:736
 msgid "Future dated sample"
 msgstr "已預約的樣本"
 
@@ -2507,7 +2636,7 @@ msgstr ""
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "問候/稱謂標題如：先生，太太，博士"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:356
 msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
 msgstr "通過在LIMS表類別組分析服務，幫助時，名單很長"
 
@@ -2521,7 +2650,7 @@ msgid "Hazardous"
 msgstr "有危險的"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:81
+#: bika/lims/browser/analysisrequest/manage_analyses.py:84
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
 msgstr "隱藏的"
@@ -2534,8 +2663,20 @@ msgstr "隱藏域"
 msgid "Hidden from report"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
 msgid "Hide additional fields"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:487
+msgid "Hide history"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
 msgstr ""
 
 #: bika/lims/config.py:140
@@ -2559,7 +2700,7 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1380
+#: senaite/core/content/senaitesetup.py:1407
 msgid "ID Server"
 msgstr ""
 
@@ -2567,7 +2708,7 @@ msgstr ""
 msgid "ID Server Settings"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1188
+#: bika/lims/content/bikasetup.py:1189
 msgid "ID Server Values"
 msgstr ""
 
@@ -2587,15 +2728,15 @@ msgstr "如選此項，選擇列表將顯示在錄入觀點分析結果字段旁
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
 msgstr "如果選中，直至進行下一個有效校準時, 儀器將不可用。該複選框會自動選中。"
 
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:462
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:818
+#: bika/lims/content/abstractbaseanalysis.py:821
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "如果啟用，則提交此檢驗結果的使用者也可以對其進行複核。 此設定對分配了角色的使用者生效，允許他們複核結果（預設情況下，管理員，實驗室管理員和復核者）。 此處設定的選項優先於全域設定中設定的選項"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:494
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
@@ -2603,7 +2744,7 @@ msgstr ""
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "如果啟用，分析的名稱將用斜體。"
 
-#: bika/lims/content/abstractbaseanalysis.py:802
+#: bika/lims/content/abstractbaseanalysis.py:805
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr "如果啟用，則預設不會在報告中顯示此分析及其結果。 可以在檢驗套餐或樣本中可以覆蓋此設置。"
 
@@ -2643,7 +2784,7 @@ msgstr "如果未選中，實驗室管理員將無法在建立工作表時為同
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr "如果您的公式需要外部Python庫中的特殊函數，您可以在此處匯入。 例如，如果你想使用Python'math'模組中的'floor'函數，你可以在Module欄位中加入'math'，在函數欄位中加入'floor'。 等同於Python中語句「from math import floor」。 在你的計算公式中可以使用'floor（[Ca] + [Mg]）'。"
 
-#: senaite/core/content/senaitesetup.py:328
+#: senaite/core/content/senaitesetup.py:329
 msgid "Immediate results entry"
 msgstr ""
 
@@ -2674,11 +2815,11 @@ msgstr "在實驗室校準程序"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:75
+#: senaite/core/browser/controlpanel/labels/view.py:76
 msgid "Inactive"
 msgstr "待用/不活躍的"
 
-#: bika/lims/content/bikasetup.py:240
+#: bika/lims/content/bikasetup.py:241
 msgid "Include and display pricing information"
 msgstr "包括和顯示的價格信息"
 
@@ -2875,7 +3016,7 @@ msgid "Internal Certificate"
 msgstr "內部證書"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:608
+#: senaite/core/browser/samples/view.py:746
 msgid "Internal use"
 msgstr "內部使用"
 
@@ -2896,13 +3037,13 @@ msgstr "解釋模板"
 msgid "Interval"
 msgstr "間隔"
 
-#: senaite/core/browser/dashboard/dashboard.py:137
-#: senaite/core/browser/samples/view.py:383
+#: senaite/core/browser/dashboard/dashboard.py:168
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "無效"
 
-#: senaite/core/content/senaitesetup.py:1417
+#: senaite/core/content/senaitesetup.py:1444
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
 msgstr ""
 
@@ -2965,15 +3106,15 @@ msgstr "開票給"
 msgid "Invoice {} created"
 msgstr "已建立發票{}"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2426
+#: senaite/core/exportimport/setupdata/__init__.py:2427
 msgid "InvoiceBatch has no End Date"
 msgstr "發票批沒有結束日期"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2423
+#: senaite/core/exportimport/setupdata/__init__.py:2424
 msgid "InvoiceBatch has no Start Date"
 msgstr "發票批沒有開始日期"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2420
+#: senaite/core/exportimport/setupdata/__init__.py:2421
 msgid "InvoiceBatch has no Title"
 msgstr "發票批無標題"
 
@@ -2985,7 +3126,7 @@ msgstr "職位名稱"
 msgid "Job title"
 msgstr "職位名稱"
 
-#: bika/lims/content/abstractbaseanalysis.py:753
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "Keep order above"
 msgstr ""
 
@@ -2997,9 +3138,9 @@ msgstr "關鍵"
 msgid "Key <span class=\"sort-indicator\" />"
 msgstr ""
 
+#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "關鍵詞"
 
@@ -3015,6 +3156,10 @@ msgstr ""
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "多個關鍵詞"
+
+#: senaite/core/browser/samples/view.py:249
+msgid "Keywords of the analyses contained in the sample"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
 #: bika/lims/config.py:52
@@ -3059,8 +3204,8 @@ msgstr "實驗室產品"
 msgid "Lab URL"
 msgstr "實驗室網址"
 
-#: senaite/core/behaviors/label.py:107
-#: senaite/core/extender/label.py:76
+#: senaite/core/behaviors/label.py:115
+#: senaite/core/extender/label.py:80
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
 msgstr "標籤"
@@ -3069,7 +3214,7 @@ msgstr "標籤"
 msgid "Label configuration"
 msgstr ""
 
-#: senaite/core/content/label.py:65
+#: senaite/core/content/label.py:93
 msgid "Label names must be unique"
 msgstr ""
 
@@ -3077,13 +3222,13 @@ msgstr ""
 msgid "Label schema extender"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:50
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "Labeled Objects"
 msgstr ""
 
-#: senaite/core/browser/controlpanel/labels/view.py:51
-#: senaite/core/browser/label/labeled_objects.py:65
-#: senaite/core/extender/label.py:57
+#: senaite/core/browser/controlpanel/labels/view.py:52
+#: senaite/core/browser/label/labeled_objects.py:66
+#: senaite/core/browser/samples/view.py:875
 msgid "Labels"
 msgstr "標籤"
 
@@ -3096,7 +3241,7 @@ msgstr "實驗室"
 msgid "Laboratory Accredited"
 msgstr "實驗室受認可"
 
-#: senaite/core/content/senaitesetup.py:1023
+#: senaite/core/content/senaitesetup.py:1046
 msgid "Laboratory Workdays"
 msgstr ""
 
@@ -3108,7 +3253,7 @@ msgstr ""
 msgid "Large Sticker"
 msgstr "大標籤"
 
-#: senaite/core/content/senaitesetup.py:1150
+#: senaite/core/content/senaitesetup.py:1173
 msgid "Large Sticker Template"
 msgstr ""
 
@@ -3120,11 +3265,11 @@ msgstr "上一次自動匯入日誌"
 msgid "Last Login Time"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:439
+#: senaite/core/browser/samples/view.py:469
 msgid "Late"
 msgstr "逾期"
 
-#: senaite/core/browser/samples/view.py:593
+#: senaite/core/browser/samples/view.py:731
 msgid "Late Analyses"
 msgstr "後期分析/最近的分析"
 
@@ -3170,15 +3315,15 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:52
 msgid "List all objects with labels"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:736
+#: bika/lims/content/abstractbaseanalysis.py:739
 msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
 msgstr "可能的最終結果清單。 設定後，結果輸入中不允許自訂結果，使用者必須從這些值中進行選擇。"
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1203
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
 
@@ -3202,7 +3347,7 @@ msgstr "在這載入證明文件"
 msgid "Loading navigation..."
 msgstr ""
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:40
+#: senaite/core/browser/dashboard/templates/dashboard.pt:41
 msgid "Loading..."
 msgstr ""
 
@@ -3230,6 +3375,14 @@ msgstr "位置類型"
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
 msgstr "文件儲存位置"
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Lock"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Locked"
+msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3293,7 +3446,7 @@ msgstr "男"
 msgid "Manage Analyses"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
 msgid "Manage Form Fields"
 msgstr ""
 
@@ -3317,7 +3470,7 @@ msgstr "管理樣本表單字段"
 msgid "Manage linked User"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
 msgid "Manage sample fields"
 msgstr ""
 
@@ -3341,7 +3494,7 @@ msgstr "經理電郵"
 msgid "Manager Phone"
 msgstr "經理電話"
 
-#: bika/lims/browser/analyses/view.py:1162
+#: bika/lims/browser/analyses/view.py:1163
 msgid "Manual"
 msgstr "說明書/手動"
 
@@ -3370,7 +3523,7 @@ msgstr "多個製造商"
 msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:94
+#: bika/lims/browser/analysisrequest/manage_analyses.py:97
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3385,7 +3538,7 @@ msgstr "最大時間"
 msgid "Max operator"
 msgstr "最大運算符"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:92
+#: bika/lims/browser/analysisrequest/manage_analyses.py:95
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
@@ -3420,15 +3573,15 @@ msgid "Member Discount"
 msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:281
+#: bika/lims/content/bikasetup.py:282
 msgid "Member discount %"
 msgstr "會員折扣%"
 
-#: bika/lims/content/client.py:83
+#: bika/lims/content/client.py:87
 msgid "Member discount applies"
 msgstr "會員可用折扣"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:318
+#: senaite/core/browser/clients/client/contacts/login_details.py:329
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
@@ -3436,7 +3589,7 @@ msgstr ""
 msgid "Message sent to {}, "
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:217
+#: senaite/core/content/resultsreport.py:218
 msgid "Metadata"
 msgstr ""
 
@@ -3467,7 +3620,7 @@ msgstr "中間初始"
 msgid "Middle name"
 msgstr "中間名字"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:90
+#: bika/lims/browser/analysisrequest/manage_analyses.py:93
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
@@ -3478,7 +3631,7 @@ msgstr "最小"
 msgid "Min operator"
 msgstr "最小運算符"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:91
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
@@ -3496,7 +3649,7 @@ msgstr "最少5個"
 msgid "Minimum Volume"
 msgstr "最小體積"
 
-#: bika/lims/content/bikasetup.py:339
+#: bika/lims/content/bikasetup.py:340
 msgid "Minimum number of results for QC stats calculations"
 msgstr "進行質量控制的統計計算結果的最小數量"
 
@@ -3527,6 +3680,10 @@ msgstr ""
 msgid "Monday"
 msgstr "星期一"
 
+#: senaite/core/browser/dashboard/dashboard.py:137
+msgid "Monthly"
+msgstr ""
+
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
 msgstr ""
@@ -3540,11 +3697,11 @@ msgstr ""
 msgid "Multi Results"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:528
+#: bika/lims/content/bikasetup.py:529
 msgid "Multi Verification type"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1585
+#: bika/lims/browser/analyses/view.py:1586
 msgid "Multi-verification required"
 msgstr ""
 
@@ -3580,13 +3737,17 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
 msgstr ""
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
 #: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:114
+#: senaite/core/content/contact.py:146
 msgid "Name"
 msgstr "名稱"
 
@@ -3596,6 +3757,10 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
 msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgstr ""
+
+#: senaite/core/api/remarks.py:490
+msgid "Newest first"
 msgstr ""
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
@@ -3638,6 +3803,10 @@ msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:131
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:458
@@ -3686,6 +3855,10 @@ msgstr ""
 msgid "No changes made."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:130
+msgid "No data for the selected period"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
 msgstr ""
@@ -3730,12 +3903,26 @@ msgstr "沒有選擇的項目"
 msgid "No items selected."
 msgstr ""
 
+# senaite.app.listing: Column config — empty state for hidden section with
+# search
+msgid "No matches in hidden columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with
+# search
+msgid "No matches in visible columns."
+msgstr ""
+
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
 msgstr "無新項目建立"
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
+msgstr ""
+
+#: senaite/core/api/remarks.py:493
+msgid "No remarks yet"
 msgstr ""
 
 #: bika/lims/browser/publish/emailview.py:176
@@ -3752,6 +3939,10 @@ msgstr ""
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
 msgstr ""
 
 #: senaite/core/exportimport/instruments/importer.py:322
@@ -3780,7 +3971,7 @@ msgstr ""
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1118
+#: senaite/core/content/senaitesetup.py:1141
 msgid "None"
 msgstr "没有"
 
@@ -3796,11 +3987,11 @@ msgstr ""
 msgid "Not defined"
 msgstr "沒有定義的"
 
-#: senaite/core/browser/samples/view.py:565
+#: senaite/core/browser/samples/view.py:703
 msgid "Not printed"
 msgstr ""
 
-#: bika/lims/api/snapshot.py:433
+#: bika/lims/api/snapshot.py:611
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
 msgstr ""
@@ -3821,7 +4012,7 @@ msgstr "注意：設定是全域的，適用於所有樣本視圖。"
 msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1354
+#: senaite/core/content/senaitesetup.py:1381
 msgid "Notifications"
 msgstr ""
 
@@ -3833,7 +4024,7 @@ msgstr "數列"
 msgid "Number"
 msgstr "數量"
 
-#: senaite/core/browser/samples/view.py:230
+#: senaite/core/browser/samples/view.py:242
 msgid "Number of Analyses"
 msgstr "分析數"
 
@@ -3849,16 +4040,16 @@ msgstr "複製數量"
 msgid "Number of prominent columns"
 msgstr "突顯列數"
 
-#: bika/lims/content/abstractbaseanalysis.py:836
-#: bika/lims/content/bikasetup.py:512
+#: bika/lims/content/abstractbaseanalysis.py:839
+#: bika/lims/content/bikasetup.py:513
 msgid "Number of required verifications"
 msgstr "複核次數"
 
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/bikasetup.py:514
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/abstractbaseanalysis.py:837
+#: bika/lims/content/abstractbaseanalysis.py:840
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "在該分析的給定結果被視為「已驗證」之前，具有足夠權限的不同使用者所需的驗證次數。 此處設定的選項優先於站點設定中設定的選項"
 
@@ -3868,6 +4059,10 @@ msgstr "標準數列"
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
+msgstr ""
+
+#: senaite/core/api/remarks.py:491
+msgid "Oldest first"
 msgstr ""
 
 #: bika/lims/content/preservation.py:53
@@ -3886,11 +4081,11 @@ msgstr ""
 msgid "Only instruments that have an import interface configured are displayed"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1024
+#: senaite/core/content/senaitesetup.py:1047
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:753
+#: bika/lims/content/bikasetup.py:754
 msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
 msgstr ""
 
@@ -3898,13 +4093,13 @@ msgstr ""
 msgid "Only to empty or zero fields"
 msgstr "只有空或零域"
 
-#: senaite/core/browser/samples/view.py:525
+#: senaite/core/browser/samples/view.py:652
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "打開"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:243
 msgid "Open / To be verified / Verified / Total"
 msgstr ""
 
@@ -3912,8 +4107,16 @@ msgstr ""
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr "基於開源的雲端實驗室資訊管理系統"
 
+#: senaite/core/browser/dashboard/dashboard.py:97
+msgid "Open Worksheets"
+msgstr ""
+
 #: bika/lims/browser/publish/reports_listing.py:128
 msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:522
+msgid "Open worksheets with analyses awaiting results"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
@@ -3941,7 +4144,7 @@ msgstr ""
 msgid "Other reasons:"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:183
 msgid "Other status"
 msgstr ""
 
@@ -3963,11 +4166,11 @@ msgstr ""
 msgid "Override non-empty analysis results, also with empty"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:197
+#: senaite/core/content/resultsreport.py:198
 msgid "PDF"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:198
+#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
 msgstr ""
 
@@ -4064,11 +4267,11 @@ msgstr ""
 msgid "Please provide the reason for invalidating the sample."
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:222
+#: senaite/core/browser/clients/client/contacts/login_details.py:213
 msgid "Please select a User from the list"
 msgstr ""
 
-#: senaite/core/browser/stickers/view.py:257
+#: senaite/core/browser/stickers/view.py:267
 msgid "Please select a sticker template"
 msgstr ""
 
@@ -4081,6 +4284,7 @@ msgid "Please select number of partitions to create and press the preview button
 msgstr "請選擇要建立的分區數量並按預覽按鈕"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
+#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
 msgstr ""
 
@@ -4100,12 +4304,16 @@ msgstr ""
 msgid "Please write a comment where the listed sample(s) are dispatched"
 msgstr ""
 
+#: senaite/core/browser/samples/templates/dispose_samples.pt:73
+msgid "Please write a comment where the listed sample(s) are disposed"
+msgstr ""
+
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "捕獲點"
 
-#: senaite/core/content/senaitesetup.py:206
+#: senaite/core/content/senaitesetup.py:207
 msgid "Portal Type"
 msgstr ""
 
@@ -4144,33 +4352,33 @@ msgstr "小數位精度"
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "當數值不不確定時之小數位。小數點位置將通過從不確定數的零之後的第一個數字給出，在該位，在該位置，系統將四捨五入的不確定性和結果。例如，具有5.243的結果和0.22的不確定性，則系統將正確地為5.2 ±0.2顯示量。如果沒有不確定性範圍被設定為結果，系統將使用固定精度集。"
 
-#: bika/lims/content/abstractbaseanalysis.py:735
+#: bika/lims/content/abstractbaseanalysis.py:738
 msgid "Predefined results"
 msgstr "預定義結果"
 
-#: bika/lims/content/bikasetup.py:312
+#: bika/lims/content/bikasetup.py:313
 msgid "Preferred decimal mark for reports."
 msgstr "報告首選十進制標誌。"
 
-#: bika/lims/content/bikasetup.py:546
+#: bika/lims/content/bikasetup.py:547
 msgid "Preferred decimal mark for results"
 msgstr "結果首選十進制標誌。"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:575
 msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
 msgstr ""
 "“工作表”视图中结果条目表的首选布局。经典布局在行中显示样品，在列中显示检验项目。转置布局显示列中的样本和行中的检验项目。\n"
 "工作表視圖中結果輸入表的首選佈局。 經典佈局在行中顯示樣本，在列中顯示分析。 轉置佈局在列中顯示樣本，在行中顯示分析。"
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:327
 msgid "Preferred scientific notation format for reports"
 msgstr "報告首選科學記數法格式"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:561
 msgid "Preferred scientific notation format for results"
 msgstr "結果首選科學記數法格式"
 
-#: senaite/core/content/senaitesetup.py:240
+#: senaite/core/content/senaitesetup.py:241
 msgid "Prefix"
 msgstr ""
 
@@ -4203,7 +4411,7 @@ msgstr ""
 msgid "Preserve"
 msgstr "防腐"
 
-#: senaite/core/browser/samples/view.py:222
+#: senaite/core/browser/samples/view.py:234
 msgid "Preserver"
 msgstr "保存人/保護劑/防腐劑"
 
@@ -4220,11 +4428,11 @@ msgstr "預防"
 msgid "Preventive maintenance procedure"
 msgstr "預防性保養程序"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:250
+#: senaite/core/browser/samples/templates/partition_magic.pt:258
 msgid "Preview"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4252,7 +4460,7 @@ msgstr "價目表為:"
 msgid "Pricelists"
 msgstr "價格表"
 
-#: bika/lims/content/client.py:94
+#: bika/lims/content/client.py:98
 msgid "Primary Contact"
 msgstr ""
 
@@ -4261,7 +4469,7 @@ msgstr ""
 msgid "Primary Sample"
 msgstr "主樣品"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:851
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
@@ -4283,11 +4491,11 @@ msgstr "打印日期"
 msgid "Print pricelist"
 msgstr "列印價格表"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:272
 msgid "Print stickers"
 msgstr "列印標籤"
 
-#: senaite/core/browser/samples/view.py:241
+#: senaite/core/browser/samples/view.py:259
 msgid "Printed"
 msgstr "已列印"
 
@@ -4300,7 +4508,7 @@ msgstr "已列印在"
 msgid "Priority"
 msgstr "優先"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:238
 msgid "Profile"
 msgstr "數據圖表/簡要介紹"
 
@@ -4324,7 +4532,7 @@ msgstr ""
 msgid "Profile keyword must be unique"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:122
+#: senaite/core/browser/samples/view.py:134
 msgid "Progress"
 msgstr "進度"
 
@@ -4333,7 +4541,7 @@ msgstr "進度"
 msgid "Prominent fields"
 msgstr "突顯欄位"
 
-#: bika/lims/content/abstractbaseanalysis.py:865
+#: bika/lims/content/abstractbaseanalysis.py:868
 msgid "Protocol ID"
 msgstr "協議/草案ID"
 
@@ -4341,7 +4549,7 @@ msgstr "協議/草案ID"
 msgid "Province"
 msgstr "省份"
 
-#: senaite/core/content/resultsreport.py:119
+#: senaite/core/content/resultsreport.py:120
 msgid "Publication Modes"
 msgstr ""
 
@@ -4350,8 +4558,12 @@ msgstr ""
 msgid "Publish"
 msgstr "發布報告"
 
-#: senaite/core/browser/dashboard/dashboard.py:128
-#: senaite/core/browser/samples/view.py:351
+#: senaite/core/browser/dashboard/dashboard.py:112
+msgid "Publish Reports"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:150
+#: senaite/core/browser/samples/view.py:369
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "已發佈"
@@ -4367,6 +4579,10 @@ msgstr "發佈日期"
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "公佈結果"
+
+#: senaite/core/browser/dashboard/dashboard.py:448
+msgid "Published samples whose reports have not been printed yet"
+msgstr ""
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
@@ -4388,6 +4604,14 @@ msgstr "QC 結果"
 #: bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
 msgstr "質量控制樣品ID"
+
+#: senaite/core/browser/dashboard/dashboard.py:138
+msgid "Quarterly"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:128
+msgid "Quick Actions"
+msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4413,7 +4637,7 @@ msgstr "重新輸入密碼。確保密碼是相同的。"
 msgid "Reasons for rejection"
 msgstr ""
 
-#: senaite/core/browser/worksheets/view.py:344
+#: senaite/core/browser/worksheets/view.py:348
 msgid "Reassign"
 msgstr "重新分派"
 
@@ -4425,30 +4649,34 @@ msgstr ""
 msgid "Reattach"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1170
+#: bika/lims/browser/analyses/view.py:1171
 msgid "Recalculate"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1121
+#: senaite/core/content/senaitesetup.py:1144
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "接收"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:321
+#: senaite/core/browser/samples/view.py:339
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "已接收"
 
-#: senaite/core/browser/dashboard/dashboard.py:135
+#: senaite/core/browser/dashboard/dashboard.py:420
+msgid "Received samples with analyses awaiting results"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:160
 msgid "Reception pending"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:244
+#: senaite/core/content/resultsreport.py:245
 msgid "Recipient"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:241
+#: senaite/core/content/resultsreport.py:242
 msgid "Recipients"
 msgstr "收件人"
 
@@ -4499,11 +4727,15 @@ msgstr "參考值"
 msgid "Reference sample values are zero or 'blank'"
 msgstr "參考樣品的值是零或“空白”"
 
-#: senaite/core/content/senaitesetup.py:1120
+#: senaite/core/content/senaitesetup.py:1143
 msgid "Register"
 msgstr "註冊"
 
-#: senaite/core/browser/dashboard/dashboard.py:121
+#: senaite/core/browser/dashboard/dashboard.py:105
+msgid "Register Samples"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:145
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
@@ -4529,9 +4761,9 @@ msgstr "拒絕分析"
 msgid "Reject samples"
 msgstr "拒絕樣本"
 
-#: senaite/core/browser/dashboard/dashboard.py:125
+#: senaite/core/browser/dashboard/dashboard.py:153
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:402
+#: senaite/core/browser/samples/view.py:432
 msgid "Rejected"
 msgstr "已拒絕"
 
@@ -4547,7 +4779,7 @@ msgstr "被拒樣本"
 msgid "Rejected {} samples: {}"
 msgstr "{} 個被拒樣本：{}"
 
-#: bika/lims/content/bikasetup.py:1201
+#: bika/lims/content/bikasetup.py:1202
 msgid "Rejection Reasons"
 msgstr ""
 
@@ -4608,8 +4840,16 @@ msgstr "遠端 IP"
 msgid "Remove"
 msgstr "移除"
 
+#: senaite/core/browser/samples/view.py:597
+msgid "Remove this analysis from the filter"
+msgstr ""
+
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
 msgstr ""
 
 #: bika/lims/content/attachment.py:80
@@ -4645,11 +4885,11 @@ msgstr "報告ID"
 msgid "Report identification number"
 msgstr "報告識別號碼"
 
-#: senaite/core/content/resultsreport.py:229
+#: senaite/core/content/resultsreport.py:230
 msgid "Report metadata"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:243
 msgid "Report recipients"
 msgstr ""
 
@@ -4661,7 +4901,7 @@ msgstr "上傳報告"
 msgid "Republish"
 msgstr "重發佈"
 
-#: senaite/core/browser/samples/view.py:574
+#: senaite/core/browser/samples/view.py:712
 msgid "Republished after last print"
 msgstr "上次列印後重發佈"
 
@@ -4670,7 +4910,7 @@ msgstr "上次列印後重發佈"
 msgid "Request ID"
 msgstr "請求ID"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
 msgid "Request new analyses"
 msgstr "新分析的請求"
 
@@ -4686,8 +4926,20 @@ msgstr "需求的量"
 msgid "Reset"
 msgstr "重置"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:83
@@ -4695,15 +4947,16 @@ msgstr ""
 msgid "Responsibles"
 msgstr "職責"
 
+#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:175
+#: bika/lims/content/bikasetup.py:176
 msgid "Restrict worksheet access to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:206
+#: bika/lims/content/bikasetup.py:207
 msgid "Restrict worksheet management to lab managers"
 msgstr ""
 
@@ -4728,15 +4981,15 @@ msgstr ""
 msgid "Result Value must be unique"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1526
+#: bika/lims/browser/analyses/view.py:1527
 msgid "Result in shoulder range"
 msgstr "結果瀕臨上下限"
 
-#: bika/lims/browser/analyses/view.py:1523
+#: bika/lims/browser/analyses/view.py:1524
 msgid "Result out of range"
 msgstr "結果超出範圍"
 
-#: bika/lims/browser/analyses/view.py:1545
+#: bika/lims/browser/analyses/view.py:1546
 msgid "Result range is different from Specification: {}"
 msgstr "結果範圍與規格不同：{}"
 
@@ -4744,7 +4997,7 @@ msgstr "結果範圍與規格不同：{}"
 msgid "Result type"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:427
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "擁有至少這有效位數的結果值將以字母 “e” 的科學記數法表示。精度可以在個別分析服務中配置。"
 
@@ -4760,16 +5013,20 @@ msgstr "結果"
 msgid "Results Interpretation"
 msgstr "結果詮釋"
 
-#: senaite/core/content/resultsreport.py:132
+#: senaite/core/browser/dashboard/dashboard.py:85
+msgid "Results Pending"
+msgstr ""
+
+#: senaite/core/content/resultsreport.py:133
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1285
+#: senaite/core/content/senaitesetup.py:1308
 msgid "Results Reports"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:588
+#: senaite/core/browser/samples/view.py:726
 msgid "Results have been withdrawn"
 msgstr "結果被撤回"
 
@@ -4777,7 +5034,7 @@ msgstr "結果被撤回"
 msgid "Results interpretation"
 msgstr "結果詮釋"
 
-#: senaite/core/browser/dashboard/dashboard.py:123
+#: senaite/core/browser/dashboard/dashboard.py:161
 msgid "Results pending"
 msgstr "等待結果"
 
@@ -4801,7 +5058,7 @@ msgstr "已複檢"
 msgid "Retract"
 msgstr "撤回"
 
-#: senaite/core/browser/dashboard/dashboard.py:126
+#: senaite/core/browser/dashboard/dashboard.py:152
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
@@ -4837,6 +5094,10 @@ msgstr "復原"
 msgid "Routine Analyses"
 msgstr "例行分析"
 
+#: bika/lims/api/snapshot.py:555
+msgid "Row ${num}"
+msgstr ""
+
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
 msgstr ""
@@ -4862,6 +5123,7 @@ msgstr "SENAITE LIMS 首頁"
 msgid "SENAITE Registry"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
@@ -4871,7 +5133,7 @@ msgstr ""
 msgid "SENAITE front-page"
 msgstr "SENAITE 首頁"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:315
+#: senaite/core/browser/clients/client/contacts/login_details.py:326
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "SMTP 伺服器短線。終止用戶創建。"
 
@@ -4885,7 +5147,7 @@ msgstr "頭銜"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:150
+#: senaite/core/content/resultsreport.py:151
 msgid "Sample"
 msgstr "樣本"
 
@@ -4922,7 +5184,7 @@ msgid "Sample Header"
 msgstr ""
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:127
+#: senaite/core/browser/samples/view.py:139
 msgid "Sample ID"
 msgstr "樣本編號"
 
@@ -4942,7 +5204,7 @@ msgstr "樣本基體"
 msgid "Sample Partitions"
 msgstr "樣本分樣"
 
-#: senaite/core/browser/samples/view.py:205
+#: senaite/core/browser/samples/view.py:217
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -4969,7 +5231,7 @@ msgid "Sample Templates"
 msgstr "樣本樣板"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:213
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "樣本類型"
@@ -5030,7 +5292,7 @@ msgstr "樣本類型"
 msgid "SampleTypes"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:219
+#: senaite/core/browser/samples/view.py:231
 msgid "Sampler"
 msgstr "採樣人"
 
@@ -5042,8 +5304,8 @@ msgstr "已排期採樣的採樣人"
 msgid "Sampler required for sample %s"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:411
-#: senaite/core/browser/samples/view.py:100
+#: senaite/core/browser/dashboard/dashboard.py:457
+#: senaite/core/browser/samples/view.py:112
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "樣本"
@@ -5060,6 +5322,18 @@ msgstr ""
 msgid "Samples ${sample_ids} were successfully invalidated."
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:400
+msgid "Samples awaiting collection of the sample"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:404
+msgid "Samples awaiting preservation"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:416
+msgid "Samples awaiting reception at the laboratory"
+msgstr ""
+
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
@@ -5069,7 +5343,23 @@ msgstr "這種類型的樣品應被視為危險物處理"
 msgid "Samples rejection reporting form"
 msgstr "拒絕樣本的報告表格"
 
-#: senaite/core/content/senaitesetup.py:1337
+#: senaite/core/browser/dashboard/dashboard.py:81
+msgid "Samples to Receive"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:432
+msgid "Samples whose reports have been published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:424
+msgid "Samples whose results are awaiting verification"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:409
+msgid "Samples with a scheduled sampling date"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:1362
 msgid "Sampling"
 msgstr ""
 
@@ -5077,7 +5367,7 @@ msgstr ""
 msgid "Sampling Date"
 msgstr "採樣日期"
 
-#: senaite/core/browser/samples/view.py:214
+#: senaite/core/browser/samples/view.py:226
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
 msgstr "採樣偏差"
@@ -5090,7 +5380,7 @@ msgstr "採樣偏差"
 msgid "Sampling Frequency"
 msgstr "採樣頻率"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
+#: senaite/core/browser/dashboard/dashboard.py:159
 msgid "Sampling scheduled"
 msgstr "已排期採樣"
 
@@ -5098,15 +5388,24 @@ msgstr "已排期採樣"
 msgid "Saturday"
 msgstr "星期六"
 
+#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
-#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "儲存"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
 msgid "Save and Copy"
 msgstr "儲存並複製"
+
+# senaite.app.listing: Saved filter presets — footer button to save the
+# current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr ""
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
@@ -5120,7 +5419,7 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:299
+#: senaite/core/browser/samples/view.py:317
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
@@ -5137,6 +5436,10 @@ msgstr "科學名稱/學名"
 msgid "Search"
 msgstr "搜尋"
 
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
 msgstr ""
@@ -5145,7 +5448,7 @@ msgstr ""
 msgid "Seconds"
 msgstr "秒"
 
-#: senaite/core/content/senaitesetup.py:1261
+#: senaite/core/content/senaitesetup.py:1284
 msgid "Security"
 msgstr ""
 
@@ -5235,11 +5538,11 @@ msgstr ""
 msgid "Select template"
 msgstr "選擇模板"
 
-#: bika/lims/content/bikasetup.py:269
+#: bika/lims/content/bikasetup.py:270
 msgid "Select the country the site will show by default"
 msgstr "選擇一個國家, 該國的網站將默認顯示"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:255
 msgid "Select the currency the site will use to display prices."
 msgstr "選擇網站將用於顯示價格的幣種。"
 
@@ -5251,11 +5554,11 @@ msgstr "選擇默認的容器被用於此分析服務。如果要使用的容器
 msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
 msgstr "選擇默認的登錄頁面。這是當一個客戶機用戶登錄到系統中，或當從客戶端文件夾列表中選擇的客戶使用。"
 
-#: senaite/core/content/senaitesetup.py:1129
+#: senaite/core/content/senaitesetup.py:1152
 msgid "Select the default sticker template used for automatic printing."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:1000
+#: bika/lims/content/bikasetup.py:1001
 msgid "Select the default sticker template used for automatic printing.<br/>"
 msgstr ""
 
@@ -5263,31 +5566,39 @@ msgstr ""
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1063
+#: senaite/core/content/senaitesetup.py:1086
 msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:593
 msgid "Select this to activate the dashboard as a default front page."
 msgstr "選擇此選項可將儀表板為預設首頁。"
 
-#: senaite/core/content/senaitesetup.py:990
+#: senaite/core/content/senaitesetup.py:1013
 msgid "Select this to activate the sample collection workflow steps."
 msgstr "選擇啟用樣本採集工作流程。"
 
-#: senaite/core/content/senaitesetup.py:998
+#: senaite/core/content/senaitesetup.py:1021
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:1001
+msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:991
+msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:981
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1008
+#: senaite/core/content/senaitesetup.py:1031
 msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:723
 msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
 msgstr "選擇向客戶聯絡人顯示分裝樣品。 如果停用，分裝將不會包含在清單中，且沒有與初級樣品連結的資訊會顯示給客戶聯絡人。"
 
@@ -5299,7 +5610,7 @@ msgstr "選擇工作表中要包含的分析"
 msgid "Selection list"
 msgstr "選擇清單"
 
-#: bika/lims/content/abstractbaseanalysis.py:817
+#: bika/lims/content/abstractbaseanalysis.py:820
 msgid "Self-verification of results"
 msgstr "結果自我複核"
 
@@ -5311,11 +5622,11 @@ msgstr ""
 msgid "Send Analysis Reports via Email"
 msgstr "透過電子郵件發送檢驗報告單"
 
-#: senaite/core/content/resultsreport.py:256
+#: senaite/core/content/resultsreport.py:257
 msgid "Send Log"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:259
+#: senaite/core/content/resultsreport.py:260
 msgid "Send Log Entry"
 msgstr ""
 
@@ -5337,7 +5648,7 @@ msgstr "發送至"
 msgid "Separate Container"
 msgstr "單獨的容器"
 
-#: senaite/core/content/senaitesetup.py:216
+#: senaite/core/content/senaitesetup.py:217
 msgid "Seq Type"
 msgstr ""
 
@@ -5351,7 +5662,7 @@ msgstr "序列號"
 msgid "Service"
 msgstr "服務"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
 msgid "Service cannot be deselected. Please click the info button for further details"
 msgstr ""
 
@@ -5379,7 +5690,7 @@ msgstr ""
 msgid "Set the maintenance task as closed."
 msgstr "當關閉時, 設置維護/保護任務。"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1096
 msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
 msgstr ""
 
@@ -5427,29 +5738,41 @@ msgstr ""
 msgid "Should the default example content be added to the site?"
 msgstr ""
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
 msgid "Show additional fields"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
 msgid "Show all"
+msgstr ""
+
+#: senaite/core/api/remarks.py:486
+msgid "Show history"
 msgstr ""
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
 msgstr "顯示上次自動匯入日誌"
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
+#: senaite/core/api/remarks.py:489
 msgid "Show less"
 msgstr ""
 
-#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
+#: senaite/core/api/remarks.py:488
 msgid "Show more"
 msgstr ""
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
 msgstr "顯示標準欄位"
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:129
+msgid "Show/hide timeline"
+msgstr ""
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5471,11 +5794,11 @@ msgstr "地點代碼"
 msgid "Site Description"
 msgstr "網站/地點說明"
 
-#: senaite/core/content/senaitesetup.py:313
+#: senaite/core/content/senaitesetup.py:314
 msgid "Site Logo"
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:319
+#: senaite/core/content/senaitesetup.py:320
 msgid "Site Logo CSS"
 msgstr ""
 
@@ -5496,7 +5819,7 @@ msgstr ""
 msgid "Small Sticker"
 msgstr "小標籤"
 
-#: senaite/core/content/senaitesetup.py:1138
+#: senaite/core/content/senaitesetup.py:1161
 msgid "Small Sticker Template"
 msgstr ""
 
@@ -5513,6 +5836,14 @@ msgstr "有分析使用了過期或未經校準的儀器。結果版不允許"
 #: bika/lims/content/subgroup.py:38
 msgid "Sort Key"
 msgstr "排序關鍵字"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
@@ -5538,7 +5869,7 @@ msgstr ""
 msgid "Specifications"
 msgstr "多個規範"
 
-#: senaite/core/content/senaitesetup.py:1163
+#: senaite/core/content/senaitesetup.py:1186
 msgid "Specify how many copies of each sticker should be printed by default."
 msgstr ""
 
@@ -5546,7 +5877,7 @@ msgstr ""
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "指定工作表的大小，例如對應於特定儀器的托盤尺寸。 然後選擇每個工作表位置的分析'類型'。 選擇品管樣品時，也要選擇應使用哪一個參考樣品。 如果選擇了複製分析，請指出它應該是哪個樣品位置。"
 
-#: senaite/core/content/senaitesetup.py:245
+#: senaite/core/content/senaitesetup.py:246
 msgid "Split Length"
 msgstr ""
 
@@ -5563,17 +5894,17 @@ msgstr "開始日期"
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:246
+#: senaite/core/browser/samples/view.py:264
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "狀況/說明"
 
-#: bika/lims/browser/analyses/view.py:200
+#: senaite/core/browser/dashboard/dashboard.py:127
 msgid "Status"
 msgstr "狀態"
 
-#: senaite/core/content/senaitesetup.py:1368
+#: senaite/core/content/senaitesetup.py:1395
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "標籤"
@@ -5582,7 +5913,11 @@ msgstr "標籤"
 msgid "Stickers preview"
 msgstr "標籤預覽"
 
-#: senaite/core/browser/samples/view.py:209
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+#: senaite/core/browser/samples/view.py:221
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
 msgstr "存儲位置"
@@ -5622,7 +5957,11 @@ msgstr "提交"
 msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr "提交包含設定記錄的有效 Open XML (.XLSX) 檔案以繼續。"
 
-#: bika/lims/browser/analyses/view.py:1570
+#: senaite/core/browser/dashboard/dashboard.py:490
+msgid "Submitted analyses awaiting verification"
+msgstr ""
+
+#: bika/lims/browser/analyses/view.py:1571
 msgid "Submitted and verified by the same user: {}"
 msgstr "由同一用戶提交並複核：{}"
 
@@ -5630,7 +5969,7 @@ msgstr "由同一用戶提交並複核：{}"
 msgid "Submitter"
 msgstr "提交者"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "子項總計"
@@ -5672,7 +6011,7 @@ msgstr "切換到儀表板"
 msgid "Switch to transposed view"
 msgstr "切換到轉置視圖"
 
-#: bika/lims/content/abstractbaseanalysis.py:1086
+#: bika/lims/content/abstractbaseanalysis.py:1089
 msgid "System default"
 msgstr "系統預設"
 
@@ -5698,7 +6037,7 @@ msgstr ""
 msgid "Technical description and instructions intended for analysts"
 msgstr "為分析員準備的技術描述和說明"
 
-#: senaite/core/browser/samples/view.py:236
+#: senaite/core/browser/samples/view.py:254
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -5780,7 +6119,7 @@ msgstr "樣本保存的日期"
 msgid "The date when the sample was received"
 msgstr "樣本接收的日期"
 
-#: bika/lims/content/client.py:226
+#: bika/lims/content/client.py:230
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "在Bika 設置所選的十進制標記將被使用。"
 
@@ -5788,7 +6127,7 @@ msgstr "在Bika 設置所選的十進制標記將被使用。"
 msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:283
 msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
 msgstr "輸入折扣的百分數, 該折扣將用於標為'會員'的用户,通常企業或協會人員將得到該折扣"
 
@@ -5816,7 +6155,11 @@ msgstr ""
 msgid "The following sample(s) will be dispatched"
 msgstr "將發送以下樣本"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/browser/samples/templates/dispose_samples.pt:47
+msgid "The following sample(s) will be disposed"
+msgstr ""
+
+#: senaite/core/content/senaitesetup.py:299
 msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
 msgstr "全域審核日誌顯示系統的所有修改。 啟用後，所有實體都將在單獨的目錄中建立索引。 這將增加建立或修改物件的時間。"
 
@@ -5824,11 +6167,11 @@ msgstr "全域審核日誌顯示系統的所有修改。 啟用後，所有實�
 msgid "The height or depth at which the sample has to be taken"
 msgstr "取樣的高度或深度"
 
-#: bika/lims/browser/analyses/view.py:1845
+#: bika/lims/browser/analyses/view.py:1846
 msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1857
+#: bika/lims/browser/analyses/view.py:1858
 msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
 msgstr ""
 
@@ -5865,11 +6208,11 @@ msgstr "分析所需的最小樣品體積如 '10毫升“或” 1千克“ 。"
 msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1051
+#: senaite/core/content/senaitesetup.py:1074
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "樣品有效天數, 過期的樣品將不能分析. 該設置可以在樣品類型設置中為具體樣品類型重置."
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:163
 msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
 msgstr "幾分鐘內用戶將被自動登出。 0禁用自動登出"
 
@@ -5909,7 +6252,7 @@ msgstr "認証機構向實驗室發放的參考碼"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1835
+#: bika/lims/browser/analyses/view.py:1836
 msgid "The result was captured past the holding time limit."
 msgstr ""
 
@@ -5933,11 +6276,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "唯一標識文書的序列號"
 
-#: bika/lims/content/abstractbaseanalysis.py:866
+#: bika/lims/content/abstractbaseanalysis.py:869
 msgid "The service's analytical protocol ID"
 msgstr "該服務的解析協議ID"
 
-#: bika/lims/content/abstractbaseanalysis.py:854
+#: bika/lims/content/abstractbaseanalysis.py:857
 msgid "The service's commercial ID for accounting purposes"
 msgstr "為會計目的服務的商業ID"
 
@@ -5989,11 +6332,11 @@ msgstr "這是第二樣本屬於"
 msgid "This is a detached partition from Sample"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:768
+#: bika/lims/content/bikasetup.py:769
 msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:1038
+#: senaite/core/content/senaitesetup.py:1061
 msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
 msgstr ""
 
@@ -6017,11 +6360,11 @@ msgstr ""
 msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
 msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
 msgstr ""
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:315
 msgid "This shows a custom logo on your SENAITE site."
 msgstr ""
 
@@ -6053,8 +6396,8 @@ msgstr "時間"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "提示. 添加文件不會被加載，除非它們是存在於實例。"
 
-#: senaite/core/browser/controlpanel/labels/view.py:59
-#: senaite/core/browser/label/labeled_objects.py:58
+#: senaite/core/browser/controlpanel/labels/view.py:60
+#: senaite/core/browser/label/labeled_objects.py:59
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "標題"
@@ -6081,34 +6424,42 @@ msgstr "場地的標題"
 msgid "To"
 msgstr "至"
 
-#: senaite/core/browser/samples/view.py:289
+#: senaite/core/browser/samples/view.py:307
 msgid "To Be Preserved"
 msgstr "需要保留"
 
-#: senaite/core/browser/samples/view.py:280
+#: senaite/core/browser/samples/view.py:298
 msgid "To Be Sampled"
 msgstr "需要取樣"
+
+#: senaite/core/browser/dashboard/dashboard.py:93
+msgid "To be Published"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:89
+msgid "To be Verified"
+msgstr ""
 
 #: bika/lims/content/analysiscategory.py:48
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "將每個分析類型結果報告顯示"
 
-#: senaite/core/browser/dashboard/dashboard.py:133
+#: senaite/core/browser/dashboard/dashboard.py:158
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "待保存"
 
-#: senaite/core/browser/dashboard/dashboard.py:398
+#: senaite/core/browser/dashboard/dashboard.py:441
 msgid "To be printed"
 msgstr "待列印"
 
-#: senaite/core/browser/dashboard/dashboard.py:132
+#: senaite/core/browser/dashboard/dashboard.py:157
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "待抽樣"
 
-#: senaite/core/browser/dashboard/dashboard.py:124
-#: senaite/core/browser/samples/view.py:331
+#: senaite/core/browser/dashboard/dashboard.py:148
+#: senaite/core/browser/samples/view.py:349
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "需要驗証"
@@ -6121,7 +6472,7 @@ msgstr "若要測試計算，請在此輸入所有計算參數的值。 這包�
 msgid "Toggle visibility of standard sample header fields"
 msgstr ""
 
-#: senaite/core/browser/samples/view.py:523
+#: senaite/core/browser/samples/view.py:650
 msgid "Total"
 msgstr "總計"
 
@@ -6143,7 +6494,7 @@ msgid "Tuesday"
 msgstr "星期二"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:61
+#: senaite/core/browser/label/labeled_objects.py:62
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "類型"
@@ -6168,6 +6519,10 @@ msgstr ""
 msgid "Type to filter ..."
 msgstr ""
 
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
 #: senaite/core/registry/schema.py:78
 msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
 msgstr ""
@@ -6176,7 +6531,7 @@ msgstr ""
 msgid "Types with labels"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:99
+#: senaite/core/content/resultsreport.py:100
 msgid "UID"
 msgstr ""
 
@@ -6188,6 +6543,7 @@ msgstr "無法加載模板"
 msgid "Unassign"
 msgstr "未分配"
 
+#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "未分配"
@@ -6220,8 +6576,12 @@ msgstr "未知IBAN 國家％S"
 msgid "Unlink User"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
+#: senaite/core/browser/clients/client/contacts/login_details.py:239
 msgid "Unlinked User"
+msgstr ""
+
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+msgid "Unlock"
 msgstr ""
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
@@ -6238,13 +6598,17 @@ msgstr "無法識別文件格式${fileformat}"
 msgid "Unrecognized file format ${format}"
 msgstr "無法辨識的檔案格式 ${format}"
 
-#: senaite/core/browser/samples/view.py:425
+#: senaite/core/browser/samples/view.py:455
 msgid "Unsassigned"
 msgstr "未分配"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "上傳附件"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
@@ -6254,7 +6618,7 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "上傳一張可用於打印分析報告的簽名掃描檔, 理想尺寸為250像素寬, 150像素高"
 
-#: bika/lims/content/client.py:250
+#: bika/lims/content/client.py:254
 msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
 msgstr ""
 
@@ -6262,7 +6626,7 @@ msgstr ""
 msgid "Use Analysis Profile Price"
 msgstr "使用检验套餐價格"
 
-#: bika/lims/content/bikasetup.py:591
+#: bika/lims/content/bikasetup.py:592
 msgid "Use Dashboard as default front page"
 msgstr "使用儀表板做為預設首頁"
 
@@ -6300,7 +6664,7 @@ msgstr ""
 msgid "User is linked to the global contact '${fullname}'"
 msgstr ""
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:217
+#: senaite/core/browser/clients/client/contacts/login_details.py:233
 msgid "User linked to this Contact"
 msgstr ""
 
@@ -6308,15 +6672,15 @@ msgstr ""
 msgid "User name"
 msgstr ""
 
-#: senaite/core/content/resultsreport.py:104
+#: senaite/core/content/resultsreport.py:105
 msgid "Username"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:341
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "取样点太少时分析结果无意义. 请在质量控制统计处理前设置可接受的最小样品量."
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
@@ -6324,7 +6688,7 @@ msgstr "增值税"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
 #: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:296
+#: bika/lims/content/bikasetup.py:297
 msgid "VAT %"
 msgstr "增值税%"
 
@@ -6571,8 +6935,8 @@ msgstr ""
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "值可以在此輸入，將覆蓋在計算臨時字段中指定的默認值。"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
-#: senaite/core/browser/samples/view.py:341
+#: senaite/core/browser/dashboard/dashboard.py:149
+#: senaite/core/browser/samples/view.py:359
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "已驗證"
@@ -6581,11 +6945,19 @@ msgstr "已驗證"
 msgid "Verified By"
 msgstr ""
 
+#: senaite/core/browser/dashboard/dashboard.py:428
+msgid "Verified samples ready to be published"
+msgstr ""
+
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
 msgstr "複核"
+
+#: senaite/core/browser/dashboard/dashboard.py:109
+msgid "Verify Results"
+msgstr ""
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6600,6 +6972,14 @@ msgstr "查看"
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
 msgstr "瀏覽LIMS站點"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr ""
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
@@ -6634,6 +7014,10 @@ msgstr ""
 msgid "Wednesday"
 msgstr "星期三"
 
+#: senaite/core/browser/dashboard/dashboard.py:136
+msgid "Weekly"
+msgstr ""
+
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
 msgstr "兩週後過期"
@@ -6646,19 +7030,19 @@ msgstr ""
 msgid "Welcome to SENAITE"
 msgstr "歡迎來到LIMS"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:177
 msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:208
 msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:477
 msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:191
 msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
 msgstr ""
 
@@ -6709,10 +7093,18 @@ msgstr "工作表模板"
 msgid "Worksheet printing templates order"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:489
+#: senaite/core/browser/dashboard/dashboard.py:107
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "工作表"
+
+#: senaite/core/browser/dashboard/dashboard.py:531
+msgid "Worksheets that have been verified"
+msgstr ""
+
+#: senaite/core/browser/dashboard/dashboard.py:526
+msgid "Worksheets whose results are awaiting verification"
+msgstr ""
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
@@ -6721,6 +7113,10 @@ msgstr ""
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "錯IBAN長度由%s: %sshort by %i"
+
+#: senaite/core/browser/dashboard/dashboard.py:140
+msgid "Yearly"
+msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -6804,6 +7200,10 @@ msgstr ""
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:254
@@ -6908,8 +7308,17 @@ msgstr "天"
 msgid "deactivate"
 msgstr "關閉"
 
+#. Default: "Sample disposed after the retention period."
+#: senaite/core/browser/samples/templates/dispose_samples.pt:66
+msgid "default_dispose_reason"
+msgstr ""
+
+#: senaite/core/api/remarks.py:485
+msgid "deleted by {user} at {time}"
+msgstr ""
+
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:118
+#: senaite/core/behaviors/label.py:126
 msgid "description_Labels"
 msgstr ""
 
@@ -6974,7 +7383,7 @@ msgstr ""
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
 #. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:770
+#: bika/lims/content/abstractbaseanalysis.py:773
 msgid "description_analysis_results_options_sorting"
 msgstr ""
 
@@ -7144,46 +7553,46 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:396
+#: bika/lims/content/bikasetup.py:397
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:853
+#: bika/lims/content/bikasetup.py:854
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:368
+#: bika/lims/content/bikasetup.py:369
 msgid "description_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:689
+#: bika/lims/content/bikasetup.py:690
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:829
+#: bika/lims/content/bikasetup.py:830
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:805
+#: bika/lims/content/bikasetup.py:806
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:443
+#: bika/lims/content/bikasetup.py:444
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
 
@@ -7195,19 +7604,19 @@ msgstr ""
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
 #. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:946
+#: bika/lims/content/bikasetup.py:947
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:913
+#: bika/lims/content/bikasetup.py:914
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:382
+#: bika/lims/content/bikasetup.py:383
 msgid "description_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -7228,16 +7637,21 @@ msgstr ""
 msgid "description_calculation_formula"
 msgstr ""
 
-#. should your calculation require them. The field title specified here will
-#. be used as column headers and field descriptors where the interim fields
-#. are displayed. If 'Apply wide' is enabled the field will be shown in a
-#. selection box on the top of the worksheet, allowing to apply a specific
-#. value to all the corresponding fields on the sheet."
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
 #. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
 #: senaite/core/content/calculation.py:268
 msgid "description_calculation_imports"
 msgstr ""
 
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
@@ -7262,12 +7676,12 @@ msgid "description_category_department"
 msgstr ""
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:184
+#: bika/lims/content/client.py:188
 msgid "description_client_defaultcategories"
 msgstr ""
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:208
+#: bika/lims/content/client.py:212
 msgid "description_client_restrictcategories"
 msgstr ""
 
@@ -7277,7 +7691,7 @@ msgid "description_confidence_level"
 msgstr ""
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:123
+#: senaite/core/content/contact.py:155
 msgid "description_contact_cccontact"
 msgstr ""
 
@@ -7380,6 +7794,19 @@ msgstr ""
 msgid "description_labcontact_departments"
 msgstr ""
 
+#. the default style."
+#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
+#: senaite/core/content/label.py:72
+msgid "description_label_color"
+msgstr ""
+
+#. labeled content. The cascade runs in the same transaction as the save and
+#. may take a moment on large datasets."
+#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
+#: senaite/core/content/label.py:45
+msgid "description_label_title"
+msgstr ""
+
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
@@ -7409,6 +7836,13 @@ msgstr ""
 #. Default: "Please provide the VAT in percent that is added to the labproduct price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
+msgstr ""
+
+#. nested and positioned as they appear on the site. Use the controls to hide,
+#. show or reorder each viewlet."
+#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
+msgid "description_manage_viewlets"
 msgstr ""
 
 #. Default: "Location where the document set is shelved"
@@ -7555,12 +7989,12 @@ msgid "description_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:186
+#: senaite/core/content/resultsreport.py:187
 msgid "description_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:158
+#: senaite/core/content/resultsreport.py:159
 msgid "description_resultsreport_sample"
 msgstr ""
 
@@ -7813,7 +8247,7 @@ msgstr ""
 
 #. entered manually for analyses"
 #. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:361
+#: senaite/core/content/senaitesetup.py:362
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
@@ -7821,163 +8255,163 @@ msgstr ""
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
 #. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:455
+#: senaite/core/content/senaitesetup.py:456
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. departments will receive publication emails."
 #. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:288
+#: senaite/core/content/senaitesetup.py:289
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. 0 disables automatic log-off"
 #. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:427
+#: senaite/core/content/senaitesetup.py:428
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
 #. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:654
+#: senaite/core/content/senaitesetup.py:655
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. when the list is long"
 #. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:599
+#: senaite/core/content/senaitesetup.py:600
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:340
+#: senaite/core/content/senaitesetup.py:341
 msgid "description_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:496
+#: senaite/core/content/senaitesetup.py:497
 msgid "description_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:861
+#: senaite/core/content/senaitesetup.py:862
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
 #. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:386
+#: senaite/core/content/senaitesetup.py:387
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:557
+#: senaite/core/content/senaitesetup.py:558
 msgid "description_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:510
+#: senaite/core/content/senaitesetup.py:511
 msgid "description_senaitesetup_default_country"
 msgstr ""
 
 #. to create new Samples"
 #. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:744
+#: senaite/core/content/senaitesetup.py:745
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
 #. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:260
+#: senaite/core/content/senaitesetup.py:261
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. analysis in results entry view"
 #. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:641
+#: senaite/core/content/senaitesetup.py:642
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:612
+#: senaite/core/content/senaitesetup.py:613
 msgid "description_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. 'Reject' option will be displayed in the actions menu."
 #. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:758
+#: senaite/core/content/senaitesetup.py:759
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
 #. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:625
+#: senaite/core/content/senaitesetup.py:626
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
 #. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:330
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
 #. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:411
+#: senaite/core/content/senaitesetup.py:412
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:874
+#: senaite/core/content/senaitesetup.py:875
 msgid "description_senaitesetup_landing_page"
 msgstr ""
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
 #. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:373
+#: senaite/core/content/senaitesetup.py:374
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
 #. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:524
+#: senaite/core/content/senaitesetup.py:525
 msgid "description_senaitesetup_member_discount"
 msgstr ""
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
 #. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:583
+#: senaite/core/content/senaitesetup.py:584
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
 #. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:687
+#: senaite/core/content/senaitesetup.py:688
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
 #. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:274
+#: senaite/core/content/senaitesetup.py:275
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
 
 #. rejecting a sample."
 #. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:773
+#: senaite/core/content/senaitesetup.py:774
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
 
@@ -7985,47 +8419,47 @@ msgstr ""
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
 #. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:471
+#: senaite/core/content/senaitesetup.py:472
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. are assigned. When disabled, analysts have access to all worksheets."
 #. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:441
+#: senaite/core/content/senaitesetup.py:442
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:718
+#: senaite/core/content/senaitesetup.py:719
 msgid "description_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
 #. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:968
+#: senaite/core/content/senaitesetup.py:969
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:350
+#: senaite/core/content/senaitesetup.py:351
 msgid "description_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:804
+#: senaite/core/content/senaitesetup.py:805
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:570
+#: senaite/core/content/senaitesetup.py:571
 msgid "description_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:731
+#: senaite/core/content/senaitesetup.py:732
 msgid "description_senaitesetup_scientific_notation_results"
 msgstr ""
 
@@ -8034,20 +8468,20 @@ msgstr ""
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
 #. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:669
+#: senaite/core/content/senaitesetup.py:670
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. page, above the access credentials."
 #. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:399
+#: senaite/core/content/senaitesetup.py:400
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
 #. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:898
+#: senaite/core/content/senaitesetup.py:899
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
 
@@ -8055,32 +8489,32 @@ msgstr ""
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
 #. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:913
+#: senaite/core/content/senaitesetup.py:914
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. top-level folders, level 2 includes their children, and so on."
 #. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:932
+#: senaite/core/content/senaitesetup.py:933
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. navigation. If none are selected, all content types will be shown."
 #. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:949
+#: senaite/core/content/senaitesetup.py:950
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
 #. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:703
+#: senaite/core/content/senaitesetup.py:704
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. system wide but can be overwritten on individual items"
 #. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:541
+#: senaite/core/content/senaitesetup.py:542
 msgid "description_senaitesetup_vat"
 msgstr ""
 
@@ -8088,21 +8522,21 @@ msgstr ""
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
 #. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:845
+#: senaite/core/content/senaitesetup.py:846
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
 #. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:824
+#: senaite/core/content/senaitesetup.py:825
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
 #. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:616
+#: bika/lims/content/bikasetup.py:617
 msgid "description_setup_landingpage"
 msgstr ""
 
@@ -8258,6 +8692,10 @@ msgstr ""
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
+msgstr ""
+
+#: senaite/core/api/remarks.py:481
+msgid "edited"
 msgstr ""
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
@@ -8570,7 +9008,7 @@ msgid "invalid_wildcards_check_error"
 msgstr ""
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:117
+#: senaite/core/behaviors/label.py:125
 msgid "label_Labels"
 msgstr ""
 
@@ -8631,7 +9069,7 @@ msgid "label_analysis_maxholdingtime"
 msgstr ""
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:766
+#: bika/lims/content/abstractbaseanalysis.py:769
 msgid "label_analysis_results_options_sorting"
 msgstr ""
 
@@ -8747,52 +9185,52 @@ msgid "label_batch_client"
 msgstr "批次"
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:394
+#: bika/lims/content/bikasetup.py:395
 msgid "label_bikasetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:850
+#: bika/lims/content/bikasetup.py:851
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:366
+#: bika/lims/content/bikasetup.py:367
 msgid "label_bikasetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:685
+#: bika/lims/content/bikasetup.py:686
 msgid "label_bikasetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:826
+#: bika/lims/content/bikasetup.py:827
 msgid "label_bikasetup_email_body_sample_publication"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:801
+#: bika/lims/content/bikasetup.py:802
 msgid "label_bikasetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:441
+#: bika/lims/content/bikasetup.py:442
 msgid "label_bikasetup_immediateresultsentry"
 msgstr ""
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:942
+#: bika/lims/content/bikasetup.py:943
 msgid "label_bikasetup_invalidation_email_body"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:909
+#: bika/lims/content/bikasetup.py:910
 msgid "label_bikasetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:380
+#: bika/lims/content/bikasetup.py:381
 msgid "label_bikasetup_sampleanalysesrequired"
 msgstr ""
 
@@ -8862,12 +9300,12 @@ msgid "label_category_department"
 msgstr ""
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:181
+#: bika/lims/content/client.py:185
 msgid "label_client_defaultcategories"
 msgstr ""
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:205
+#: bika/lims/content/client.py:209
 msgid "label_client_restrictcategories"
 msgstr ""
 
@@ -8877,7 +9315,7 @@ msgid "label_confirm_password"
 msgstr ""
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:119
+#: senaite/core/content/contact.py:151
 msgid "label_contact_cccontact"
 msgstr ""
 
@@ -9173,7 +9611,7 @@ msgid "label_powered_by_plone"
 msgstr ""
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:99
+#: senaite/core/content/contact.py:131
 msgid "label_publication_preference"
 msgstr ""
 
@@ -9298,12 +9736,12 @@ msgid "label_registry_worksheet_settings"
 msgstr ""
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:183
+#: senaite/core/content/resultsreport.py:184
 msgid "label_resultsreport_contained_samples"
 msgstr ""
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:155
+#: senaite/core/content/resultsreport.py:156
 msgid "label_resultsreport_sample"
 msgstr ""
 
@@ -9513,7 +9951,7 @@ msgid "label_sampletype_title"
 msgstr ""
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
 msgid "label_save"
 msgstr ""
 
@@ -9523,12 +9961,12 @@ msgid "label_senaite"
 msgstr ""
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:368
+#: senaite/core/content/senaitesetup.py:369
 msgid "label_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:613
+#: bika/lims/content/bikasetup.py:614
 msgid "label_setup_landingpage"
 msgstr ""
 
@@ -9586,6 +10024,22 @@ msgstr ""
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
+msgstr ""
+
+#. Default: "Added ${count} label(s) to ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:185
+msgid "labels_added"
+msgstr ""
+
+#. sample(s)"
+#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:174
+msgid "labels_changed"
+msgstr ""
+
+#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
+#: senaite/core/browser/modals/manage_labels.py:194
+msgid "labels_removed"
 msgstr ""
 
 #. Default: "Category"
@@ -10762,87 +11216,87 @@ msgid "listing_suppliers_title"
 msgstr ""
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:63
+#: senaite/core/browser/worksheets/view.py:67
 msgid "listing_worksheets_action_add"
 msgstr ""
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:114
+#: senaite/core/browser/worksheets/view.py:118
 msgid "listing_worksheets_column_analyst"
 msgstr ""
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:146
+#: senaite/core/browser/worksheets/view.py:150
 msgid "listing_worksheets_column_created"
 msgstr ""
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:140
+#: senaite/core/browser/worksheets/view.py:144
 msgid "listing_worksheets_column_number_analyses"
 msgstr ""
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:134
+#: senaite/core/browser/worksheets/view.py:138
 msgid "listing_worksheets_column_number_qc_analyses"
 msgstr ""
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:128
+#: senaite/core/browser/worksheets/view.py:132
 msgid "listing_worksheets_column_number_samples"
 msgstr ""
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:101
+#: senaite/core/browser/worksheets/view.py:105
 msgid "listing_worksheets_column_progress"
 msgstr ""
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:153
+#: senaite/core/browser/worksheets/view.py:157
 msgid "listing_worksheets_column_state_title"
 msgstr ""
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:121
+#: senaite/core/browser/worksheets/view.py:125
 msgid "listing_worksheets_column_template_title"
 msgstr ""
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:107
+#: senaite/core/browser/worksheets/view.py:111
 msgid "listing_worksheets_column_title"
 msgstr ""
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:164
+#: senaite/core/browser/worksheets/view.py:168
 msgid "listing_worksheets_state_active"
 msgstr ""
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:223
+#: senaite/core/browser/worksheets/view.py:227
 msgid "listing_worksheets_state_all"
 msgstr ""
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:244
+#: senaite/core/browser/worksheets/view.py:248
 msgid "listing_worksheets_state_mine"
 msgstr ""
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:181
+#: senaite/core/browser/worksheets/view.py:185
 msgid "listing_worksheets_state_open"
 msgstr ""
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:195
+#: senaite/core/browser/worksheets/view.py:199
 msgid "listing_worksheets_state_to_be_verified"
 msgstr ""
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:209
+#: senaite/core/browser/worksheets/view.py:213
 msgid "listing_worksheets_state_verified"
 msgstr ""
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:71
+#: senaite/core/browser/worksheets/view.py:75
 msgid "listing_worksheets_title"
 msgstr ""
 
@@ -10895,6 +11349,11 @@ msgstr ""
 msgid "minutes"
 msgstr "分鐘"
 
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied
+# preset
+msgid "modified"
+msgstr ""
+
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
 msgstr "每月"
@@ -10945,12 +11404,20 @@ msgstr ""
 msgid "num_of_positions_button_title"
 msgstr ""
 
-#: senaite/core/browser/dashboard/dashboard.py:544
+#: senaite/core/browser/dashboard/dashboard.py:607
 msgid "of"
+msgstr ""
+
+#: senaite/core/api/remarks.py:494
+msgid "original"
 msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
 msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
@@ -11028,6 +11495,11 @@ msgstr ""
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
+msgstr ""
+
+#. Default: "This sample has been disposed by ${actor} on ${date}"
+#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
+msgid "this_sample_has_been_disposed_by"
 msgstr ""
 
 #. Default: "${I}:${M} ${p}"
@@ -11262,13 +11734,18 @@ msgstr ""
 msgid "title_lab_manager_role"
 msgstr ""
 
+#. Default: "Color"
+#: senaite/core/content/label.py:68
+msgid "title_label_color"
+msgstr ""
+
 #. Default: "Description"
-#: senaite/core/content/label.py:46
+#: senaite/core/content/label.py:56
 msgid "title_label_description"
 msgstr ""
 
 #. Default: "Name"
-#: senaite/core/content/label.py:38
+#: senaite/core/content/label.py:41
 msgid "title_label_title"
 msgstr ""
 
@@ -11355,6 +11832,11 @@ msgstr ""
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
+msgstr ""
+
+#. Default: "Manage Viewlets"
+#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
+msgid "title_manage_viewlets"
 msgstr ""
 
 #. Default: "Manager"
@@ -11600,222 +12082,222 @@ msgid "title_samplingdeviation_title"
 msgstr ""
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:359
+#: senaite/core/content/senaitesetup.py:360
 msgid "title_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:451
+#: senaite/core/content/senaitesetup.py:452
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:285
+#: senaite/core/content/senaitesetup.py:286
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:423
+#: senaite/core/content/senaitesetup.py:424
 msgid "title_senaitesetup_auto_log_off"
 msgstr ""
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:650
+#: senaite/core/content/senaitesetup.py:651
 msgid "title_senaitesetup_auto_verify_samples"
 msgstr ""
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:595
+#: senaite/core/content/senaitesetup.py:596
 msgid "title_senaitesetup_categorise_analysis_services"
 msgstr ""
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:338
+#: senaite/core/content/senaitesetup.py:339
 msgid "title_senaitesetup_categorizesampleanalyses"
 msgstr ""
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:492
+#: senaite/core/content/senaitesetup.py:493
 msgid "title_senaitesetup_currency"
 msgstr ""
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:857
+#: senaite/core/content/senaitesetup.py:858
 msgid "title_senaitesetup_dashboard_by_default"
 msgstr ""
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:383
+#: senaite/core/content/senaitesetup.py:384
 msgid "title_senaitesetup_date_sampled_required"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:553
+#: senaite/core/content/senaitesetup.py:554
 msgid "title_senaitesetup_decimal_mark"
 msgstr ""
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:506
+#: senaite/core/content/senaitesetup.py:507
 msgid "title_senaitesetup_default_country"
 msgstr ""
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:740
+#: senaite/core/content/senaitesetup.py:741
 msgid "title_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:256
+#: senaite/core/content/senaitesetup.py:257
 msgid "title_senaitesetup_email_from_sample_publication"
 msgstr ""
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:637
+#: senaite/core/content/senaitesetup.py:638
 msgid "title_senaitesetup_enable_analysis_remarks"
 msgstr ""
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:608
+#: senaite/core/content/senaitesetup.py:609
 msgid "title_senaitesetup_enable_ar_specs"
 msgstr ""
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:754
+#: senaite/core/content/senaitesetup.py:755
 msgid "title_senaitesetup_enable_rejection_workflow"
 msgstr ""
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:621
+#: senaite/core/content/senaitesetup.py:622
 msgid "title_senaitesetup_exponential_format_threshold"
 msgstr ""
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:408
+#: senaite/core/content/senaitesetup.py:409
 msgid "title_senaitesetup_invalidation_reason_required"
 msgstr ""
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:870
+#: senaite/core/content/senaitesetup.py:871
 msgid "title_senaitesetup_landing_page"
 msgstr ""
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:520
+#: senaite/core/content/senaitesetup.py:521
 msgid "title_senaitesetup_member_discount"
 msgstr ""
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:579
+#: senaite/core/content/senaitesetup.py:580
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:683
+#: senaite/core/content/senaitesetup.py:684
 msgid "title_senaitesetup_number_of_required_verifications"
 msgstr ""
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:272
+#: senaite/core/content/senaitesetup.py:273
 msgid "title_senaitesetup_publication_email_text"
 msgstr ""
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:769
+#: senaite/core/content/senaitesetup.py:770
 msgid "title_senaitesetup_rejection_reasons"
 msgstr ""
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:467
+#: senaite/core/content/senaitesetup.py:468
 msgid "title_senaitesetup_restrict_worksheet_management"
 msgstr ""
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:437
+#: senaite/core/content/senaitesetup.py:438
 msgid "title_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:714
+#: senaite/core/content/senaitesetup.py:715
 msgid "title_senaitesetup_results_decimal_mark"
 msgstr ""
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:964
+#: senaite/core/content/senaitesetup.py:965
 msgid "title_senaitesetup_sample_duplicate_enabled"
 msgstr ""
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:348
+#: senaite/core/content/senaitesetup.py:349
 msgid "title_senaitesetup_sampleanalysesrequired"
 msgstr ""
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:800
+#: senaite/core/content/senaitesetup.py:801
 msgid "title_senaitesetup_sampleview_columns_order"
 msgstr ""
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:566
+#: senaite/core/content/senaitesetup.py:567
 msgid "title_senaitesetup_scientific_notation_report"
 msgstr ""
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:727
+#: senaite/core/content/senaitesetup.py:728
 msgid "title_senaitesetup_scientific_notation_results"
 msgstr ""
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:665
+#: senaite/core/content/senaitesetup.py:666
 msgid "title_senaitesetup_self_verification_enabled"
 msgstr ""
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:396
+#: senaite/core/content/senaitesetup.py:397
 msgid "title_senaitesetup_show_lab_name_in_login"
 msgstr ""
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:894
+#: senaite/core/content/senaitesetup.py:895
 msgid "title_senaitesetup_show_partitions"
 msgstr ""
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:484
+#: senaite/core/content/senaitesetup.py:485
 msgid "title_senaitesetup_show_prices"
 msgstr ""
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:909
+#: senaite/core/content/senaitesetup.py:910
 msgid "title_senaitesetup_sidebar_folders"
 msgstr ""
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:928
+#: senaite/core/content/senaitesetup.py:929
 msgid "title_senaitesetup_sidebar_navigation_depth"
 msgstr ""
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:945
+#: senaite/core/content/senaitesetup.py:946
 msgid "title_senaitesetup_sidebar_skip_types"
 msgstr ""
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:699
+#: senaite/core/content/senaitesetup.py:700
 msgid "title_senaitesetup_type_of_multi_verification"
 msgstr ""
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:537
+#: senaite/core/content/senaitesetup.py:538
 msgid "title_senaitesetup_vat"
 msgstr ""
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:841
+#: senaite/core/content/senaitesetup.py:842
 msgid "title_senaitesetup_worksheet_layout"
 msgstr ""
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:820
+#: senaite/core/content/senaitesetup.py:821
 msgid "title_senaitesetup_wsview_columns_order"
 msgstr ""
 
@@ -12069,7 +12551,7 @@ msgstr ""
 msgid "validator_uloq_above_ulod"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:1587
+#: bika/lims/browser/analyses/view.py:1588
 msgid "verification(s) pending"
 msgstr ""
 
@@ -12112,7 +12594,7 @@ msgstr ""
 msgid "{sid} result for '{keyword}': '{result}'"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:627
+#: bika/lims/browser/analyses/view.py:628
 msgid "{} (Out of date)"
 msgstr ""
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Regular translation sync from Transifex, plus complete German, Dutch and Spanish translations and a fix that makes the dashboard fully translatable.

## Current behavior before PR

- German was ~96% translated, Dutch was almost entirely untranslated, and Spanish had a few hundred missing strings in the `senaite.core` (and framework) message catalogs.
- The dashboard rendered several labels in English regardless of the active language: the status cards, quick actions, section legends and the client-side labels (Status, Quick Actions, Show/hide timeline, period pills, ...). The card/quick-action titles were not wrapped in the message factory, the async JSON payload was serialized without translating the message ids, and `dashboard.js` used hardcoded English strings.

## Desired behavior after PR merged

- Complete German, Dutch and Spanish translations (0 untranslated strings remaining in both the `senaite.core` and framework catalogs).
- The dashboard is fully translated:
  - Status-card and quick-action titles are wrapped in the message factory.
  - The async JSON payload is translated server-side before serialization.
  - The legend label is translated.
  - `dashboard.js` reads pre-translated labels from a `data-i18n` attribute, with English fallbacks, so the script stays translation-agnostic.
- The 19 new dashboard message ids are registered in every language catalog (translated for German, Dutch and Spanish) for future syncs.

______

- [x] I added an entry to `CHANGES.rst`